### PR TITLE
Align roster header controls

### DIFF
--- a/DH_P2-5.18/rosters/rosters.html
+++ b/DH_P2-5.18/rosters/rosters.html
@@ -56,6 +56,10 @@
 </div>
 <div class="hidden" id="contextual-controls">
 <div class="header-row">
+<button class="analyzer-button" id="analyzeLeagueButton">
+<i class="fa-solid fa-square-poll-vertical"></i>
+<span class="label">Lg. Analyzer</span>
+</button>
 <div class="custom-select-wrapper">
 <select disabled="" id="leagueSelect">
 <option>Select a league...</option>
@@ -65,7 +69,6 @@
 <button id="positionalViewBtn">Positional</button>
 <button id="depthChartViewBtn">Lineup</button>
 </div>
-<button id="analyzeLeagueButton">Lg. Analyzer</button>
 </div>
 <div class="header-row" id="filters-row">
     <div class="filters-container">

--- a/DH_P2-5.18/styles/styles.css
+++ b/DH_P2-5.18/styles/styles.css
@@ -238,6 +238,7 @@
             gap: 0.25rem;
             padding-left: 0.25rem;
             padding-right: 0.25rem;
+            justify-content: space-between;
         }
 
         #contextual-controls {
@@ -308,7 +309,7 @@
             position: relative;
             flex-grow: 1;
             min-width: 100px;
-            max-width: 120px;
+            max-width: 160px;
         }
         #leagueSelect {
             appearance: none;  /* EDITED: Increased transparency */
@@ -317,9 +318,10 @@
             border-radius: 8px;
             -webkit-backdrop-filter: blur(4px) saturate(110%);
             backdrop-filter: blur(4px) saturate(110%);
-            box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);           
-            padding: 0.45rem 1.5rem 0.45rem 0.5rem;
-            font-size: 0.7rem;
+            box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
+            padding: 0.23rem 1.5rem 0.23rem 0.5rem;
+            font-size: 0.5rem;
+            font-weight: 300;
             color: #c4c8ea;
             width: 100%;
             cursor: pointer;
@@ -342,6 +344,53 @@
             transform: translateY(-50%) scale(0.6);
             color: var(--color-text-secondary);
             pointer-events: none;
+        }
+
+        .analyzer-button {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 0.05rem;
+            background: transparent;
+            border: none;
+            color: var(--color-text-secondary);
+            padding: 0.25rem;
+            min-width: 2.5rem;
+            height: 2.5rem;
+            border-radius: 8px;
+            cursor: pointer;
+            flex-shrink: 0;
+            transition: color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .analyzer-button:hover {
+            color: var(--color-text-primary);
+            background: var(--color-panel-bg);
+            box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
+        }
+
+        .analyzer-button:focus {
+            outline: none;
+            box-shadow: 0 0 var(--glow-strength) var(--color-accent-primary-glow);
+        }
+
+        .analyzer-button i {
+            display: block;
+            margin: 0;
+            line-height: 1;
+            font-size: 1.05rem;
+        }
+
+        .analyzer-button .label {
+            display: block;
+            margin: -2px 0 0 0;
+            padding: 0;
+            font-size: 0.55rem;
+            font-weight: 500;
+            line-height: 1;
+            color: inherit;
+            letter-spacing: 0.02em;
         }
 
         /* · · Row 3 · · */
@@ -422,6 +471,11 @@
         
         /* · · Primary buttons are bolder · · */
         .primary-switcher button {
+            font-weight: 400;
+            font-size: 0.9rem;
+        }
+
+        .secondary-switcher button {
             font-weight: 400;
             font-size: 0.9rem;
         }
@@ -2170,38 +2224,31 @@ font-weight: 500 !important;
 }
 
 #analyzeLeagueButton {
-    padding: 0.29rem 0.6rem;
-    font-size: 0.8rem;
-    font-weight: 500;
-    border: 1px solid #cfafcf8a;
-    background: linear-gradient(to bottom, rgba(0,0,0,0.02), rgba(0,0,0,0.2))!important;
-    box-shadow: 0 0 9px #eeddff65;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    white-space: nowrap;
-    color: #d1b1d1aa;
+    border: none;
+    background: transparent;
+    box-shadow: none;
+    color: var(--color-text-secondary);
 }
 
 #analyzeLeagueButton.glow-on-select {
-    box-shadow: 0 0 8px #7300ff;
+    background: var(--color-panel-bg);
     color: #eeeeee;
-    border: 1px solid #4E00DA;
+    box-shadow: 0 0 8px var(--color-accent-primary-glow);
 }
 
 #analyzeLeagueButton.active {
-    color: #ffffff;
-    border: 1px solid #a300ff;
-    background: #7300ff39;
-    box-shadow: 0 0 10px #7300ff;
+    color: var(--color-accent-primary);
+    background: var(--color-panel-bg);
+    box-shadow: 0 0 10px var(--color-accent-primary-glow);
 }
 
 #analyzeLeagueButton:disabled {
-    background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1))!important;
-    box-shadow: inset 0 1px 2px rgba(200,200,200,0.08) !important;
+    background: transparent;
+    box-shadow: none !important;
     color: var(--color-text-tertiary) !important;
     cursor: not-allowed;
-    border-color: var(--color-panel-border) !important;
+    opacity: 0.6;
+    pointer-events: none;
 }
 
 


### PR DESCRIPTION
## Summary
- restyle the roster page context header so the analyzer shortcut, league picker, and view switcher mirror the primary header row
- replace the text analyzer button with an icon + label treatment that matches the hamburger menu sizing
- tighten shared switcher and select styles so the second row controls align visually with the first row inputs

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cd62efc68c832ead90e3abfc5f57b5