### PR TITLE
Update roster header controls with icon buttons

### DIFF
--- a/DH_P2-5.18/rosters/rosters.html
+++ b/DH_P2-5.18/rosters/rosters.html
@@ -56,16 +56,25 @@
 </div>
 <div class="hidden" id="contextual-controls">
 <div class="header-row">
+<button id="analyzeLeagueButton" class="icon-action-button">
+    <i class="fa-solid fa-square-poll-vertical"></i>
+    <span class="label">Lg-Analyzer</span>
+</button>
 <div class="custom-select-wrapper">
 <select disabled="" id="leagueSelect">
 <option>Select a league...</option>
 </select>
 </div>
-<div class="view-switcher secondary-switcher">
-<button id="positionalViewBtn">Positional</button>
-<button id="depthChartViewBtn">Lineup</button>
+<div class="view-switcher secondary-switcher icon-switcher">
+<button id="positionalViewBtn" class="icon-toggle">
+    <i class="fa-duotone fa-solid fa-arrows-turn-to-dots"></i>
+    <span class="label">by position</span>
+</button>
+<button id="depthChartViewBtn" class="icon-toggle">
+    <i class="fa-duotone fa-light fa-clipboard-list"></i>
+    <span class="label">by lineup</span>
+</button>
 </div>
-<button id="analyzeLeagueButton">Lg. Analyzer</button>
 </div>
 <div class="header-row" id="filters-row">
     <div class="filters-container">

--- a/DH_P2-5.18/styles/styles.css
+++ b/DH_P2-5.18/styles/styles.css
@@ -405,6 +405,36 @@
             color: var(--color-text-secondary);
             text-shadow: 0 0 2px rgba(0,0,0,0.2);
         }
+        .icon-switcher {
+            align-items: stretch;
+            justify-content: center;
+            gap: 0.25rem;
+        }
+        .icon-switcher .icon-toggle {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 0.35rem 0.6rem 0.3rem;
+            font-size: 0.9rem;
+            line-height: 1;
+        }
+        .icon-switcher .icon-toggle i {
+            display: block;
+            margin: 0;
+            line-height: 1;
+            font-size: 1.05rem;
+        }
+        .icon-switcher .icon-toggle .label {
+            display: block;
+            margin: -2px 0 0 0;
+            padding: 0;
+            font-size: 0.55rem;
+            font-weight: 500;
+            line-height: 1;
+            color: inherit;
+            text-transform: none;
+        }
         .filter-btn {
             padding: 0.15rem 0.6rem;
             font-size: 0.85rem;
@@ -2170,8 +2200,12 @@ font-weight: 500 !important;
 }
 
 #analyzeLeagueButton {
-    padding: 0.29rem 0.6rem;
-    font-size: 0.8rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 0.35rem 0.6rem 0.3rem;
+    font-size: 0.9rem;
     font-weight: 500;
     border: 1px solid #cfafcf8a;
     background: linear-gradient(to bottom, rgba(0,0,0,0.02), rgba(0,0,0,0.2))!important;
@@ -2179,8 +2213,23 @@ font-weight: 500 !important;
     border-radius: 6px;
     cursor: pointer;
     transition: all 0.2s ease;
-    white-space: nowrap;
     color: #d1b1d1aa;
+    text-align: center;
+}
+#analyzeLeagueButton i {
+    display: block;
+    margin: 0;
+    line-height: 1;
+    font-size: 1.05rem;
+}
+#analyzeLeagueButton .label {
+    display: block;
+    margin: -2px 0 0 0;
+    padding: 0;
+    font-size: 0.55rem;
+    font-weight: 500;
+    line-height: 1;
+    color: inherit;
 }
 
 #analyzeLeagueButton.glow-on-select {


### PR DESCRIPTION
## Summary
- convert the roster header's analyzer and view controls into icon-driven buttons with labels for consistency
- add supporting styles for the icon switcher and analyzer control to preserve the existing segmented control appearance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd72d9f240832eb8ccfa1a2b7256b3