### PR TITLE
Style header controls with icon-based layout

### DIFF
--- a/DH_P2-5.18/ownership/ownership.html
+++ b/DH_P2-5.18/ownership/ownership.html
@@ -54,16 +54,25 @@
 </div>
 <div class="hidden" id="contextual-controls">
 <div class="header-row">
-<div class="custom-select-wrapper">
-<select disabled="" id="leagueSelect">
-<option>Select a league...</option>
-</select>
-</div>
-<div class="view-switcher secondary-switcher">
-<button id="positionalViewBtn">Positional</button>
-<button id="depthChartViewBtn">Lineup</button>
-</div>
-<button id="analyzeLeagueButton" class="control-button">LG-Analyzer</button>
+    <button id="analyzeLeagueButton" class="control-icon-button">
+        <i class="fa-solid fa-square-poll-vertical"></i>
+        <span class="label">Lg-Analyzer</span>
+    </button>
+    <div class="custom-select-wrapper">
+        <select disabled="" id="leagueSelect">
+            <option>Select a league...</option>
+        </select>
+    </div>
+    <div class="view-switcher secondary-switcher icon-switcher">
+        <button id="positionalViewBtn" class="icon-toggle">
+            <i class="fa-duotone fa-solid fa-arrows-turn-to-dots"></i>
+            <span class="label">by position</span>
+        </button>
+        <button id="depthChartViewBtn" class="icon-toggle">
+            <i class="fa-duotone fa-light fa-clipboard-list"></i>
+            <span class="label">by lineup</span>
+        </button>
+    </div>
 </div>
 <div class="header-row">
 <div id="positional-filters">

--- a/DH_P2-5.18/rosters/rosters.html
+++ b/DH_P2-5.18/rosters/rosters.html
@@ -56,16 +56,25 @@
 </div>
 <div class="hidden" id="contextual-controls">
 <div class="header-row">
-<div class="custom-select-wrapper">
-<select disabled="" id="leagueSelect">
-<option>Select a league...</option>
-</select>
-</div>
-<div class="view-switcher secondary-switcher">
-<button id="positionalViewBtn">Positional</button>
-<button id="depthChartViewBtn">Lineup</button>
-</div>
-<button id="analyzeLeagueButton">Lg. Analyzer</button>
+    <button id="analyzeLeagueButton" class="control-icon-button">
+        <i class="fa-solid fa-square-poll-vertical"></i>
+        <span class="label">Lg-Analyzer</span>
+    </button>
+    <div class="custom-select-wrapper">
+        <select disabled="" id="leagueSelect">
+            <option>Select a league...</option>
+        </select>
+    </div>
+    <div class="view-switcher secondary-switcher icon-switcher">
+        <button id="positionalViewBtn" class="icon-toggle">
+            <i class="fa-duotone fa-solid fa-arrows-turn-to-dots"></i>
+            <span class="label">by position</span>
+        </button>
+        <button id="depthChartViewBtn" class="icon-toggle">
+            <i class="fa-duotone fa-light fa-clipboard-list"></i>
+            <span class="label">by lineup</span>
+        </button>
+    </div>
 </div>
 <div class="header-row" id="filters-row">
     <div class="filters-container">

--- a/DH_P2-5.18/styles/styles.css
+++ b/DH_P2-5.18/styles/styles.css
@@ -405,6 +405,37 @@
             color: var(--color-text-secondary);
             text-shadow: 0 0 2px rgba(0,0,0,0.2);
         }
+        .icon-switcher {
+            gap: 0.25rem;
+            padding: 0.2rem;
+        }
+        .icon-switcher .icon-toggle {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 0.125rem;
+            padding: 0.25rem 0.45rem;
+            white-space: normal;
+            min-width: 0;
+            text-align: center;
+        }
+        .icon-switcher .icon-toggle i {
+            display: block;
+            margin: 0;
+            line-height: 1;
+            font-size: 1rem;
+        }
+        .icon-switcher .icon-toggle .label {
+            display: block;
+            margin: -2px 0 0 0;
+            padding: 0;
+            font-size: 0.55rem;
+            font-weight: 500;
+            line-height: 1;
+            color: inherit;
+            text-transform: none;
+        }
         .filter-btn {
             padding: 0.15rem 0.6rem;
             font-size: 0.85rem;
@@ -2179,8 +2210,32 @@ font-weight: 500 !important;
     border-radius: 6px;
     cursor: pointer;
     transition: all 0.2s ease;
-    white-space: nowrap;
+    white-space: normal;
     color: #d1b1d1aa;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.125rem;
+    text-align: center;
+    min-height: 0;
+}
+
+#analyzeLeagueButton i {
+    display: block;
+    margin: 0;
+    line-height: 1;
+    font-size: 1.05rem;
+}
+
+#analyzeLeagueButton .label {
+    display: block;
+    margin: -2px 0 0 0;
+    padding: 0;
+    font-size: 0.55rem;
+    font-weight: 500;
+    line-height: 1;
+    color: inherit;
 }
 
 #analyzeLeagueButton.glow-on-select {


### PR DESCRIPTION
## Summary
- convert the contextual roster header controls to an icon-first layout with labels beneath each control
- reuse the new layout on the ownership page so both views stay consistent
- add supporting styles so the analyzer and view toggle buttons retain their segmented active states while using icons

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cd72d9f240832eb8ccfa1a2b7256b3