### PR TITLE
Refine roster header controls with icon buttons

### DIFF
--- a/DH_P2-5.18/ownership/ownership.html
+++ b/DH_P2-5.18/ownership/ownership.html
@@ -54,16 +54,25 @@
 </div>
 <div class="hidden" id="contextual-controls">
 <div class="header-row">
-<div class="custom-select-wrapper">
-<select disabled="" id="leagueSelect">
-<option>Select a league...</option>
-</select>
-</div>
-<div class="view-switcher secondary-switcher">
-<button id="positionalViewBtn">Positional</button>
-<button id="depthChartViewBtn">Lineup</button>
-</div>
-<button id="analyzeLeagueButton" class="control-button">LG-Analyzer</button>
+  <button id="analyzeLeagueButton" class="icon-control">
+    <i aria-hidden="true" class="fa-solid fa-square-poll-vertical"></i>
+    <span class="label">Lg-Analyzer</span>
+  </button>
+  <div class="custom-select-wrapper">
+    <select disabled="" id="leagueSelect">
+      <option>Select a league...</option>
+    </select>
+  </div>
+  <div class="view-switcher secondary-switcher">
+    <button id="positionalViewBtn" class="icon-control">
+      <i aria-hidden="true" class="fa-duotone fa-solid fa-arrows-turn-to-dots"></i>
+      <span class="label">by position</span>
+    </button>
+    <button id="depthChartViewBtn" class="icon-control">
+      <i aria-hidden="true" class="fa-duotone fa-light fa-clipboard-list"></i>
+      <span class="label">by lineup</span>
+    </button>
+  </div>
 </div>
 <div class="header-row">
 <div id="positional-filters">

--- a/DH_P2-5.18/rosters/rosters.html
+++ b/DH_P2-5.18/rosters/rosters.html
@@ -55,18 +55,27 @@
 </div>
 </div>
 <div class="hidden" id="contextual-controls">
-<div class="header-row">
-<div class="custom-select-wrapper">
-<select disabled="" id="leagueSelect">
-<option>Select a league...</option>
-</select>
-</div>
-<div class="view-switcher secondary-switcher">
-<button id="positionalViewBtn">Positional</button>
-<button id="depthChartViewBtn">Lineup</button>
-</div>
-<button id="analyzeLeagueButton">Lg. Analyzer</button>
-</div>
+        <div class="header-row">
+          <button id="analyzeLeagueButton" class="icon-control">
+            <i aria-hidden="true" class="fa-solid fa-square-poll-vertical"></i>
+            <span class="label">Lg-Analyzer</span>
+          </button>
+          <div class="custom-select-wrapper">
+            <select disabled="" id="leagueSelect">
+              <option>Select a league...</option>
+            </select>
+          </div>
+          <div class="view-switcher secondary-switcher">
+            <button id="positionalViewBtn" class="icon-control">
+              <i aria-hidden="true" class="fa-duotone fa-solid fa-arrows-turn-to-dots"></i>
+              <span class="label">by position</span>
+            </button>
+            <button id="depthChartViewBtn" class="icon-control">
+              <i aria-hidden="true" class="fa-duotone fa-light fa-clipboard-list"></i>
+              <span class="label">by lineup</span>
+            </button>
+          </div>
+        </div>
 <div class="header-row" id="filters-row">
     <div class="filters-container">
         <div id="positional-filters">

--- a/DH_P2-5.18/styles/styles.css
+++ b/DH_P2-5.18/styles/styles.css
@@ -405,6 +405,11 @@
             color: var(--color-text-secondary);
             text-shadow: 0 0 2px rgba(0,0,0,0.2);
         }
+        .secondary-switcher .icon-control {
+            padding: 0.4rem 0.55rem;
+            min-width: 3.6rem;
+            white-space: normal;
+        }
         .filter-btn {
             padding: 0.15rem 0.6rem;
             font-size: 0.85rem;
@@ -916,6 +921,35 @@
           font-weight: 500;
           line-height: 1;
           color: inherit;
+        }
+
+
+        .icon-control {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          gap: 0.125rem;
+          line-height: 1;
+          text-align: center;
+        }
+
+        .icon-control i {
+          display: block;
+          margin: 0;
+          line-height: 1;
+          font-size: 1.05rem;
+        }
+
+        .icon-control .label {
+          display: block;
+          margin: -2px 0 0 0;
+          padding: 0;
+          font-size: 0.55rem;
+          font-weight: 500;
+          line-height: 1;
+          color: inherit;
+          text-transform: none;
         }
         
         
@@ -2170,7 +2204,7 @@ font-weight: 500 !important;
 }
 
 #analyzeLeagueButton {
-    padding: 0.29rem 0.6rem;
+    padding: 0.45rem 0.6rem;
     font-size: 0.8rem;
     font-weight: 500;
     border: 1px solid #cfafcf8a;
@@ -2179,8 +2213,9 @@ font-weight: 500 !important;
     border-radius: 6px;
     cursor: pointer;
     transition: all 0.2s ease;
-    white-space: nowrap;
+    white-space: normal;
     color: #d1b1d1aa;
+    margin-right: auto;
 }
 
 #analyzeLeagueButton.glow-on-select {


### PR DESCRIPTION
## Summary
- replace the second header row controls with icon-centric buttons and labels for clearer mobile use
- move the league analyzer shortcut to the leading edge and swap in the poll icon with matching caption
- reuse the styling across rosters and ownership pages, adding shared icon-control styles in the global stylesheet

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd72d9f240832eb8ccfa1a2b7256b3