### PR TITLE
Align roster header controls across rows

### DIFF
--- a/DH_P2-5.18/rosters/rosters.html
+++ b/DH_P2-5.18/rosters/rosters.html
@@ -55,7 +55,12 @@
 </div>
 </div>
 <div class="hidden" id="contextual-controls">
-<div class="header-row">
+<div class="header-row" id="secondary-header-row">
+<div class="header-icon-slot">
+<button aria-label="Open League Analyzer" class="header-icon-button" id="analyzeLeagueButton">
+<i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+</button>
+</div>
 <div class="custom-select-wrapper">
 <select disabled="" id="leagueSelect">
 <option>Select a league...</option>
@@ -65,7 +70,6 @@
 <button id="positionalViewBtn">Positional</button>
 <button id="depthChartViewBtn">Lineup</button>
 </div>
-<button id="analyzeLeagueButton">Lg. Analyzer</button>
 </div>
 <div class="header-row" id="filters-row">
     <div class="filters-container">

--- a/DH_P2-5.18/styles/styles.css
+++ b/DH_P2-5.18/styles/styles.css
@@ -19,6 +19,11 @@
         --color-accent-secondary-glow: rgba(66, 194, 255, 0.5);
         --color-accent-trade-win: #00F5A0;
         --color-accent-trade-lose: #FF47A6;
+
+        /* · · Header sizing vars for mirrored controls · · */
+        --header-icon-size: clamp(2rem, 7vw, 2.75rem);
+        --header-field-basis: clamp(7.25rem, 26vw, 12rem);
+        --header-switcher-basis: clamp(7.75rem, 28vw, 12.5rem);
     
         /* · · Position Colors · · */
         --pos-qb: #FF3A75ca;
@@ -224,7 +229,8 @@
             padding-bottom: 2px; /* space for scrollbar */
         }
 
-.app-header > .header-row:first-of-type {
+.app-header > .header-row:first-of-type,
+#secondary-header-row {
     justify-content: space-between;
     padding-left: 0.25rem;
     padding-right: 0.25rem;
@@ -255,9 +261,9 @@
         
                 /* · · Row 1 · · */
                 .username-area {
-                    flex-grow: 1;
-                    min-width: 100px; /* prevent it from getting too small */
-                    max-width: 160px;
+                    flex: 1 1 var(--header-field-basis);
+                    max-width: var(--header-field-basis);
+                    width: 100%;
                     padding: .3rem;
                 }
                 /* · · Replace existing #usernameInput block with this · · */
@@ -306,9 +312,9 @@
         /* · · Row 2 · · */
         .custom-select-wrapper {
             position: relative;
-            flex-grow: 1;
-            min-width: 100px;
-            max-width: 120px;
+            flex: 1 1 var(--header-field-basis);
+            max-width: var(--header-field-basis);
+            width: 100%;
         }
         #leagueSelect {
             appearance: none;  /* EDITED: Increased transparency */
@@ -364,6 +370,13 @@
             gap: 0.15rem;
             flex-shrink: 0;
        }
+        .primary-switcher,
+        .secondary-switcher {
+            flex: 1 1 var(--header-switcher-basis);
+            max-width: var(--header-switcher-basis);
+            width: 100%;
+            justify-content: center;
+        }
 		.primary-switcher {           
             background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1));
             box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
@@ -2095,21 +2108,65 @@ font-weight: 500 !important;
 /* ⬇︎  MENU BUTTON AND DROPDOWN  ⬇︎ */
 .menu-container {
     position: relative;
-    display: inline-block;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--header-icon-size);
+    height: var(--header-icon-size);
+    flex: 0 0 var(--header-icon-size);
+}
+
+.header-icon-slot {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--header-icon-size);
+    height: var(--header-icon-size);
+    flex: 0 0 var(--header-icon-size);
 }
 
 .menu-button {
     background: transparent;
     border: none;
     cursor: pointer;
-    padding: 0.25rem;
+    padding: 0;
     display: flex;
     align-items: center;
     justify-content: center;
+    width: 100%;
+    height: 100%;
+    border-radius: 8px;
+}
+
+.header-icon-button {
+    width: 100%;
+    height: 100%;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: 1px solid #cfafcf8a;
+    background: linear-gradient(to bottom, rgba(0,0,0,0.02), rgba(0,0,0,0.2));
+    box-shadow: 0 0 9px #eeddff65;
+    color: #d1b1d1aa;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.header-icon-button i {
+    font-size: 1.1rem;
+}
+
+.header-icon-button:hover,
+.header-icon-button:focus {
+    color: #eeeeee;
 }
 
 .menu-button svg {
     fill: var(--color-text-secondary);
+    width: 1.1rem;
+    height: 1.1rem;
 }
 
 .menu-button:hover svg {
@@ -2181,6 +2238,13 @@ font-weight: 500 !important;
     transition: all 0.2s ease;
     white-space: nowrap;
     color: #d1b1d1aa;
+}
+
+#analyzeLeagueButton.header-icon-button {
+    padding: 0;
+    border-radius: 8px;
+    font-size: 1.1rem;
+    white-space: normal;
 }
 
 #analyzeLeagueButton.glow-on-select {


### PR DESCRIPTION
## Summary
- move the league analyzer trigger to the left of the second header row and replace it with a poll icon button
- size the analyzer button, league selector, and view switcher to mirror the hamburger, username, and primary switcher controls
- introduce shared CSS variables and styles so both header rows stay visually balanced on mobile and desktop

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd753d9d48832ea3be3eae43506c9f