### PR TITLE
Mirror header control sizing on rosters page

### DIFF
--- a/DH_P2-5.18/rosters/rosters.html
+++ b/DH_P2-5.18/rosters/rosters.html
@@ -30,59 +30,64 @@
 <div id="header-container">
 <header class="app-header glass-panel">
 <div class="header-row">
-<div class="menu-container">
-    <button id="menu-button" class="menu-button">
-        <svg viewBox="0 0 100 80" width="20" height="20">
-            <rect width="100" height="15"></rect>
-            <rect y="30" width="100" height="15"></rect>
-            <rect y="60" width="100" height="15"></rect>
-        </svg>
-    </button>
-    <div id="dropdown-menu" class="dropdown-menu hidden">
-        <a href="../">Home</a>
-        <a href="#" id="menu-rosters">Rosters</a>
-        <a href="#" id="menu-ownership">Ownership</a>
-        <a href="#" id="menu-analyzer">League Analyzer</a>
-        <a href="#">Placeholder</a>
+    <div class="menu-container header-icon-wrapper">
+        <button id="menu-button" class="menu-button">
+            <svg viewBox="0 0 100 80" width="20" height="20">
+                <rect width="100" height="15"></rect>
+                <rect y="30" width="100" height="15"></rect>
+                <rect y="60" width="100" height="15"></rect>
+            </svg>
+        </button>
+        <div id="dropdown-menu" class="dropdown-menu hidden">
+            <a href="../">Home</a>
+            <a href="#" id="menu-rosters">Rosters</a>
+            <a href="#" id="menu-ownership">Ownership</a>
+            <a href="#" id="menu-analyzer">League Analyzer</a>
+            <a href="#">Placeholder</a>
+        </div>
     </div>
-</div>
-<div class="username-area">
-<input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
-</div>
-<div class="app-view-switcher primary-switcher">
-<button id="fetchRostersButton">Rosters</button>
-<button id="fetchOwnershipButton">Ownership %</button>
-</div>
+    <div class="username-area header-field">
+        <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
+    </div>
+    <div class="app-view-switcher primary-switcher header-switcher">
+        <button id="fetchRostersButton">Rosters</button>
+        <button id="fetchOwnershipButton">Ownership %</button>
+    </div>
 </div>
 <div class="hidden" id="contextual-controls">
-<div class="header-row">
-<div class="custom-select-wrapper">
-<select disabled="" id="leagueSelect">
-<option>Select a league...</option>
-</select>
-</div>
-<div class="view-switcher secondary-switcher">
-<button id="positionalViewBtn">Positional</button>
-<button id="depthChartViewBtn">Lineup</button>
-</div>
-<button id="analyzeLeagueButton">Lg. Analyzer</button>
-</div>
-<div class="header-row" id="filters-row">
-    <div class="filters-container">
-        <div id="positional-filters">
-            <button class="filter-btn" data-position="QB">QB</button>
-            <button class="filter-btn" data-position="RB">RB</button>
-            <button class="filter-btn" data-position="WR">WR</button>
-            <button class="filter-btn" data-position="TE">TE</button>
-            <button class="filter-btn" data-position="FLX">FLX</button>
+    <div class="header-row">
+        <div class="header-icon-wrapper analyzer-button-container">
+            <button id="analyzeLeagueButton" class="menu-button analyzer-button" aria-label="Open League Analyzer">
+                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+                <span class="sr-only">League Analyzer</span>
+            </button>
         </div>
-        <button class="control-button-subtle" id="clearFiltersButton">Clear</button>
+        <div class="custom-select-wrapper header-field">
+            <select disabled="" id="leagueSelect">
+                <option>Select a league...</option>
+            </select>
+        </div>
+        <div class="view-switcher secondary-switcher header-switcher">
+            <button id="positionalViewBtn">Positional</button>
+            <button id="depthChartViewBtn">Lineup</button>
+        </div>
     </div>
-    <div class="compare-controls">
-        <button class="control-button" disabled="" id="compareButton">Preview</button>
-        <button class="control-button-subtle hidden" id="clearCompareButton">Clear</button>
+    <div class="header-row" id="filters-row">
+        <div class="filters-container">
+            <div id="positional-filters">
+                <button class="filter-btn" data-position="QB">QB</button>
+                <button class="filter-btn" data-position="RB">RB</button>
+                <button class="filter-btn" data-position="WR">WR</button>
+                <button class="filter-btn" data-position="TE">TE</button>
+                <button class="filter-btn" data-position="FLX">FLX</button>
+            </div>
+            <button class="control-button-subtle" id="clearFiltersButton">Clear</button>
+        </div>
+        <div class="compare-controls">
+            <button class="control-button" disabled="" id="compareButton">Preview</button>
+            <button class="control-button-subtle hidden" id="clearCompareButton">Clear</button>
+        </div>
     </div>
-</div>
 </div>
 </header>
 </div>

--- a/DH_P2-5.18/scripts/app.js
+++ b/DH_P2-5.18/scripts/app.js
@@ -44,6 +44,57 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const menuOwnership = document.getElementById('menu-ownership');
         const menuAnalyzer = document.getElementById('menu-analyzer');
         const analyzeLeagueButton = document.getElementById('analyzeLeagueButton');
+        const headerElement = document.querySelector('.app-header');
+
+        let headerSyncRaf = null;
+        const syncHeaderSizing = () => {
+            if (pageType !== 'rosters' || !headerElement) return;
+
+            if (headerSyncRaf) {
+                cancelAnimationFrame(headerSyncRaf);
+            }
+
+            headerSyncRaf = requestAnimationFrame(() => {
+                headerSyncRaf = null;
+
+                const menuWrapper = headerElement.querySelector('.menu-container');
+                if (menuWrapper) {
+                    const iconRect = menuWrapper.getBoundingClientRect();
+                    if (iconRect.width > 0 && iconRect.height > 0) {
+                        const iconWidth = `${iconRect.width}px`;
+                        const iconHeight = `${iconRect.height}px`;
+                        if (headerElement.style.getPropertyValue('--header-icon-size') !== iconWidth) {
+                            headerElement.style.setProperty('--header-icon-size', iconWidth);
+                        }
+                        if (headerElement.style.getPropertyValue('--header-icon-height') !== iconHeight) {
+                            headerElement.style.setProperty('--header-icon-height', iconHeight);
+                        }
+                    }
+                }
+
+                const usernameWrapper = headerElement.querySelector('.username-area');
+                if (usernameWrapper) {
+                    const fieldRect = usernameWrapper.getBoundingClientRect();
+                    if (fieldRect.width > 0) {
+                        const fieldWidth = `${fieldRect.width}px`;
+                        if (headerElement.style.getPropertyValue('--header-field-width') !== fieldWidth) {
+                            headerElement.style.setProperty('--header-field-width', fieldWidth);
+                        }
+                    }
+                }
+
+                const primarySwitcherEl = headerElement.querySelector('.primary-switcher');
+                if (primarySwitcherEl) {
+                    const switcherRect = primarySwitcherEl.getBoundingClientRect();
+                    if (switcherRect.width > 0) {
+                        const switcherWidth = `${switcherRect.width}px`;
+                        if (headerElement.style.getPropertyValue('--header-switcher-width') !== switcherWidth) {
+                            headerElement.style.setProperty('--header-switcher-width', switcherWidth);
+                        }
+                    }
+                }
+            });
+        };
 
         menuButton?.addEventListener('click', (e) => {
             e.stopPropagation();
@@ -55,6 +106,22 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 dropdownMenu.classList.add('hidden');
             }
         });
+
+        if (pageType === 'rosters' && headerElement) {
+            syncHeaderSizing();
+            window.addEventListener('resize', syncHeaderSizing);
+            window.addEventListener('orientationchange', syncHeaderSizing);
+            window.addEventListener('load', () => syncHeaderSizing(), { once: true });
+
+            if (document?.fonts?.ready) {
+                document.fonts.ready.then(() => syncHeaderSizing()).catch(() => {});
+            }
+
+            if (typeof ResizeObserver !== 'undefined') {
+                const headerResizeObserver = new ResizeObserver(() => syncHeaderSizing());
+                headerResizeObserver.observe(headerElement);
+            }
+        }
 
         menuRosters?.addEventListener('click', () => {
             const username = usernameInput.value.trim();
@@ -286,13 +353,14 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 await fetchAndSetUser(username);
                 const leagues = await fetchUserLeagues(state.userId);
                 state.leagues = leagues.sort((a, b) => a.name.localeCompare(b.name));
-                
+
                 updateButtonStates('rosters');
                 contextualControls.classList.remove('hidden');
+                syncHeaderSizing();
                 playerListView.classList.add('hidden');
                 rosterView.classList.remove('hidden');
                 setRosterView('positional'); // Set default view
-                
+
                 populateLeagueSelect(state.leagues);
 
                 const params = new URLSearchParams(window.location.search);

--- a/DH_P2-5.18/styles/styles.css
+++ b/DH_P2-5.18/styles/styles.css
@@ -65,6 +65,18 @@
           outline-offset: 2px;                         /* optional spacing */
         }
 
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+
       .content-wrapper {
         display: flex;
         flex-direction: column;
@@ -238,6 +250,96 @@
             gap: 0.25rem;
             padding-left: 0.25rem;
             padding-right: 0.25rem;
+        }
+
+        body[data-page="rosters"] .app-header {
+            --header-icon-size: clamp(2.25rem, 10vw, 2.5rem);
+            --header-icon-height: clamp(2.25rem, 10vw, 2.5rem);
+            --header-field-width: clamp(110px, 38vw, 160px);
+            --header-switcher-width: clamp(140px, 43vw, 200px);
+        }
+
+        body[data-page="rosters"] .header-icon-wrapper {
+            position: relative;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex: 0 0 var(--header-icon-size);
+            width: var(--header-icon-size);
+            height: var(--header-icon-height);
+        }
+
+        body[data-page="rosters"] .header-icon-wrapper .menu-button {
+            width: 100%;
+            height: 100%;
+            box-sizing: border-box;
+        }
+
+        body[data-page="rosters"] .header-field {
+            flex: 0 0 var(--header-field-width);
+            width: var(--header-field-width);
+            max-width: var(--header-field-width);
+            box-sizing: border-box;
+        }
+
+        body[data-page="rosters"] .header-switcher {
+            flex: 0 0 var(--header-switcher-width);
+            width: var(--header-switcher-width);
+            max-width: var(--header-switcher-width);
+        }
+
+        body[data-page="rosters"] #contextual-controls .header-row:first-child {
+            justify-content: space-between;
+            gap: 0.5rem;
+        }
+
+        body[data-page="rosters"] #analyzeLeagueButton {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0.25rem;
+            border-radius: 8px;
+            border: 1px solid var(--color-panel-border);
+            background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1));
+            box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
+            color: var(--color-text-secondary);
+            cursor: pointer;
+            transition: all 0.2s ease;
+            line-height: 1;
+        }
+
+        body[data-page="rosters"] #analyzeLeagueButton i {
+            font-size: 1.15rem;
+            color: currentColor;
+        }
+
+        body[data-page="rosters"] #analyzeLeagueButton:hover,
+        body[data-page="rosters"] #analyzeLeagueButton:focus-visible {
+            color: var(--color-text-primary);
+            border-color: var(--color-panel-border-glow);
+            box-shadow: 0 0 calc(var(--glow-strength) * 2) var(--color-accent-primary-glow);
+        }
+
+        body[data-page="rosters"] #analyzeLeagueButton.glow-on-select {
+            border: 1px solid #4E00DA;
+            box-shadow: 0 0 8px #7300ff;
+            color: #eeeeee;
+        }
+
+        body[data-page="rosters"] #analyzeLeagueButton.active {
+            color: #ffffff;
+            border: 1px solid #a300ff;
+            background: #7300ff39;
+            box-shadow: 0 0 10px #7300ff;
+        }
+
+        body[data-page="rosters"] #analyzeLeagueButton:disabled {
+            background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1));
+            box-shadow: inset 0 1px 2px rgba(200,200,200,0.08);
+            color: var(--color-text-tertiary);
+            cursor: not-allowed;
+            border-color: var(--color-panel-border);
+            opacity: 0.5;
         }
 
         #contextual-controls {


### PR DESCRIPTION
## Summary
- Reorganize the rosters header so the analyzer control becomes an icon button that mirrors the hamburger menu and aligns with new shared sizing classes
- Add rosters-specific styling utilities to mirror header control widths, introduce an sr-only helper, and restyle the analyzer icon states
- Sync header control dimensions via JavaScript so the second row matches the first row regardless of content or viewport changes

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cd753d9d48832ea3be3eae43506c9f