### PR TITLE
Refine header icon controls

### DIFF
--- a/DH_P2-5.18/ownership/ownership.html
+++ b/DH_P2-5.18/ownership/ownership.html
@@ -54,16 +54,23 @@
 </div>
 <div class="hidden" id="contextual-controls">
 <div class="header-row">
-<div class="custom-select-wrapper">
-<select disabled="" id="leagueSelect">
-<option>Select a league...</option>
-</select>
-</div>
-<div class="view-switcher secondary-switcher">
-<button id="positionalViewBtn">Positional</button>
-<button id="depthChartViewBtn">Lineup</button>
-</div>
-<button id="analyzeLeagueButton" class="control-button">LG-Analyzer</button>
+    <button id="analyzeLeagueButton" class="control-icon-button">
+        <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+        <span class="label">Lg-Analyzer</span>
+    </button>
+    <div class="custom-select-wrapper">
+        <select disabled="" id="leagueSelect">
+            <option>Select a league...</option>
+        </select>
+    </div>
+    <div class="view-switcher secondary-switcher icon-only-switcher">
+        <button id="positionalViewBtn" aria-label="View by position" title="View by position">
+            <i class="fa-duotone fa-solid fa-arrows-turn-to-dots" aria-hidden="true"></i>
+        </button>
+        <button id="depthChartViewBtn" aria-label="View by lineup" title="View by lineup">
+            <i class="fa-duotone fa-light fa-clipboard-list" aria-hidden="true"></i>
+        </button>
+    </div>
 </div>
 <div class="header-row">
 <div id="positional-filters">

--- a/DH_P2-5.18/rosters/rosters.html
+++ b/DH_P2-5.18/rosters/rosters.html
@@ -56,16 +56,23 @@
 </div>
 <div class="hidden" id="contextual-controls">
 <div class="header-row">
-<div class="custom-select-wrapper">
-<select disabled="" id="leagueSelect">
-<option>Select a league...</option>
-</select>
-</div>
-<div class="view-switcher secondary-switcher">
-<button id="positionalViewBtn">Positional</button>
-<button id="depthChartViewBtn">Lineup</button>
-</div>
-<button id="analyzeLeagueButton">Lg. Analyzer</button>
+    <button id="analyzeLeagueButton" class="control-icon-button">
+        <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+        <span class="label">Lg-Analyzer</span>
+    </button>
+    <div class="custom-select-wrapper">
+        <select disabled="" id="leagueSelect">
+            <option>Select a league...</option>
+        </select>
+    </div>
+    <div class="view-switcher secondary-switcher icon-only-switcher">
+        <button id="positionalViewBtn" aria-label="View by position" title="View by position">
+            <i class="fa-duotone fa-solid fa-arrows-turn-to-dots" aria-hidden="true"></i>
+        </button>
+        <button id="depthChartViewBtn" aria-label="View by lineup" title="View by lineup">
+            <i class="fa-duotone fa-light fa-clipboard-list" aria-hidden="true"></i>
+        </button>
+    </div>
 </div>
 <div class="header-row" id="filters-row">
     <div class="filters-container">

--- a/DH_P2-5.18/styles/styles.css
+++ b/DH_P2-5.18/styles/styles.css
@@ -405,6 +405,22 @@
             color: var(--color-text-secondary);
             text-shadow: 0 0 2px rgba(0,0,0,0.2);
         }
+        .icon-only-switcher {
+            gap: 0.18rem;
+            padding: 0.12rem;
+        }
+        .icon-only-switcher button {
+            padding: 0.2rem 0.45rem;
+            font-size: 1rem;
+            line-height: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .icon-only-switcher button i {
+            line-height: 1;
+            font-size: 1rem;
+        }
         .filter-btn {
             padding: 0.15rem 0.6rem;
             font-size: 0.85rem;
@@ -419,6 +435,37 @@
             text-shadow: 0 0 2px rgba(0,0,0,0.2);
         }
 
+        .control-icon-button {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 0.12rem;
+            padding: 0.3rem 0.55rem;
+            border: 1px solid transparent;
+            background: transparent;
+            border-radius: 6px;
+            color: var(--color-text-secondary);
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+        .control-icon-button i {
+            display: block;
+            margin: 0;
+            line-height: 1;
+            font-size: 1rem;
+        }
+        .control-icon-button .label {
+            display: block;
+            margin: -2px 0 0 0;
+            padding: 0;
+            font-size: 0.55rem;
+            font-weight: 500;
+            line-height: 1;
+            color: inherit;
+            text-transform: none;
+        }
+
         
         /* · · Primary buttons are bolder · · */
         .primary-switcher button {
@@ -427,7 +474,7 @@
         }
 
         /* · · Hover States · · */
-        .primary-switcher button:hover, .secondary-switcher button:hover, .filter-btn:hover {
+        .primary-switcher button:hover, .secondary-switcher button:hover, .filter-btn:hover, .control-icon-button:hover {
             color: var(--color-text-primary);
             background: var(--color-panel-bg);
         }
@@ -2179,8 +2226,32 @@ font-weight: 500 !important;
     border-radius: 6px;
     cursor: pointer;
     transition: all 0.2s ease;
-    white-space: nowrap;
+    white-space: normal;
     color: #d1b1d1aa;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.125rem;
+    text-align: center;
+    min-height: 0;
+}
+
+#analyzeLeagueButton i {
+    display: block;
+    margin: 0;
+    line-height: 1;
+    font-size: 1.05rem;
+}
+
+#analyzeLeagueButton .label {
+    display: block;
+    margin: -2px 0 0 0;
+    padding: 0;
+    font-size: 0.55rem;
+    font-weight: 500;
+    line-height: 1;
+    color: inherit;
 }
 
 #analyzeLeagueButton.glow-on-select {


### PR DESCRIPTION
## Summary
- convert the contextual view toggle into compact icon-only buttons that retain the segmented styling and correct lineup glyph
- keep the league analyzer button leading the row with a stacked label while marking its icon as decorative
- add supporting styles for the streamlined toggle buttons and shared icon-button layout

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cd72d9f240832eb8ccfa1a2b7256b3