### PR TITLE
Align header controls with icon labels

### DIFF
--- a/DH_P2-5.18/ownership/ownership.html
+++ b/DH_P2-5.18/ownership/ownership.html
@@ -74,7 +74,13 @@
 <button class="filter-btn" data-position="FLX">FLX</button>
 </div>
 <div class="compare-controls">
-<button class="control-button" disabled="" id="compareButton">Preview</button>
+<button class="control-button" disabled="" id="compareButton" type="button" aria-label="Preview selected teams">
+    <span class="button-text">Preview</span>
+    <span class="button-icon-label">
+        <i class="fa-solid fa-arrows-left-right-to-line" aria-hidden="true"></i>
+        <span class="label">Show All</span>
+    </span>
+</button>
 <button class="control-button-subtle hidden" id="clearCompareButton">Clear</button>
 </div>
 </div>

--- a/DH_P2-5.18/rosters/rosters.html
+++ b/DH_P2-5.18/rosters/rosters.html
@@ -29,7 +29,7 @@
 <div class="relative z-10 content-wrapper">
 <div id="header-container">
 <header class="app-header glass-panel">
-<div class="header-row">
+<div class="header-row" id="primary-header-row">
 <div class="menu-container">
     <button id="menu-button" class="menu-button">
         <svg viewBox="0 0 100 80" width="20" height="20">
@@ -51,11 +51,17 @@
 </div>
 <div class="app-view-switcher primary-switcher">
 <button id="fetchRostersButton">Rosters</button>
-<button id="fetchOwnershipButton">Ownership %</button>
+<button id="fetchOwnershipButton">Ownership%</button>
 </div>
 </div>
 <div class="hidden" id="contextual-controls">
-<div class="header-row">
+<div class="header-row" id="secondary-header-row">
+<div class="analyzer-button-container">
+<button aria-label="Open League Analyzer" class="menu-button analyzer-button" id="analyzeLeagueButton" type="button">
+<i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+<span class="label">L-Analyzer</span>
+</button>
+</div>
 <div class="custom-select-wrapper">
 <select disabled="" id="leagueSelect">
 <option>Select a league...</option>
@@ -65,7 +71,6 @@
 <button id="positionalViewBtn">Positional</button>
 <button id="depthChartViewBtn">Lineup</button>
 </div>
-<button id="analyzeLeagueButton">Lg. Analyzer</button>
 </div>
 <div class="header-row" id="filters-row">
     <div class="filters-container">
@@ -76,10 +81,19 @@
             <button class="filter-btn" data-position="TE">TE</button>
             <button class="filter-btn" data-position="FLX">FLX</button>
         </div>
-        <button class="control-button-subtle" id="clearFiltersButton">Clear</button>
+        <button class="control-button-subtle" id="clearFiltersButton" aria-label="Clear filters">
+            <i class="fa-regular fa-filter-circle-xmark" aria-hidden="true"></i>
+            <span class="label">Clear</span>
+        </button>
     </div>
     <div class="compare-controls">
-        <button class="control-button" disabled="" id="compareButton">Preview</button>
+        <button class="control-button" disabled="" id="compareButton" type="button" aria-label="Preview selected teams">
+            <span class="button-text">Preview</span>
+            <span class="button-icon-label">
+                <i class="fa-solid fa-arrows-left-right-to-line" aria-hidden="true"></i>
+                <span class="label">Show All</span>
+            </span>
+        </button>
         <button class="control-button-subtle hidden" id="clearCompareButton">Clear</button>
     </div>
 </div>

--- a/DH_P2-5.18/scripts/app.js
+++ b/DH_P2-5.18/scripts/app.js
@@ -489,12 +489,12 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             }
 
             if (state.isCompareMode) {
-                compareButton.textContent = 'Show All';
                 compareButton.classList.add('active');
                 compareButton.classList.remove('glow-on-select');
+                compareButton.setAttribute('aria-label', 'Show all teams');
             } else {
-                compareButton.textContent = 'Preview';
                 compareButton.classList.remove('active');
+                compareButton.setAttribute('aria-label', 'Preview selected teams');
             }
             
             if (count < 2 && state.isCompareMode) {

--- a/DH_P2-5.18/styles/styles.css
+++ b/DH_P2-5.18/styles/styles.css
@@ -212,6 +212,10 @@
             display: flex;
             flex-direction: column;
             gap: 0.25rem;
+            --header-icon-size: 2.25rem;
+            --header-control-height: 2.2rem;
+            --header-field-max-width: 160px;
+            --header-switcher-width: 12.25rem;
         }
 
         .header-row {
@@ -224,20 +228,119 @@
             padding-bottom: 2px; /* space for scrollbar */
         }
 
-.app-header > .header-row:first-of-type {
-    justify-content: space-between;
-    padding-left: 0.25rem;
-    padding-right: 0.25rem;
-}
+        .app-header > .header-row:first-of-type,
+        #contextual-controls .header-row:first-child {
+            display: grid;
+            grid-template-columns: var(--header-icon-size) minmax(120px, var(--header-field-max-width)) minmax(var(--header-switcher-width), 1fr);
+            align-items: center;
+            gap: 0.5rem;
+            padding-left: 0.25rem;
+            padding-right: 0.25rem;
+        }
+
         #contextual-controls .header-row {
             border-top: 1px solid var(--color-panel-border);
             padding-top: 0.25rem;
         }
-        #contextual-controls .header-row:first-child,
+        #contextual-controls .header-row:first-child {
+            gap: 0.5rem;
+        }
         #contextual-controls .header-row:has(#positional-filters) {
             gap: 0.25rem;
             padding-left: 0.25rem;
             padding-right: 0.25rem;
+        }
+
+        #primary-header-row .menu-container,
+        #secondary-header-row .analyzer-button-container {
+            width: var(--header-icon-size);
+            height: var(--header-control-height);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        #primary-header-row .menu-container {
+            position: relative;
+        }
+
+        #primary-header-row .menu-button,
+        #secondary-header-row .analyzer-button {
+            width: 100%;
+            height: 100%;
+            border-radius: 8px;
+            box-sizing: border-box;
+        }
+
+        #primary-header-row .menu-button svg {
+            width: 1.25rem;
+            height: 1.25rem;
+        }
+
+        #secondary-header-row .analyzer-button {
+            border: none;
+            background: transparent;
+            color: var(--color-text-secondary);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 0;
+            gap: 0.1rem;
+        }
+
+        #secondary-header-row .analyzer-button i {
+            display: block;
+            margin: 0;
+            line-height: 1;
+            font-size: 1.2rem;
+        }
+
+        #secondary-header-row .analyzer-button .label {
+            display: block;
+            margin: -2px 0 0 0;
+            padding: 0;
+            font-size: 0.5rem;
+            font-weight: 500;
+            line-height: 1;
+            color: inherit;
+        }
+
+        #secondary-header-row .analyzer-button:hover i,
+        #secondary-header-row .analyzer-button:focus-visible i {
+            color: var(--color-text-primary);
+        }
+
+        #primary-header-row .username-area,
+        #secondary-header-row .custom-select-wrapper {
+            justify-self: center;
+            width: 100%;
+        }
+
+        #primary-header-row .primary-switcher,
+        #secondary-header-row .secondary-switcher {
+            justify-self: end;
+            width: min(var(--header-switcher-width), 100%);
+            max-width: var(--header-switcher-width);
+            height: var(--header-control-height);
+            display: flex;
+            align-items: stretch;
+            margin-block: 0.075rem;
+        }
+
+        #primary-header-row .primary-switcher button,
+        #secondary-header-row .secondary-switcher button {
+            flex: 1 1 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        #primary-header-row .menu-container,
+        #primary-header-row .username-area,
+        #secondary-header-row .analyzer-button-container,
+        #secondary-header-row .custom-select-wrapper {
+            margin-block: 0.075rem;
         }
 
         #contextual-controls {
@@ -257,8 +360,11 @@
                 .username-area {
                     flex-grow: 1;
                     min-width: 100px; /* prevent it from getting too small */
-                    max-width: 160px;
-                    padding: .3rem;
+                    max-width: var(--header-field-max-width);
+                    padding: 0;
+                    height: var(--header-control-height);
+                    display: flex;
+                    align-items: stretch;
                 }
                 /* · · Replace existing #usernameInput block with this · · */
         #usernameInput {
@@ -277,6 +383,7 @@
           font-size: 0.5rem;
           font-weight: 300;
           width: 100%;
+          height: 100%;
           transition: all 0.2s ease;
         }
         
@@ -307,8 +414,12 @@
         .custom-select-wrapper {
             position: relative;
             flex-grow: 1;
-            min-width: 100px;
-            max-width: 120px;
+            min-width: 0;
+            max-width: var(--header-field-max-width);
+            height: var(--header-control-height);
+            display: flex;
+            align-items: stretch;
+            overflow: hidden;
         }
         #leagueSelect {
             appearance: none;  /* EDITED: Increased transparency */
@@ -317,11 +428,13 @@
             border-radius: 8px;
             -webkit-backdrop-filter: blur(4px) saturate(110%);
             backdrop-filter: blur(4px) saturate(110%);
-            box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);           
-            padding: 0.45rem 1.5rem 0.45rem 0.5rem;
+            box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
+            padding: 0.32rem 1.25rem 0.32rem 0.5rem;
             font-size: 0.7rem;
             color: #c4c8ea;
             width: 100%;
+            height: 100%;
+            min-width: 0;
             cursor: pointer;
             white-space: nowrap;
             overflow: hidden;
@@ -360,7 +473,7 @@
             display: flex;
             border: 1px solid var(--color-panel-border);
             border-radius: 8px;
-            padding: 0.14rem;
+            padding: 0.1rem 0.12rem;
             gap: 0.15rem;
             flex-shrink: 0;
        }
@@ -380,7 +493,7 @@
 
 /* ⬇︎ MAIN BUTTON STYLES  ⬇︎ */
         .primary-switcher button {
-            padding: 0.15rem 0.6rem;
+            padding: 0.12rem 0.55rem;
             font-size: 0.85rem;
             font-weight: 400;
             border: 1px solid transparent;
@@ -393,7 +506,7 @@
             text-shadow: 0 0 2px rgba(0,0,0,0.2);
         }
         .secondary-switcher button, .filter-btn {
-            padding: 0.15rem 0.6rem;
+            padding: 0.12rem 0.55rem;
             font-size: 0.85rem;
             font-weight: 400;
             border: 1px solid transparent;
@@ -520,6 +633,46 @@
 
         .control-button-subtle.active {
             color: var(--color-text-secondary);
+        }
+
+        #compareButton {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 0.15rem;
+        }
+
+        #compareButton .button-text {
+            line-height: 1;
+        }
+
+        #compareButton .button-icon-label {
+            display: none;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.05rem;
+            line-height: 1;
+        }
+
+        #compareButton .button-icon-label i {
+            font-size: 1rem;
+            line-height: 1;
+        }
+
+        #compareButton .button-icon-label .label {
+            font-size: 0.5rem;
+            font-weight: 500;
+            line-height: 1;
+            margin-top: -2px;
+        }
+
+        #compareButton.active .button-icon-label {
+            display: flex;
+        }
+
+        #compareButton.active .button-text {
+            display: none;
         }
 
 
@@ -2160,6 +2313,25 @@ font-weight: 500 !important;
 #clearFiltersButton {
     margin-left: 0rem;   /* small space on the left  */
     margin-right: 0.6rem;  /* larger space on the right */
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.1rem;
+    padding: 0;
+    text-decoration: none;
+}
+
+#clearFiltersButton i {
+    font-size: 1rem;
+    line-height: 1;
+}
+
+#clearFiltersButton .label {
+    font-size: 0.5rem;
+    font-weight: 500;
+    line-height: 1;
+    margin-top: -2px;
 }
 
 .team-header-item .team-name {
@@ -2181,6 +2353,22 @@ font-weight: 500 !important;
     transition: all 0.2s ease;
     white-space: nowrap;
     color: #d1b1d1aa;
+}
+
+body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton {
+    padding: 0;
+    border: none;
+    background: transparent !important;
+    box-shadow: none;
+    color: var(--color-text-secondary);
+}
+
+body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.glow-on-select,
+body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
+    box-shadow: none;
+    background: transparent;
+    border: none;
+    color: var(--color-text-primary);
 }
 
 #analyzeLeagueButton.glow-on-select {


### PR DESCRIPTION
## Summary
- shrink the league analyzer caption and give the filter clear button a stacked icon/label treatment
- show the "Show All" preview state as an icon with a caption across the rosters and ownership headers
- update the compare button state handler so it toggles accessibility labels without rewriting the button contents

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd753d9d48832ea3be3eae43506c9f