### PR TITLE
Add SYOP insights page with interactive visualizations

### DIFF
--- a/DH_P3-5.21Gb/analyzer/analyzer.html
+++ b/DH_P3-5.21Gb/analyzer/analyzer.html
@@ -152,7 +152,7 @@
                             <a href="#" id="menu-rosters">Rosters</a>
                             <a href="#" id="menu-ownership">Ownership</a>
                             <a href="#" id="menu-analyzer">League Analyzer</a>
-                            <a href="#">Placeholder</a>
+                            <a href="#" id="menu-syop">SYOP</a>
                         </div>
                     </div>
                     <div class="username-area">

--- a/DH_P3-5.21Gb/index.html
+++ b/DH_P3-5.21Gb/index.html
@@ -44,7 +44,7 @@
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
         <a href="#" id="menu-analyzer">League Analyzer</a>
-        <a href="#">Coming Soon..</a>
+        <a href="#" id="menu-syop">SYOP</a>
     </div>
 </div>
 <div class="username-area">

--- a/DH_P3-5.21Gb/ownership/ownership.html
+++ b/DH_P3-5.21Gb/ownership/ownership.html
@@ -41,7 +41,7 @@
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
         <a href="#" id="menu-analyzer">League Analyzer</a>
-        <a href="#">Placeholder</a>
+        <a href="#" id="menu-syop">SYOP</a>
     </div>
 </div>
 <div class="username-area">

--- a/DH_P3-5.21Gb/rosters/rosters.html
+++ b/DH_P3-5.21Gb/rosters/rosters.html
@@ -43,7 +43,7 @@
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
         <a href="#" id="menu-analyzer">League Analyzer</a>
-        <a href="#">Placeholder</a>
+        <a href="#" id="menu-syop">SYOP</a>
     </div>
 </div>
 <div class="username-area">

--- a/DH_P3-5.21Gb/scripts/app.js
+++ b/DH_P3-5.21Gb/scripts/app.js
@@ -50,6 +50,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const menuRosters = document.getElementById('menu-rosters');
         const menuOwnership = document.getElementById('menu-ownership');
         const menuAnalyzer = document.getElementById('menu-analyzer');
+        const menuSyop = document.getElementById('menu-syop');
         const analyzeLeagueButton = document.getElementById('analyzeLeagueButton');
 
         menuButton?.addEventListener('click', (e) => {
@@ -94,6 +95,12 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 url += `&leagueId=${selected}`;
             }
             window.location.href = url;
+            dropdownMenu.classList.add('hidden');
+        });
+
+        menuSyop?.addEventListener('click', () => {
+            const baseUrl = pageType === 'welcome' ? 'syop/syop.html' : '../syop/syop.html';
+            window.location.href = baseUrl;
             dropdownMenu.classList.add('hidden');
         });
 

--- a/DH_P3-5.21Gb/scripts/syop.js
+++ b/DH_P3-5.21Gb/scripts/syop.js
@@ -1,0 +1,968 @@
+(function () {
+  'use strict';
+
+  const page = document.body?.dataset?.page;
+  if (page !== 'syop') {
+    return;
+  }
+
+  const syopColors = {
+    bg: '#0B0E16',
+    panel: 'rgba(26, 29, 44, 0.55)',
+    panelBorder: 'rgba(255,255,255,0.08)',
+    text: '#E9ECF9',
+    subtext: '#B6B9D6',
+    qb: '#A855F7',
+    rb: '#EC4899',
+    wr: '#22D3EE',
+    te: '#F472B6',
+    muted: '#334155',
+  };
+
+  const SUNBURST = {
+    labels: [
+      'Mean | Λ <br>&<br> Mode | M',
+      'QB ',
+      'RB ',
+      'WR ',
+      'TE ',
+      'SPΛ <br>(7.2)',
+      'BOΛ <br>(2.3)',
+      'SPM <br>(6)',
+      'BOM <br>(1)',
+      'SPΛ <br>(3.41)',
+      'BOΛ <br>(2.2)',
+      'SPM <br>(0.7)',
+      'BOM <br>(1.7)',
+      'SPΛ <br>(4.9)',
+      'BOΛ <br>(2.9)',
+      'SPM <br>(3)',
+      'BOM <br>(2)',
+      'SPΛ <br>(4.0)',
+      'BOΛ <br>(3.5)',
+      'SPM <br>(2)',
+      'BOM <br>(3)',
+    ],
+    parents: [
+      '',
+      'Mean | Λ <br>&<br> Mode | M',
+      'Mean | Λ <br>&<br> Mode | M',
+      'Mean | Λ <br>&<br> Mode | M',
+      'Mean | Λ <br>&<br> Mode | M',
+      'QB ',
+      'QB ',
+      'QB ',
+      'QB ',
+      'RB ',
+      'RB ',
+      'RB ',
+      'RB ',
+      'WR ',
+      'WR ',
+      'WR ',
+      'WR ',
+      'TE ',
+      'TE ',
+      'TE ',
+      'TE ',
+    ],
+    values: [
+      51.6, 16.46, 9.8, 12.82, 12.5, 6.5, 2.49, 5.35, 2.1, 3.31, 2.5, 1.89, 2.1, 4.92, 2.84, 3, 2, 4.01, 3.49, 2, 3,
+    ],
+  };
+
+  const SYOP_DATA = [
+    { SYOP: '1', 'QB %': 6.67, 'RB %': 27.54, 'WR %': 13.0, 'TE %': 26.92 },
+    { SYOP: '2', 'QB %': 11.11, 'RB %': 20.29, 'WR %': 14.1, 'TE %': 26.92 },
+    { SYOP: '3', 'QB %': 8.89, 'RB %': 11.59, 'WR %': 14.1, 'TE %': 7.69 },
+    { SYOP: '4', 'QB %': 8.89, 'RB %': 11.4, 'WR %': 12.0, 'TE %': 7.69 },
+    { SYOP: '5', 'QB %': 4.44, 'RB %': 13.04, 'WR %': 5.4, 'TE %': 0.4 },
+    { SYOP: '6', 'QB %': 13.33, 'RB %': 5.8, 'WR %': 7.6, 'TE %': 7.69 },
+    { SYOP: '7', 'QB %': 8.89, 'RB %': 1.45, 'WR %': 13.0, 'TE %': 7.69 },
+    { SYOP: '8', 'QB %': 4.44, 'RB %': 2.9, 'WR %': 9.8, 'TE %': 0.4 },
+    { SYOP: '9', 'QB %': 11.11, 'RB %': 3.3, 'WR %': 2.2, 'TE %': 3.85 },
+    { SYOP: '10', 'QB %': 2.22, 'RB %': 1.45, 'WR %': 4.49, 'TE %': 3.51 },
+    { SYOP: '11', 'QB %': 0.4, 'RB %': 1.45, 'WR %': 2.2, 'TE %': 3.85 },
+    { SYOP: '12+', 'QB %': 20.0, 'RB %': 0.4, 'WR %': 2.2, 'TE %': 3.85 },
+  ];
+
+  const GAUGES = [
+    { key: 'TE', value: 4.0, color: syopColors.te },
+    { key: 'RB', value: 3.39, color: syopColors.rb },
+    { key: 'WR', value: 4.9, color: syopColors.wr },
+    { key: 'QB', value: 7.22, color: syopColors.qb },
+  ];
+
+  const DRAFT_OVERALL = [
+    { round: '1', hit: 78.4 },
+    { round: '2', hit: 47.7 },
+    { round: '3', hit: 38.5 },
+    { round: '4', hit: 18.0 },
+    { round: '5', hit: 15.0 },
+    { round: '6', hit: 14.1 },
+    { round: '7', hit: 9.4 },
+  ];
+
+  const DRAFT_POSITIONAL = [
+    { round: '1', QB: 78, RB: 83, TE: 78, WR: 76 },
+    { round: '2', QB: 42, RB: 50, TE: 40, WR: 51 },
+    { round: '3', QB: 31, RB: 62, TE: 36, WR: 30 },
+    { round: '4', QB: 20, RB: 27, TE: 23, WR: 9 },
+    { round: '5', QB: 7, RB: 27, TE: 9, WR: 13 },
+    { round: '6', QB: 11, RB: 18, TE: 8, WR: 15 },
+    { round: '7', QB: 13, RB: 9, TE: 4, WR: 11 },
+  ];
+
+  const draftColors = {
+    QB: '#FF41E1',
+    RB: '#20F7A7',
+    TE: '#9E5AF7',
+    WR: '#46E7FF',
+    grid: 'rgba(148,163,184,0.14)',
+    text: '#E2E8F0',
+  };
+
+  const seriesOrder = [
+    { key: 'QB %', label: 'QB %', color: syopColors.qb },
+    { key: 'RB %', label: 'RB %', color: syopColors.rb },
+    { key: 'WR %', label: 'WR %', color: syopColors.wr },
+    { key: 'TE %', label: 'TE %', color: syopColors.te },
+  ];
+
+  const syopChartState = {
+    filters: {
+      'QB %': true,
+      'RB %': true,
+      'WR %': true,
+      'TE %': true,
+    },
+    stacked: false,
+  };
+
+  const svgNS = 'http://www.w3.org/2000/svg';
+
+  function createSvgElement(name, attrs) {
+    const el = document.createElementNS(svgNS, name);
+    if (attrs) {
+      Object.entries(attrs).forEach(([key, value]) => {
+        if (value !== undefined && value !== null) {
+          el.setAttribute(key, String(value));
+        }
+      });
+    }
+    return el;
+  }
+
+  function stripTags(str) {
+    return (str || '').replace(/<br\s*\/?>(?=\s*)/gi, ' ').replace(/<[^>]*>/g, '').trim();
+  }
+
+  function splitLabelValue(raw) {
+    const txt = stripTags(raw);
+    const match = txt.match(/^(.+?)\s*\(([^)]+)\)\s*$/);
+    if (match) {
+      return { main: match[1].trim(), paren: match[2].trim() };
+    }
+    return { main: txt, paren: null };
+  }
+
+  function buildSunburstTree() {
+    const nodes = SUNBURST.labels.map((label, i) => ({
+      label,
+      parent: SUNBURST.parents[i],
+      value: SUNBURST.values[i],
+    }));
+    const rootLabel = SUNBURST.labels[0];
+    const children = (parent) => nodes.filter((n) => n.parent === parent);
+    const ring1 = children(rootLabel);
+    const byParent = {};
+    ring1.forEach((node) => {
+      byParent[node.label] = children(node.label);
+    });
+    return { ring1, byParent, rootLabel };
+  }
+
+  function polar(cx, cy, r, angle) {
+    return {
+      x: cx + r * Math.cos(angle),
+      y: cy + r * Math.sin(angle),
+    };
+  }
+
+  function arcPath(cx, cy, innerR, outerR, a0, a1) {
+    const p0 = polar(cx, cy, outerR, a0);
+    const p1 = polar(cx, cy, outerR, a1);
+    const p2 = polar(cx, cy, innerR, a1);
+    const p3 = polar(cx, cy, innerR, a0);
+    const largeArc = a1 - a0 > Math.PI ? 1 : 0;
+    return `M ${p0.x} ${p0.y} A ${outerR} ${outerR} 0 ${largeArc} 1 ${p1.x} ${p1.y} L ${p2.x} ${p2.y} A ${innerR} ${innerR} 0 ${largeArc} 0 ${p3.x} ${p3.y} Z`;
+  }
+
+  function seriesFromLabel(label) {
+    if (!label) return '';
+    const trimmed = stripTags(label).trim().toUpperCase();
+    if (trimmed.startsWith('QB')) return 'QB';
+    if (trimmed.startsWith('RB')) return 'RB';
+    if (trimmed.startsWith('WR')) return 'WR';
+    if (trimmed.startsWith('TE')) return 'TE';
+    return '';
+  }
+
+  function seriesColor(series) {
+    switch (series) {
+      case 'QB':
+        return syopColors.qb;
+      case 'RB':
+        return syopColors.rb;
+      case 'WR':
+        return syopColors.wr;
+      case 'TE':
+        return syopColors.te;
+      default:
+        return syopColors.muted;
+    }
+  }
+
+  function renderSunburst() {
+    const container = document.getElementById('syop-sunburst');
+    if (!container) return;
+    container.innerHTML = '';
+
+    const size = 520;
+    const padding = 72;
+    const svg = createSvgElement('svg', {
+      viewBox: `${-padding} ${-padding} ${size + padding * 2} ${size + padding * 2}`,
+      role: 'presentation',
+      focusable: 'false',
+    });
+
+    const { ring1, byParent, rootLabel } = buildSunburstTree();
+    const cx = size / 2;
+    const cy = size / 2;
+    const ring1Inner = 96;
+    const ring1Outer = 172;
+    const ring2Inner = 184;
+    const ring2Outer = 268;
+    const startAngle = -Math.PI / 2;
+
+    const totalRing1 = ring1.reduce((sum, node) => sum + node.value, 0) || 1;
+    let cursor = startAngle;
+    const ring1Segments = ring1.map((node) => {
+      const span = (node.value / totalRing1) * Math.PI * 2;
+      const segment = { node, a0: cursor, a1: cursor + span };
+      cursor += span;
+      return segment;
+    });
+
+    const ring2Segments = [];
+    ring1Segments.forEach((segment) => {
+      const children = byParent[segment.node.label] || [];
+      const total = children.reduce((sum, child) => sum + child.value, 0) || 1;
+      let childCursor = segment.a0;
+      children.forEach((child) => {
+        const span = (child.value / total) * (segment.a1 - segment.a0);
+        ring2Segments.push({
+          parent: segment,
+          child,
+          a0: childCursor,
+          a1: childCursor + span,
+        });
+        childCursor += span;
+      });
+    });
+
+    ring1Segments.forEach((segment) => {
+      const series = seriesFromLabel(segment.node.label);
+      const path = createSvgElement('path', {
+        d: arcPath(cx, cy, ring1Inner, ring1Outer, segment.a0, segment.a1),
+        fill: seriesColor(series),
+        opacity: '0.9',
+        stroke: syopColors.bg,
+        'stroke-width': '1',
+      });
+      svg.appendChild(path);
+
+      const midpoint = (segment.a0 + segment.a1) / 2;
+      const labelPoint = polar(cx, cy, (ring1Inner + ring1Outer) / 2, midpoint);
+      const text = createSvgElement('text', {
+        x: labelPoint.x,
+        y: labelPoint.y,
+        fill: syopColors.text,
+        'font-size': '14',
+        'font-weight': '800',
+        'text-anchor': 'middle',
+        'dominant-baseline': 'middle',
+      });
+      text.textContent = stripTags(segment.node.label);
+      svg.appendChild(text);
+    });
+
+    ring2Segments.forEach((segment, idx) => {
+      const series = seriesFromLabel(segment.parent.node.label);
+      const path = createSvgElement('path', {
+        d: arcPath(cx, cy, ring2Inner, ring2Outer, segment.a0, segment.a1),
+        fill: seriesColor(series),
+        opacity: '0.85',
+        stroke: syopColors.bg,
+        'stroke-width': '1.2',
+      });
+      svg.appendChild(path);
+
+      const midpoint = (segment.a0 + segment.a1) / 2;
+      const labelRadius = (ring2Inner + ring2Outer) / 2;
+      const labelPoint = polar(cx, cy, labelRadius, midpoint);
+      const { main, paren } = splitLabelValue(segment.child.label);
+      const textGroup = createSvgElement('text', {
+        x: labelPoint.x,
+        y: labelPoint.y - 2,
+        fill: syopColors.text,
+        'text-anchor': 'middle',
+        'dominant-baseline': 'middle',
+      });
+      const mainLine = createSvgElement('tspan', {
+        'font-size': '14',
+        'font-weight': '800',
+      });
+      mainLine.textContent = main;
+      textGroup.appendChild(mainLine);
+      if (paren) {
+        const valueLine = createSvgElement('tspan', {
+          x: labelPoint.x,
+          dy: '14',
+          'font-size': '12',
+          fill: syopColors.subtext,
+          'font-weight': '700',
+        });
+        valueLine.textContent = `(${paren})`;
+        textGroup.appendChild(valueLine);
+      }
+      svg.appendChild(textGroup);
+    });
+
+    const centerCircle = createSvgElement('circle', {
+      cx,
+      cy,
+      r: '74',
+      fill: '#1E2235',
+      stroke: syopColors.bg,
+    });
+    svg.appendChild(centerCircle);
+
+    const centerLineOne = createSvgElement('text', {
+      x: cx,
+      y: cy - 6,
+      fill: syopColors.text,
+      'font-size': '15',
+      'font-weight': '900',
+      'text-anchor': 'middle',
+      'dominant-baseline': 'middle',
+    });
+    centerLineOne.textContent = 'Mean | Λ';
+    svg.appendChild(centerLineOne);
+
+    const centerLineTwo = createSvgElement('text', {
+      x: cx,
+      y: cy + 14,
+      fill: syopColors.text,
+      'font-size': '15',
+      'font-weight': '900',
+      'text-anchor': 'middle',
+      'dominant-baseline': 'middle',
+    });
+    centerLineTwo.textContent = '& Mode | M';
+    svg.appendChild(centerLineTwo);
+
+    container.appendChild(svg);
+  }
+
+  function formatPercent(value) {
+    const rounded = Math.round(value * 10) / 10;
+    const whole = Math.round(rounded);
+    if (Math.abs(rounded - whole) < 0.05) {
+      return `${whole}%`;
+    }
+    return `${rounded.toFixed(1)}%`;
+  }
+
+  function renderColumnChart() {
+    const container = document.getElementById('syop-chart');
+    if (!container) return;
+    container.innerHTML = '';
+
+    const activeSeries = seriesOrder.filter((serie) => syopChartState.filters[serie.key]);
+    if (!activeSeries.length) {
+      const emptyState = document.createElement('p');
+      emptyState.className = 'syop-empty';
+      emptyState.textContent = 'Select at least one position to display the distribution.';
+      container.appendChild(emptyState);
+      return;
+    }
+
+    const width = 900;
+    const height = 360;
+    const margin = { top: 32, right: 24, bottom: 56, left: 72 };
+    const chartWidth = width - margin.left - margin.right;
+    const chartHeight = height - margin.top - margin.bottom;
+    const svg = createSvgElement('svg', {
+      viewBox: `0 0 ${width} ${height}`,
+      role: 'img',
+      'aria-label': 'Bar chart showing SYOP distribution by position',
+    });
+
+    const background = createSvgElement('rect', {
+      x: 0,
+      y: 0,
+      width,
+      height,
+      fill: 'transparent',
+      rx: 16,
+    });
+    svg.appendChild(background);
+
+    const axisGroup = createSvgElement('g', { transform: `translate(${margin.left}, ${margin.top})` });
+    svg.appendChild(axisGroup);
+
+    const tickValues = [0, 5, 10, 15, 20, 25, 30];
+    tickValues.forEach((tick) => {
+      const y = chartHeight - (tick / 30) * chartHeight;
+      const gridLine = createSvgElement('line', {
+        x1: 0,
+        y1: y,
+        x2: chartWidth,
+        y2: y,
+        stroke: 'rgba(255,255,255,0.08)',
+      });
+      axisGroup.appendChild(gridLine);
+
+      const label = createSvgElement('text', {
+        x: -16,
+        y: y + 4,
+        fill: syopColors.subtext,
+        'font-size': '12',
+        'text-anchor': 'end',
+      });
+      label.textContent = `${tick}%`;
+      axisGroup.appendChild(label);
+    });
+
+    const groupWidth = chartWidth / SYOP_DATA.length;
+    const innerPadding = 0.25;
+    const usableWidth = groupWidth * (1 - innerPadding);
+
+    SYOP_DATA.forEach((row, rowIndex) => {
+      const group = createSvgElement('g', {
+        transform: `translate(${rowIndex * groupWidth + (groupWidth - usableWidth) / 2}, 0)`,
+      });
+
+      let stackedOffset = 0;
+      const barWidth = syopChartState.stacked
+        ? usableWidth
+        : usableWidth / activeSeries.length - (activeSeries.length > 1 ? 6 : 0);
+      const seriesGap = syopChartState.stacked ? 0 : 6;
+
+      activeSeries.forEach((serie, serieIndex) => {
+        const value = row[serie.key] || 0;
+        const barHeight = (value / 30) * chartHeight;
+        const x = syopChartState.stacked ? 0 : serieIndex * (barWidth + seriesGap);
+        const y = chartHeight - barHeight - stackedOffset;
+
+        const rect = createSvgElement('rect', {
+          x,
+          y,
+          width: barWidth,
+          height: Math.max(barHeight, 1),
+          fill: serie.color,
+          rx: 8,
+          ry: 8,
+          opacity: '0.92',
+        });
+        group.appendChild(rect);
+
+        const label = createSvgElement('text', {
+          x: x + barWidth / 2,
+          y: y - 6,
+          fill: syopColors.text,
+          'font-size': '12',
+          'text-anchor': 'middle',
+        });
+        label.textContent = formatPercent(value);
+        group.appendChild(label);
+
+        if (syopChartState.stacked) {
+          stackedOffset += barHeight;
+        }
+      });
+
+      const axisLabel = createSvgElement('text', {
+        x: usableWidth / 2,
+        y: chartHeight + 28,
+        fill: syopColors.subtext,
+        'font-size': '13',
+        'text-anchor': 'middle',
+      });
+      axisLabel.textContent = `SYOP ${row.SYOP}`;
+      group.appendChild(axisLabel);
+
+      axisGroup.appendChild(group);
+    });
+
+    container.appendChild(svg);
+  }
+
+  function buildChartControls() {
+    const controlsContainer = document.getElementById('syop-chart-controls');
+    if (!controlsContainer) return;
+    controlsContainer.innerHTML = '';
+
+    const label = document.createElement('span');
+    label.className = 'syop-control-label';
+    label.textContent = 'Filter:';
+    controlsContainer.appendChild(label);
+
+    seriesOrder.forEach((serie) => {
+      const control = document.createElement('label');
+      control.className = 'syop-toggle';
+      control.style.setProperty('--syop-swatch', serie.color);
+
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.checked = syopChartState.filters[serie.key];
+      input.setAttribute('data-series', serie.key);
+      input.addEventListener('change', () => {
+        syopChartState.filters[serie.key] = input.checked;
+        renderColumnChart();
+      });
+
+      const switchVisual = document.createElement('span');
+      switchVisual.className = 'syop-toggle-indicator';
+
+      const text = document.createElement('span');
+      text.className = 'syop-toggle-text';
+      text.textContent = serie.label;
+
+      control.appendChild(input);
+      control.appendChild(switchVisual);
+      control.appendChild(text);
+      controlsContainer.appendChild(control);
+    });
+
+    const stackedLabel = document.createElement('label');
+    stackedLabel.className = 'syop-toggle syop-toggle-stack';
+    stackedLabel.style.setProperty('--syop-swatch', syopColors.muted);
+
+    const stackedInput = document.createElement('input');
+    stackedInput.type = 'checkbox';
+    stackedInput.checked = syopChartState.stacked;
+    stackedInput.addEventListener('change', () => {
+      syopChartState.stacked = stackedInput.checked;
+      renderColumnChart();
+    });
+
+    const stackedSwitch = document.createElement('span');
+    stackedSwitch.className = 'syop-toggle-indicator';
+
+    const stackedText = document.createElement('span');
+    stackedText.className = 'syop-toggle-text';
+    stackedText.textContent = 'Stacked';
+
+    stackedLabel.appendChild(stackedInput);
+    stackedLabel.appendChild(stackedSwitch);
+    stackedLabel.appendChild(stackedText);
+    controlsContainer.appendChild(stackedLabel);
+  }
+
+  function renderGauges() {
+    const container = document.getElementById('syop-gauges');
+    if (!container) return;
+    container.innerHTML = '';
+
+    GAUGES.forEach((gauge) => {
+      const gaugeCard = document.createElement('div');
+      gaugeCard.className = 'syop-gauge-card';
+
+      const svg = createSvgElement('svg', {
+        viewBox: '0 0 320 180',
+        role: 'img',
+        'aria-label': `${gauge.key} gauge showing ${gauge.value.toFixed(2)} years`,
+      });
+
+      const min = 2;
+      const max = 8;
+      const start = -Math.PI;
+      const end = 0;
+      const cx = 160;
+      const cy = 170;
+      const radius = 130;
+      const trackWidth = 16;
+
+      const track = createSvgElement('path', {
+        d: describeArc(cx, cy, radius, start, end),
+        stroke: '#1f2437',
+        'stroke-width': trackWidth,
+        fill: 'none',
+        'stroke-linecap': 'round',
+      });
+      svg.appendChild(track);
+
+      const clampValue = Math.max(min, Math.min(max, gauge.value));
+      const valueAngle = start + ((clampValue - min) / (max - min)) * (end - start);
+      const valuePath = createSvgElement('path', {
+        d: describeArc(cx, cy, radius, start, valueAngle),
+        stroke: gauge.color,
+        'stroke-width': trackWidth,
+        fill: 'none',
+        'stroke-linecap': 'round',
+      });
+      svg.appendChild(valuePath);
+
+      const ticks = [2, 3.5, 5, 6.5, 8];
+      ticks.forEach((tick) => {
+        const angle = start + ((tick - min) / (max - min)) * (end - start);
+        const inner = polar(cx, cy, radius - trackWidth / 2 - 4, angle);
+        const outer = polar(cx, cy, radius + trackWidth / 2 + 8, angle);
+        const tickLine = createSvgElement('line', {
+          x1: inner.x,
+          y1: inner.y,
+          x2: outer.x,
+          y2: outer.y,
+          stroke: 'rgba(255,255,255,0.7)',
+          'stroke-width': '1.5',
+        });
+        svg.appendChild(tickLine);
+
+        const tickLabel = createSvgElement('text', {
+          x: outer.x,
+          y: outer.y - 6,
+          fill: syopColors.subtext,
+          'font-size': '12',
+          'text-anchor': 'middle',
+        });
+        tickLabel.textContent = tick;
+        svg.appendChild(tickLabel);
+      });
+
+      gaugeCard.appendChild(svg);
+
+      const caption = document.createElement('div');
+      caption.className = 'syop-gauge-caption';
+      caption.innerHTML = `<span>${gauge.key}</span><strong style="color:${gauge.color}">${gauge.value.toFixed(2)}</strong>`;
+      gaugeCard.appendChild(caption);
+
+      container.appendChild(gaugeCard);
+    });
+  }
+
+  function describeArc(cx, cy, radius, startAngle, endAngle) {
+    const startPoint = polar(cx, cy, radius, startAngle);
+    const endPoint = polar(cx, cy, radius, endAngle);
+    const largeArc = endAngle - startAngle > Math.PI ? 1 : 0;
+    return `M ${startPoint.x} ${startPoint.y} A ${radius} ${radius} 0 ${largeArc} 1 ${endPoint.x} ${endPoint.y}`;
+  }
+
+  function renderHighlights() {
+    const list = document.getElementById('syop-highlights');
+    if (!list) return;
+    list.innerHTML = '';
+
+    const peaks = {};
+    seriesOrder.forEach((serie) => {
+      let best = { syop: SYOP_DATA[0].SYOP, value: SYOP_DATA[0][serie.key] };
+      SYOP_DATA.forEach((row) => {
+        if (row[serie.key] > best.value) {
+          best = { syop: row.SYOP, value: row[serie.key] };
+        }
+      });
+      peaks[serie.key] = best;
+    });
+
+    const items = [
+      {
+        label: 'QB',
+        color: syopColors.qb,
+        text: `peaks at <strong>${peaks['QB %'].value.toFixed(2)}%</strong> in SYOP <strong>${peaks['QB %'].syop}</strong>.`,
+      },
+      {
+        label: 'RB',
+        color: syopColors.rb,
+        text: `concentrates early: <strong>${peaks['RB %'].value.toFixed(2)}%</strong> in SYOP <strong>${peaks['RB %'].syop}</strong>.`,
+      },
+      {
+        label: 'WR',
+        color: syopColors.wr,
+        text: `shows a dual hump (SYOP 3–7) with a top bin at <strong>${peaks['WR %'].value.toFixed(2)}%</strong>.`,
+      },
+      {
+        label: 'TE',
+        color: syopColors.te,
+        text: `retains steady value and residuals even at <strong>12+</strong> years.`,
+      },
+    ];
+
+    items.forEach((item) => {
+      const li = document.createElement('li');
+      li.innerHTML = `<span style="color:${item.color}" class="syop-highlight-label">${item.label}</span> ${item.text}`;
+      list.appendChild(li);
+    });
+  }
+
+  function renderQaChecks() {
+    const list = document.getElementById('syop-qa');
+    if (!list) return;
+    list.innerHTML = '';
+
+    const tests = [];
+    const gaugeKeys = GAUGES.map((g) => g.key).sort().join(',');
+    const required = ['QB', 'RB', 'WR', 'TE'].sort().join(',');
+    tests.push({ name: 'Gauge keys present', pass: gaugeKeys === required });
+    tests.push({ name: 'Gauge values between 2 and 8', pass: GAUGES.every((g) => typeof g.value === 'number' && g.value >= 2 && g.value <= 8) });
+    tests.push({
+      name: 'SYOP rows cover all series',
+      pass: SYOP_DATA.every((row) => seriesOrder.every((serie) => typeof row[serie.key] === 'number')),
+    });
+    const arraysAligned = SUNBURST.labels.length === SUNBURST.parents.length && SUNBURST.parents.length === SUNBURST.values.length;
+    tests.push({ name: 'Sunburst arrays aligned', pass: arraysAligned });
+    const labelSplit = splitLabelValue('SPΛ (7.2)');
+    tests.push({ name: 'Sunburst label/value split', pass: labelSplit.main === 'SPΛ' && labelSplit.paren === '7.2' });
+    tests.push({ name: 'Sunburst center uses Λ and M', pass: SUNBURST.labels[0].includes('Λ') && SUNBURST.labels[0].includes('M') });
+    tests.push({ name: 'Arc path returns SVG path', pass: /^M\s/.test(arcPath(0, 0, 10, 20, 0, Math.PI / 2)) });
+    tests.push({ name: 'Series parser recognises prefixes', pass: seriesFromLabel('WR sample') === 'WR' });
+
+    tests.forEach((test) => {
+      const li = document.createElement('li');
+      li.className = test.pass ? 'syop-qa-pass' : 'syop-qa-fail';
+      li.textContent = `${test.name}: ${test.pass ? 'PASS' : 'FAIL'}`;
+      list.appendChild(li);
+    });
+  }
+
+  function renderDraftOverall() {
+    const container = document.getElementById('syop-draft-overall');
+    if (!container) return;
+    container.innerHTML = '';
+
+    const width = 820;
+    const height = 320;
+    const margin = { top: 24, right: 24, bottom: 48, left: 72 };
+    const chartWidth = width - margin.left - margin.right;
+    const chartHeight = height - margin.top - margin.bottom;
+
+    const svg = createSvgElement('svg', {
+      viewBox: `0 0 ${width} ${height}`,
+      role: 'img',
+      'aria-label': 'Overall draft hit probability by round',
+    });
+
+    const gridGroup = createSvgElement('g', { transform: `translate(${margin.left}, ${margin.top})` });
+    svg.appendChild(gridGroup);
+
+    const ticks = [0, 20, 40, 60, 80, 100];
+    ticks.forEach((tick) => {
+      const y = chartHeight - (tick / 100) * chartHeight;
+      const gridLine = createSvgElement('line', {
+        x1: 0,
+        y1: y,
+        x2: chartWidth,
+        y2: y,
+        stroke: draftColors.grid,
+      });
+      gridGroup.appendChild(gridLine);
+
+      const label = createSvgElement('text', {
+        x: -16,
+        y: y + 4,
+        fill: draftColors.text,
+        'font-size': '12',
+        'text-anchor': 'end',
+      });
+      label.textContent = `${tick}%`;
+      gridGroup.appendChild(label);
+    });
+
+    const groupWidth = chartWidth / DRAFT_OVERALL.length;
+    const barWidth = groupWidth * 0.55;
+
+    DRAFT_OVERALL.forEach((row, index) => {
+      const value = row.hit;
+      const barHeight = (value / 100) * chartHeight;
+      const x = index * groupWidth + (groupWidth - barWidth) / 2;
+      const y = chartHeight - barHeight;
+
+      const bar = createSvgElement('rect', {
+        x,
+        y,
+        width: barWidth,
+        height: Math.max(barHeight, 1),
+        fill: 'url(#overallGradient)',
+        rx: 10,
+      });
+      gridGroup.appendChild(bar);
+
+      const label = createSvgElement('text', {
+        x: x + barWidth / 2,
+        y: y - 6,
+        fill: '#F1F5F9',
+        'font-size': '13',
+        'text-anchor': 'middle',
+      });
+      label.textContent = `${value.toFixed(1)}%`;
+      gridGroup.appendChild(label);
+
+      const axisLabel = createSvgElement('text', {
+        x: x + barWidth / 2,
+        y: chartHeight + 28,
+        fill: draftColors.text,
+        'font-size': '13',
+        'text-anchor': 'middle',
+      });
+      axisLabel.textContent = `RD ${row.round}`;
+      gridGroup.appendChild(axisLabel);
+    });
+
+    const defs = createSvgElement('defs');
+    const gradient = createSvgElement('linearGradient', {
+      id: 'overallGradient',
+      x1: '0',
+      y1: '0',
+      x2: '0',
+      y2: '1',
+    });
+    gradient.appendChild(createSvgElement('stop', { offset: '0%', 'stop-color': '#46E7FF' }));
+    gradient.appendChild(createSvgElement('stop', { offset: '100%', 'stop-color': '#FF41E1' }));
+    defs.appendChild(gradient);
+    svg.insertBefore(defs, svg.firstChild);
+
+    container.appendChild(svg);
+
+    const table = document.getElementById('syop-draft-table');
+    if (table) {
+      table.innerHTML = '';
+      DRAFT_OVERALL.forEach((row) => {
+        const tile = document.createElement('div');
+        tile.className = 'syop-draft-tile';
+        tile.innerHTML = `<span class="syop-draft-round">${row.round}</span><span class="syop-draft-value">${row.hit.toFixed(1)}%</span>`;
+        table.appendChild(tile);
+      });
+    }
+  }
+
+  function renderDraftLegend() {
+    const legend = document.getElementById('syop-draft-legend');
+    if (!legend) return;
+    legend.innerHTML = '';
+    ['QB', 'RB', 'TE', 'WR'].forEach((key) => {
+      const item = document.createElement('li');
+      item.innerHTML = `<span class="syop-legend-dot" style="background:${draftColors[key]}"></span>${key}`;
+      legend.appendChild(item);
+    });
+  }
+
+  function renderDraftPositional() {
+    const container = document.getElementById('syop-draft-pos');
+    if (!container) return;
+    container.innerHTML = '';
+
+    const width = 860;
+    const height = 360;
+    const margin = { top: 32, right: 32, bottom: 48, left: 72 };
+    const chartWidth = width - margin.left - margin.right;
+    const chartHeight = height - margin.top - margin.bottom;
+
+    const svg = createSvgElement('svg', {
+      viewBox: `0 0 ${width} ${height}`,
+      role: 'img',
+      'aria-label': 'Line chart showing positional hit rates by round',
+    });
+
+    const gridGroup = createSvgElement('g', { transform: `translate(${margin.left}, ${margin.top})` });
+    svg.appendChild(gridGroup);
+
+    const ticks = [0, 20, 40, 60, 80, 100];
+    ticks.forEach((tick) => {
+      const y = chartHeight - (tick / 100) * chartHeight;
+      const gridLine = createSvgElement('line', {
+        x1: 0,
+        y1: y,
+        x2: chartWidth,
+        y2: y,
+        stroke: draftColors.grid,
+      });
+      gridGroup.appendChild(gridLine);
+
+      const label = createSvgElement('text', {
+        x: -16,
+        y: y + 4,
+        fill: draftColors.text,
+        'font-size': '12',
+        'text-anchor': 'end',
+      });
+      label.textContent = `${tick}%`;
+      gridGroup.appendChild(label);
+    });
+
+    const xStep = chartWidth / (DRAFT_POSITIONAL.length - 1);
+
+    ['QB', 'RB', 'TE', 'WR'].forEach((key) => {
+      const pathPoints = DRAFT_POSITIONAL.map((row, index) => {
+        const x = index * xStep;
+        const y = chartHeight - (row[key] / 100) * chartHeight;
+        return `${index === 0 ? 'M' : 'L'} ${x} ${y}`;
+      }).join(' ');
+      const path = createSvgElement('path', {
+        d: pathPoints,
+        fill: 'none',
+        stroke: draftColors[key],
+        'stroke-width': '4',
+        'stroke-linejoin': 'round',
+        'stroke-linecap': 'round',
+      });
+      gridGroup.appendChild(path);
+
+      DRAFT_POSITIONAL.forEach((row, index) => {
+        const x = index * xStep;
+        const y = chartHeight - (row[key] / 100) * chartHeight;
+        const circle = createSvgElement('circle', {
+          cx: x,
+          cy: y,
+          r: 5,
+          fill: draftColors[key],
+          stroke: '#0A0F1E',
+          'stroke-width': '2',
+        });
+        gridGroup.appendChild(circle);
+      });
+    });
+
+    DRAFT_POSITIONAL.forEach((row, index) => {
+      const x = index * xStep;
+      const label = createSvgElement('text', {
+        x,
+        y: chartHeight + 28,
+        fill: draftColors.text,
+        'font-size': '13',
+        'text-anchor': 'middle',
+      });
+      label.textContent = `RD ${row.round}`;
+      gridGroup.appendChild(label);
+    });
+
+    container.appendChild(svg);
+  }
+
+  function init() {
+    renderSunburst();
+    buildChartControls();
+    renderColumnChart();
+    renderGauges();
+    renderHighlights();
+    renderQaChecks();
+    renderDraftOverall();
+    renderDraftLegend();
+    renderDraftPositional();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/DH_P3-5.21Gb/styles/styles.css
+++ b/DH_P3-5.21Gb/styles/styles.css
@@ -4097,3 +4097,409 @@ img.team-logo.glow[alt="WAS"] {
 
 
 
+
+/* === SYOP PAGE === */
+.syop-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  padding-bottom: 4rem;
+}
+
+.syop-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.syop-hero {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.8rem;
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(72, 59, 129, 0.55), rgba(22, 30, 54, 0.7));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.syop-hero-text {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.syop-hero-secondary {
+  background: linear-gradient(135deg, rgba(19, 32, 56, 0.75), rgba(38, 55, 91, 0.55));
+}
+
+.syop-hero-text h1,
+.syop-hero-text h2 {
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.syop-hero-subtitle {
+  margin: 0;
+  color: rgba(233, 236, 249, 0.75);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  max-width: 52ch;
+}
+
+.syop-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.68rem;
+  font-weight: 700;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(14, 15, 30, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: rgba(233, 236, 249, 0.85);
+}
+
+.syop-hero-glow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 90% 20%, rgba(70, 231, 255, 0.4), transparent 55%),
+    radial-gradient(circle at 10% 80%, rgba(255, 65, 225, 0.25), transparent 60%);
+  opacity: 0.9;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.syop-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.syop-grid-top {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.syop-grid-bottom {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.syop-gauge-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.syop-panel {
+  position: relative;
+  border-radius: 24px;
+  padding: 1.5rem;
+  background: rgba(16, 19, 34, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.syop-panel-wide {
+  grid-column: span 1;
+}
+
+.syop-panel-compact {
+  padding: 1.25rem 1.35rem;
+}
+
+.syop-panel-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+.syop-panel-header h2,
+.syop-panel-header h3 {
+  margin: 0;
+  font-size: clamp(1.1rem, 2vw, 1.6rem);
+  font-weight: 600;
+}
+
+.syop-panel-header p {
+  margin: 0;
+  color: rgba(233, 236, 249, 0.65);
+  font-size: 0.85rem;
+}
+
+.syop-chart {
+  min-height: 18rem;
+}
+
+.syop-chart svg,
+.syop-sunburst svg {
+  width: 100%;
+  height: auto;
+}
+
+.syop-chart-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.syop-control-label {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(233, 236, 249, 0.7);
+  margin-right: 0.2rem;
+}
+
+.syop-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(16, 24, 44, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: rgba(233, 236, 249, 0.85);
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.syop-toggle:hover {
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.syop-toggle input {
+  display: none;
+}
+
+.syop-toggle-indicator {
+  position: relative;
+  width: 32px;
+  height: 18px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.15);
+  flex-shrink: 0;
+}
+
+.syop-toggle-indicator::before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--syop-swatch, rgba(255, 255, 255, 0.85));
+  transition: transform 0.2s ease;
+}
+
+.syop-toggle input:not(:checked) + .syop-toggle-indicator::before {
+  transform: translateX(0);
+  background: rgba(233, 236, 249, 0.45);
+}
+
+.syop-toggle input:checked + .syop-toggle-indicator::before {
+  transform: translateX(14px);
+}
+
+.syop-toggle-text {
+  letter-spacing: 0.02em;
+}
+
+.syop-empty {
+  margin: 2rem 0;
+  text-align: center;
+  color: rgba(233, 236, 249, 0.65);
+  font-size: 0.95rem;
+}
+
+.syop-gauges {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.syop-gauge-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.syop-gauge-caption {
+  text-align: center;
+  font-size: 0.9rem;
+  color: rgba(233, 236, 249, 0.8);
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.syop-gauge-caption span {
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.68rem;
+  color: rgba(233, 236, 249, 0.6);
+}
+
+.syop-highlights {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: rgba(233, 236, 249, 0.75);
+}
+
+.syop-highlight-label {
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  margin-right: 0.35rem;
+}
+
+.syop-qa-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.syop-qa-pass,
+.syop-qa-fail {
+  padding: 0.65rem 0.8rem;
+  border-radius: 14px;
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+}
+
+.syop-qa-pass {
+  background: rgba(16, 78, 56, 0.4);
+  color: rgba(189, 247, 208, 0.9);
+}
+
+.syop-qa-fail {
+  background: rgba(94, 23, 49, 0.5);
+  color: rgba(255, 190, 214, 0.9);
+}
+
+.syop-draft-grid {
+  margin-top: 1.2rem;
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+}
+
+.syop-draft-tile {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 16px;
+  background: rgba(16, 24, 44, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+}
+
+.syop-draft-round {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 12px;
+  background: rgba(10, 15, 30, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  font-weight: 600;
+}
+
+.syop-draft-value {
+  font-weight: 600;
+  color: rgba(233, 236, 249, 0.9);
+}
+
+.syop-draft-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 0.85rem;
+  color: rgba(233, 236, 249, 0.8);
+}
+
+.syop-legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+  margin-right: 0.35rem;
+}
+
+.syop-footnote {
+  margin-top: 1rem;
+  font-size: 0.78rem;
+  color: rgba(233, 236, 249, 0.55);
+}
+
+.syop-pill {
+  align-self: center;
+  margin-top: 1rem;
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(70, 231, 255, 0.25), rgba(255, 65, 225, 0.28), rgba(158, 90, 247, 0.25));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  font-size: 0.78rem;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: rgba(233, 236, 249, 0.85);
+}
+
+@media (min-width: 768px) {
+  .syop-hero {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .syop-grid-top {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 1.4fr);
+  }
+
+  .syop-grid-bottom {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.3fr);
+  }
+
+  .syop-panel-header {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 640px) {
+  .syop-panel {
+    padding: 1.1rem;
+  }
+
+  .syop-chart-controls {
+    justify-content: flex-start;
+  }
+
+  .syop-toggle {
+    padding: 0.3rem 0.5rem;
+  }
+}

--- a/DH_P3-5.21Gb/syop/syop.html
+++ b/DH_P3-5.21Gb/syop/syop.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SYOP Insights • Dynasty Hub</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@200;300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Product+Sans:wght@100;200;300;400;500;700;900&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css?family=Google+Sans:100,200,300,400,500,600,700" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="manifest" href="../manifest.webmanifest?v=20250827002411?v=20250826235225" />
+  <link rel="apple-touch-icon" sizes="180x180" href="../assets/icons/apple-touch-icon-180.png?v=20250827002411?v=20250826235225" />
+  <meta name="theme-color" content="#0D0E1B" />
+  <link rel="icon" type="image/png" sizes="32x32" href="../assets/icons/favicon-32.png?v=20250827002411?v=20250826235225" />
+  <link rel="icon" type="image/png" sizes="16x16" href="../assets/icons/favicon-16.png?v=20250827002411?v=20250826235225" />
+  <link rel="shortcut icon" href="../assets/icons/favicon.ico?v=20250827002411?v=20250826235225" />
+  <link rel="stylesheet" href="../styles/styles.css?v=20250827002411?v=20250826235225" />
+</head>
+<body data-page="syop" class="p-2 sm:p-4">
+  <div aria-hidden="true" id="starfield">
+    <div id="stars"></div>
+    <div id="stars1"></div>
+    <div id="stars2"></div>
+    <div id="stars3"></div>
+  </div>
+  <div id="noise-overlay"></div>
+  <div class="relative z-10 content-wrapper">
+    <div id="header-container">
+      <header class="app-header glass-panel">
+        <div class="header-row">
+          <div class="menu-container">
+            <button id="menu-button" class="menu-button" aria-label="Open navigation menu">
+              <svg viewBox="0 0 100 80" width="20" height="20" aria-hidden="true">
+                <rect width="100" height="15"></rect>
+                <rect y="30" width="100" height="15"></rect>
+                <rect y="60" width="100" height="15"></rect>
+              </svg>
+            </button>
+            <nav id="dropdown-menu" class="dropdown-menu hidden" aria-label="Primary">
+              <a href="../index.html">Home</a>
+              <a href="#" id="menu-rosters">Rosters</a>
+              <a href="#" id="menu-ownership">Ownership</a>
+              <a href="#" id="menu-analyzer">League Analyzer</a>
+              <a href="#" id="menu-syop">SYOP</a>
+            </nav>
+          </div>
+          <div class="username-area">
+            <input id="usernameInput" name="username" type="text" placeholder="SLPR Username..." autocomplete="username" autocapitalize="none" autocorrect="off" inputmode="text" />
+          </div>
+          <div class="app-view-switcher primary-switcher">
+            <button id="fetchRostersButton">Rosters</button>
+            <button id="fetchOwnershipButton">Ownership %</button>
+          </div>
+        </div>
+      </header>
+    </div>
+
+    <main id="content" class="container mx-auto syop-page">
+      <section class="syop-section" aria-labelledby="syop-hero-title">
+        <div class="syop-hero">
+          <div class="syop-hero-text">
+            <p class="syop-badge">Significant Years of Production</p>
+            <h1 id="syop-hero-title">Career Length Analytics</h1>
+            <p class="syop-hero-subtitle">
+              Mean (Λ) and Mode (M) views of positional longevity, charted alongside distribution, gauges, and highlights.
+            </p>
+          </div>
+          <div class="syop-hero-glow" aria-hidden="true"></div>
+        </div>
+
+        <div class="syop-grid syop-grid-top">
+          <article class="glass-panel syop-panel" aria-labelledby="syop-sunburst-title">
+            <header class="syop-panel-header">
+              <h2 id="syop-sunburst-title">AVG [Mean | Λ] · Majority [Mode | M]</h2>
+              <p>Per-position distribution captured in a custom sunburst.</p>
+            </header>
+            <div id="syop-sunburst" class="syop-sunburst" role="img" aria-label="Sunburst showing SYOP share by position"></div>
+          </article>
+
+          <article class="glass-panel syop-panel syop-panel-wide" aria-labelledby="syop-chart-title">
+            <header class="syop-panel-header">
+              <div>
+                <h2 id="syop-chart-title">Positional | Significant Years of Production</h2>
+                <p>% of each position within the SYOP bins.</p>
+              </div>
+              <div class="syop-chart-controls" id="syop-chart-controls"></div>
+            </header>
+            <div class="syop-chart" id="syop-chart" aria-live="polite"></div>
+          </article>
+        </div>
+
+        <div class="syop-grid syop-gauge-grid">
+          <article class="glass-panel syop-panel syop-panel-compact" aria-labelledby="syop-gauges-title">
+            <header class="syop-panel-header">
+              <h2 id="syop-gauges-title">SYOP Gauge Readings</h2>
+              <p>Interpolated between two and eight years.</p>
+            </header>
+            <div id="syop-gauges" class="syop-gauges"></div>
+          </article>
+          <article class="glass-panel syop-panel syop-panel-compact" aria-labelledby="syop-highlights-title">
+            <header class="syop-panel-header">
+              <h2 id="syop-highlights-title">Highlights</h2>
+              <p>Quick takeaways from the distribution.</p>
+            </header>
+            <ul id="syop-highlights" class="syop-highlights"></ul>
+          </article>
+          <article class="glass-panel syop-panel syop-panel-compact" aria-labelledby="syop-qa-title">
+            <header class="syop-panel-header">
+              <h2 id="syop-qa-title">QA Checks</h2>
+              <p>Inline validation of the data feeding each viz.</p>
+            </header>
+            <ul id="syop-qa" class="syop-qa-list"></ul>
+          </article>
+        </div>
+      </section>
+
+      <section class="syop-section" aria-labelledby="syop-draft-title">
+        <div class="syop-hero syop-hero-secondary">
+          <div class="syop-hero-text">
+            <p class="syop-badge">NFL Draft · Hit Rates 2008-2020</p>
+            <h2 id="syop-draft-title">Hit Rate by Round</h2>
+            <p class="syop-hero-subtitle">Overall probability and positional trends for drafted players.</p>
+          </div>
+        </div>
+        <div class="syop-grid syop-grid-bottom">
+          <article class="glass-panel syop-panel" aria-labelledby="syop-draft-overall-title">
+            <header class="syop-panel-header">
+              <h3 id="syop-draft-overall-title">Overall Hit Probability</h3>
+              <p>All positions combined · tabular recap below the chart.</p>
+            </header>
+            <div class="syop-chart" id="syop-draft-overall"></div>
+            <div class="syop-draft-grid" id="syop-draft-table"></div>
+          </article>
+          <article class="glass-panel syop-panel syop-panel-wide" aria-labelledby="syop-draft-pos-title">
+            <header class="syop-panel-header">
+              <div>
+                <h3 id="syop-draft-pos-title">Positional Hit Rate Trends</h3>
+                <p>Round-by-round comparison for QB, RB, TE, and WR.</p>
+              </div>
+              <ul class="syop-draft-legend" id="syop-draft-legend"></ul>
+            </header>
+            <div class="syop-chart" id="syop-draft-pos"></div>
+            <p class="syop-footnote">*Values reflect exact percentages from the provided data set.</p>
+          </article>
+        </div>
+        <div class="syop-pill">Hit Rate · All Positions &amp; By Position</div>
+      </section>
+    </main>
+  </div>
+  <script defer src="../scripts/app.js?v=20250826235225"></script>
+  <script defer src="../scripts/syop.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build a dedicated `syop/syop.html` page that mirrors the app shell and hosts SYOP and NFL Draft visual sections
- port the infographic and draft charts into vanilla SVG/JS via the new `scripts/syop.js` module and responsive `styles.css` additions
- wire the hamburger menu to the new page across all app entry points

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ce50ecbf90832e9fecd2f495a6e6c8