### PR TITLE
Add SYOP analytics page

### DIFF
--- a/DH_P3-5.21Gb/analyzer/analyzer.html
+++ b/DH_P3-5.21Gb/analyzer/analyzer.html
@@ -151,8 +151,8 @@
                             <a href="../">Home</a>
                             <a href="#" id="menu-rosters">Rosters</a>
                             <a href="#" id="menu-ownership">Ownership</a>
-                            <a href="#" id="menu-analyzer">League Analyzer</a>
-                            <a href="#">Placeholder</a>
+        <a href="#" id="menu-analyzer">League Analyzer</a>
+        <a href="#" id="menu-syop">SYOP</a>
                         </div>
                     </div>
                     <div class="username-area">

--- a/DH_P3-5.21Gb/index.html
+++ b/DH_P3-5.21Gb/index.html
@@ -44,7 +44,7 @@
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
         <a href="#" id="menu-analyzer">League Analyzer</a>
-        <a href="#">Coming Soon..</a>
+        <a href="#" id="menu-syop">SYOP</a>
     </div>
 </div>
 <div class="username-area">

--- a/DH_P3-5.21Gb/ownership/ownership.html
+++ b/DH_P3-5.21Gb/ownership/ownership.html
@@ -41,7 +41,7 @@
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
         <a href="#" id="menu-analyzer">League Analyzer</a>
-        <a href="#">Placeholder</a>
+        <a href="#" id="menu-syop">SYOP</a>
     </div>
 </div>
 <div class="username-area">

--- a/DH_P3-5.21Gb/rosters/rosters.html
+++ b/DH_P3-5.21Gb/rosters/rosters.html
@@ -43,7 +43,7 @@
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
         <a href="#" id="menu-analyzer">League Analyzer</a>
-        <a href="#">Placeholder</a>
+        <a href="#" id="menu-syop">SYOP</a>
     </div>
 </div>
 <div class="username-area">

--- a/DH_P3-5.21Gb/scripts/app.js
+++ b/DH_P3-5.21Gb/scripts/app.js
@@ -50,6 +50,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const menuRosters = document.getElementById('menu-rosters');
         const menuOwnership = document.getElementById('menu-ownership');
         const menuAnalyzer = document.getElementById('menu-analyzer');
+        const menuSyop = document.getElementById('menu-syop');
         const analyzeLeagueButton = document.getElementById('analyzeLeagueButton');
 
         menuButton?.addEventListener('click', (e) => {
@@ -123,6 +124,20 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             dropdownMenu.classList.add('hidden');
         });
 
+        menuSyop?.addEventListener('click', () => {
+            if (pageType === 'syop') {
+                dropdownMenu.classList.add('hidden');
+                return;
+            }
+            const username = usernameInput.value.trim();
+            let url = pageType === 'welcome' ? 'syop/syop.html' : '../syop/syop.html';
+            if (username) {
+                url += `?username=${encodeURIComponent(username)}`;
+            }
+            window.location.href = url;
+            dropdownMenu.classList.add('hidden');
+        });
+
         // --- State ---
         let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), tradeBlock: {}, isTradeCollapsed: false, weeklyStats: {}, playerSeasonStats: {}, playerSeasonRanks: {}, playerWeeklyStats: {}, statsSheetsLoaded: false, seasonRankCache: null, isGameLogModalOpenFromComparison: false };
         const assignedLeagueColors = new Map();
@@ -160,6 +175,17 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 const username = usernameInput.value.trim();
                 if (!username) return;
                 window.location.href = `ownership/ownership.html?username=${encodeURIComponent(username)}`;
+            });
+        } else if (pageType === 'syop') {
+            fetchRostersButton?.addEventListener('click', () => {
+                const username = usernameInput.value.trim();
+                if (!username) return;
+                window.location.href = `../rosters/rosters.html?username=${encodeURIComponent(username)}`;
+            });
+            fetchOwnershipButton?.addEventListener('click', () => {
+                const username = usernameInput.value.trim();
+                if (!username) return;
+                window.location.href = `../ownership/ownership.html?username=${encodeURIComponent(username)}`;
             });
         } else if (pageType === 'rosters') {
             fetchRostersButton?.addEventListener('click', handleFetchRosters);

--- a/DH_P3-5.21Gb/scripts/syop.js
+++ b/DH_P3-5.21Gb/scripts/syop.js
@@ -1,0 +1,770 @@
+const SYOP_COLORS = {
+  bg: '#0B0E16',
+  panel: 'rgba(26, 29, 44, 0.55)',
+  panelBorder: 'rgba(255,255,255,0.08)',
+  text: '#E9ECF9',
+  subtext: '#B6B9D6',
+  qb: '#A855F7',
+  rb: '#EC4899',
+  wr: '#22D3EE',
+  te: '#F472B6',
+  muted: '#334155',
+};
+
+const SUNBURST_ROOT_LABEL = 'Mean | Λ <br>&<br> Mode | M';
+const SUNBURST_DATA = {
+  labels: [
+    SUNBURST_ROOT_LABEL,
+    'QB ',
+    'RB ',
+    'WR ',
+    'TE ',
+    'SPΛ <br>(7.2)',
+    'BOΛ <br>(2.3)',
+    'SPM <br>(6)',
+    'BOM <br>(1)',
+    'SPΛ <br>(3.41)',
+    'BOΛ <br>(2.2)',
+    'SPM <br>(0.7)',
+    'BOM <br>(1.7)',
+    'SPΛ <br>(4.9)',
+    'BOΛ <br>(2.9)',
+    'SPM <br>(3)',
+    'BOM <br>(2)',
+    'SPΛ <br>(4.0)',
+    'BOΛ <br>(3.5)',
+    'SPM <br>(2)',
+    'BOM <br>(3)',
+  ],
+  parents: [
+    '',
+    SUNBURST_ROOT_LABEL,
+    SUNBURST_ROOT_LABEL,
+    SUNBURST_ROOT_LABEL,
+    SUNBURST_ROOT_LABEL,
+    'QB ',
+    'QB ',
+    'QB ',
+    'QB ',
+    'RB ',
+    'RB ',
+    'RB ',
+    'RB ',
+    'WR ',
+    'WR ',
+    'WR ',
+    'WR ',
+    'TE ',
+    'TE ',
+    'TE ',
+    'TE ',
+  ],
+  values: [
+    51.6, 16.46, 9.8, 12.82, 12.5, 6.5, 2.49, 5.35, 2.1, 3.31, 2.5, 1.89, 2.1, 4.92, 2.84, 3, 2, 4.01, 3.49, 2, 3,
+  ],
+};
+
+const SYOP_SERIES = [
+  { key: 'QB %', color: SYOP_COLORS.qb },
+  { key: 'RB %', color: SYOP_COLORS.rb },
+  { key: 'WR %', color: SYOP_COLORS.wr },
+  { key: 'TE %', color: SYOP_COLORS.te },
+];
+
+const SYOP_DATA = [
+  { SYOP: '1', 'QB %': 6.67, 'RB %': 27.54, 'WR %': 13.0, 'TE %': 26.92 },
+  { SYOP: '2', 'QB %': 11.11, 'RB %': 20.29, 'WR %': 14.1, 'TE %': 26.92 },
+  { SYOP: '3', 'QB %': 8.89, 'RB %': 11.59, 'WR %': 14.1, 'TE %': 7.69 },
+  { SYOP: '4', 'QB %': 8.89, 'RB %': 11.4, 'WR %': 12.0, 'TE %': 7.69 },
+  { SYOP: '5', 'QB %': 4.44, 'RB %': 13.04, 'WR %': 5.4, 'TE %': 0.4 },
+  { SYOP: '6', 'QB %': 13.33, 'RB %': 5.8, 'WR %': 7.6, 'TE %': 7.69 },
+  { SYOP: '7', 'QB %': 8.89, 'RB %': 1.45, 'WR %': 13.0, 'TE %': 7.69 },
+  { SYOP: '8', 'QB %': 4.44, 'RB %': 2.9, 'WR %': 9.8, 'TE %': 0.4 },
+  { SYOP: '9', 'QB %': 11.11, 'RB %': 3.3, 'WR %': 2.2, 'TE %': 3.85 },
+  { SYOP: '10', 'QB %': 2.22, 'RB %': 1.45, 'WR %': 4.49, 'TE %': 3.51 },
+  { SYOP: '11', 'QB %': 0.4, 'RB %': 1.45, 'WR %': 2.2, 'TE %': 3.85 },
+  { SYOP: '12+', 'QB %': 20.0, 'RB %': 0.4, 'WR %': 2.2, 'TE %': 3.85 },
+];
+
+const GAUGES = [
+  { key: 'TE', value: 4.0, color: SYOP_COLORS.te },
+  { key: 'RB', value: 3.39, color: SYOP_COLORS.rb },
+  { key: 'WR', value: 4.9, color: SYOP_COLORS.wr },
+  { key: 'QB', value: 7.22, color: SYOP_COLORS.qb },
+];
+
+const DRAFT_OVERALL = [
+  { rd: '1', hit: 78.4 },
+  { rd: '2', hit: 47.7 },
+  { rd: '3', hit: 38.5 },
+  { rd: '4', hit: 18.0 },
+  { rd: '5', hit: 15.0 },
+  { rd: '6', hit: 14.1 },
+  { rd: '7', hit: 9.4 },
+];
+
+const DRAFT_POSITIONAL = [
+  { rd: '1', QB: 78, RB: 83, TE: 78, WR: 76 },
+  { rd: '2', QB: 42, RB: 50, TE: 40, WR: 51 },
+  { rd: '3', QB: 31, RB: 62, TE: 36, WR: 30 },
+  { rd: '4', QB: 20, RB: 27, TE: 23, WR: 9 },
+  { rd: '5', QB: 7, RB: 27, TE: 9, WR: 13 },
+  { rd: '6', QB: 11, RB: 18, TE: 8, WR: 15 },
+  { rd: '7', QB: 13, RB: 9, TE: 4, WR: 11 },
+];
+
+function stripTags(str = '') {
+  return str.replace(/<br\s*\/?>(?=\s*)/gi, ' ').replace(/<[^>]*>/g, '').trim();
+}
+
+function splitLabelValue(raw) {
+  const text = stripTags(raw);
+  const match = text.match(/^(.+?)\s*\(([^)]+)\)\s*$/);
+  if (match) {
+    return { label: match[1].trim(), paren: match[2].trim() };
+  }
+  return { label: text, paren: null };
+}
+
+function buildSunburstTree() {
+  const nodes = SUNBURST_DATA.labels.map((label, idx) => ({
+    label,
+    parent: SUNBURST_DATA.parents[idx],
+    value: SUNBURST_DATA.values[idx],
+  }));
+  const root = SUNBURST_DATA.labels[0];
+  const childrenOf = (parent) => nodes.filter((node) => node.parent === parent);
+  const ring1 = childrenOf(root);
+  const byParent = {};
+  ring1.forEach((node) => {
+    byParent[node.label] = childrenOf(node.label);
+  });
+  return { root, ring1, byParent };
+}
+
+function polar(cx, cy, radius, angle) {
+  return {
+    x: cx + radius * Math.cos(angle),
+    y: cy + radius * Math.sin(angle),
+  };
+}
+
+function arcPath(cx, cy, inner, outer, a0, a1) {
+  const p0 = polar(cx, cy, outer, a0);
+  const p1 = polar(cx, cy, outer, a1);
+  const p2 = polar(cx, cy, inner, a1);
+  const p3 = polar(cx, cy, inner, a0);
+  const large = a1 - a0 > Math.PI ? 1 : 0;
+  return `M ${p0.x} ${p0.y} A ${outer} ${outer} 0 ${large} 1 ${p1.x} ${p1.y} L ${p2.x} ${p2.y} A ${inner} ${inner} 0 ${large} 0 ${p3.x} ${p3.y} Z`;
+}
+
+function seriesFromLabel(label = '') {
+  const clean = label.trim();
+  if (clean.startsWith('QB')) return 'QB';
+  if (clean.startsWith('RB')) return 'RB';
+  if (clean.startsWith('WR')) return 'WR';
+  if (clean.startsWith('TE')) return 'TE';
+  return '';
+}
+
+function seriesColor(series) {
+  switch (series) {
+    case 'QB':
+      return SYOP_COLORS.qb;
+    case 'RB':
+      return SYOP_COLORS.rb;
+    case 'WR':
+      return SYOP_COLORS.wr;
+    case 'TE':
+      return SYOP_COLORS.te;
+    default:
+      return '#6b7280';
+  }
+}
+
+function createSvgElement(tag) {
+  return document.createElementNS('http://www.w3.org/2000/svg', tag);
+}
+
+function renderSunburst(container) {
+  if (!container) return;
+  container.innerHTML = '';
+  const { ring1, byParent } = buildSunburstTree();
+  const size = 520;
+  const pad = 64;
+  const cx = size / 2;
+  const cy = size / 2;
+  const inner1 = 96;
+  const outer1 = 172;
+  const inner2 = 184;
+  const outer2 = 268;
+  const start = -Math.PI / 2;
+
+  const svg = createSvgElement('svg');
+  svg.setAttribute('viewBox', `${-pad} ${-pad} ${size + pad * 2} ${size + pad * 2}`);
+  svg.setAttribute('role', 'presentation');
+  svg.classList.add('syop-sunburst-svg');
+
+  const totalRing1 = ring1.reduce((sum, node) => sum + node.value, 0) || 1;
+  let cursor = start;
+  const ring1Segments = ring1.map((node) => {
+    const span = (node.value / totalRing1) * Math.PI * 2;
+    const segment = { node, a0: cursor, a1: cursor + span };
+    cursor += span;
+    return segment;
+  });
+
+  const ring2Segments = [];
+  ring1Segments.forEach((seg) => {
+    const kids = byParent[seg.node.label] || [];
+    const sum = kids.reduce((acc, n) => acc + n.value, 0) || 1;
+    let c = seg.a0;
+    kids.forEach((child) => {
+      const span = (child.value / sum) * (seg.a1 - seg.a0);
+      ring2Segments.push({ child, parentSeg: seg, a0: c, a1: c + span });
+      c += span;
+    });
+  });
+
+  ring1Segments.forEach((seg) => {
+    const path = createSvgElement('path');
+    const series = seriesFromLabel(seg.node.label);
+    path.setAttribute('d', arcPath(cx, cy, inner1, outer1, seg.a0, seg.a1));
+    path.setAttribute('fill', seriesColor(series));
+    path.setAttribute('opacity', '0.9');
+    path.setAttribute('stroke', SYOP_COLORS.bg);
+    path.setAttribute('stroke-width', '1');
+    svg.appendChild(path);
+
+    const text = createSvgElement('text');
+    const mid = (seg.a0 + seg.a1) / 2;
+    const center = polar(cx, cy, (inner1 + outer1) / 2, mid);
+    const { label } = splitLabelValue(seg.node.label);
+    text.setAttribute('x', center.x);
+    text.setAttribute('y', center.y);
+    text.setAttribute('fill', SYOP_COLORS.text);
+    text.setAttribute('font-size', '14');
+    text.setAttribute('font-weight', '800');
+    text.setAttribute('text-anchor', 'middle');
+    text.setAttribute('dominant-baseline', 'middle');
+    text.textContent = label;
+    svg.appendChild(text);
+  });
+
+  ring2Segments.forEach((seg, idx) => {
+    const path = createSvgElement('path');
+    const parentSeries = seriesFromLabel(seg.parentSeg.node.label);
+    path.setAttribute('d', arcPath(cx, cy, inner2, outer2, seg.a0, seg.a1));
+    path.setAttribute('fill', seriesColor(parentSeries));
+    path.setAttribute('opacity', '0.85');
+    path.setAttribute('stroke', SYOP_COLORS.bg);
+    path.setAttribute('stroke-width', '1.25');
+    svg.appendChild(path);
+
+    const text = createSvgElement('text');
+    const mid = (seg.a0 + seg.a1) / 2;
+    const center = polar(cx, cy, (inner2 + outer2) / 2, mid);
+    const { label, paren } = splitLabelValue(seg.child.label);
+    text.setAttribute('x', center.x);
+    text.setAttribute('y', center.y - 4);
+    text.setAttribute('fill', SYOP_COLORS.text);
+    text.setAttribute('text-anchor', 'middle');
+    text.setAttribute('dominant-baseline', 'middle');
+    const mainTspan = createSvgElement('tspan');
+    mainTspan.setAttribute('font-size', '13');
+    mainTspan.setAttribute('font-weight', '800');
+    mainTspan.textContent = label;
+    text.appendChild(mainTspan);
+    if (paren) {
+      const parenTspan = createSvgElement('tspan');
+      parenTspan.setAttribute('x', center.x);
+      parenTspan.setAttribute('dy', '14');
+      parenTspan.setAttribute('font-size', '12');
+      parenTspan.setAttribute('font-weight', '700');
+      parenTspan.setAttribute('fill', SYOP_COLORS.subtext);
+      parenTspan.textContent = `(${paren})`;
+      text.appendChild(parenTspan);
+    }
+    svg.appendChild(text);
+  });
+
+  const centerCircle = createSvgElement('circle');
+  centerCircle.setAttribute('cx', cx);
+  centerCircle.setAttribute('cy', cy);
+  centerCircle.setAttribute('r', '74');
+  centerCircle.setAttribute('fill', '#1E2235');
+  centerCircle.setAttribute('stroke', SYOP_COLORS.bg);
+  svg.appendChild(centerCircle);
+
+  const centerText1 = createSvgElement('text');
+  centerText1.setAttribute('x', cx);
+  centerText1.setAttribute('y', cy - 6);
+  centerText1.setAttribute('fill', SYOP_COLORS.text);
+  centerText1.setAttribute('font-size', '15');
+  centerText1.setAttribute('font-weight', '900');
+  centerText1.setAttribute('text-anchor', 'middle');
+  centerText1.setAttribute('dominant-baseline', 'middle');
+  centerText1.textContent = 'Mean | Λ';
+  svg.appendChild(centerText1);
+
+  const centerText2 = createSvgElement('text');
+  centerText2.setAttribute('x', cx);
+  centerText2.setAttribute('y', cy + 14);
+  centerText2.setAttribute('fill', SYOP_COLORS.text);
+  centerText2.setAttribute('font-size', '15');
+  centerText2.setAttribute('font-weight', '900');
+  centerText2.setAttribute('text-anchor', 'middle');
+  centerText2.setAttribute('dominant-baseline', 'middle');
+  centerText2.textContent = 'Mode | M';
+  svg.appendChild(centerText2);
+
+  container.appendChild(svg);
+}
+
+function createColumnChart(ctx) {
+  const ChartConstructor = window.Chart;
+  if (!ctx || !ChartConstructor) return null;
+  const labels = SYOP_DATA.map((row) => row.SYOP);
+  const datasets = SYOP_SERIES.map((series) => ({
+    label: series.key,
+    data: SYOP_DATA.map((row) => row[series.key]),
+    backgroundColor: series.color,
+    borderRadius: 12,
+    borderSkipped: false,
+    stack: undefined,
+  }));
+
+  return new ChartConstructor(ctx, {
+    type: 'bar',
+    data: { labels, datasets },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        x: {
+          stacked: false,
+          grid: { display: false },
+          ticks: { color: SYOP_COLORS.subtext },
+        },
+        y: {
+          stacked: false,
+          beginAtZero: true,
+          max: 30,
+          grid: { color: 'rgba(255,255,255,0.08)' },
+          ticks: {
+            color: SYOP_COLORS.subtext,
+            callback: (value) => `${value}%`,
+          },
+        },
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            label(context) {
+              const val = Number(context.parsed.y || 0);
+              return `${context.dataset.label}: ${val.toFixed(2)}%`;
+            },
+          },
+          backgroundColor: SYOP_COLORS.panel,
+          borderColor: SYOP_COLORS.panelBorder,
+          borderWidth: 1,
+          titleColor: SYOP_COLORS.text,
+          bodyColor: SYOP_COLORS.text,
+        },
+      },
+    },
+  });
+}
+
+function toggleSeries(button, chart) {
+  const seriesKey = button?.parentElement?.dataset?.series;
+  if (!chart || !seriesKey) return;
+  const dataset = chart.data.datasets.find((ds) => ds.label.startsWith(seriesKey));
+  if (!dataset) return;
+  const isPressed = button.getAttribute('aria-pressed') === 'true';
+  const nextState = !isPressed;
+  button.setAttribute('aria-pressed', String(nextState));
+  button.textContent = nextState ? 'On' : 'Off';
+  dataset.hidden = !nextState;
+  chart.update();
+}
+
+function toggleStack(button, chart) {
+  if (!chart) return;
+  const pressed = button.getAttribute('aria-pressed') === 'true';
+  const nextState = !pressed;
+  button.setAttribute('aria-pressed', String(nextState));
+  button.textContent = nextState ? 'On' : 'Off';
+  chart.options.scales.x.stacked = nextState;
+  chart.options.scales.y.stacked = nextState;
+  chart.data.datasets.forEach((ds) => {
+    ds.stack = nextState ? 'stack' : undefined;
+    ds.borderRadius = nextState ? 6 : 12;
+  });
+  chart.update();
+}
+
+function renderGauges(container) {
+  if (!container) return;
+  container.innerHTML = '';
+  GAUGES.forEach((gauge) => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'syop-gauge';
+
+    const svg = createSvgElement('svg');
+    const width = 320;
+    const height = 180;
+    svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+
+    const cx = width / 2;
+    const cy = height - 10;
+    const radius = 120;
+    const min = 2;
+    const max = 8;
+    const start = -Math.PI;
+    const end = 0;
+    const value = Math.max(min, Math.min(max, gauge.value));
+    const map = (val) => start + ((val - min) / (max - min)) * (end - start);
+
+    const track = createSvgElement('path');
+    track.setAttribute('d', (() => {
+      const p0 = polar(cx, cy, radius, start);
+      const p1 = polar(cx, cy, radius, end);
+      return `M ${p0.x} ${p0.y} A ${radius} ${radius} 0 0 1 ${p1.x} ${p1.y}`;
+    })());
+    track.setAttribute('stroke', '#1f2437');
+    track.setAttribute('stroke-width', '16');
+    track.setAttribute('fill', 'none');
+    track.setAttribute('stroke-linecap', 'round');
+    svg.appendChild(track);
+
+    const valuePath = createSvgElement('path');
+    valuePath.setAttribute('d', (() => {
+      const angle = map(value);
+      const p0 = polar(cx, cy, radius, start);
+      const p1 = polar(cx, cy, radius, angle);
+      const large = angle - start > Math.PI ? 1 : 0;
+      return `M ${p0.x} ${p0.y} A ${radius} ${radius} 0 ${large} 1 ${p1.x} ${p1.y}`;
+    })());
+    valuePath.setAttribute('stroke', gauge.color);
+    valuePath.setAttribute('stroke-width', '16');
+    valuePath.setAttribute('fill', 'none');
+    valuePath.setAttribute('stroke-linecap', 'round');
+    svg.appendChild(valuePath);
+
+    const ticks = [2, 3.5, 5, 6.5, 8];
+    ticks.forEach((tick) => {
+      const angle = map(tick);
+      const pIn = polar(cx, cy, radius - 12, angle);
+      const pOut = polar(cx, cy, radius + 12, angle);
+      const line = createSvgElement('line');
+      line.setAttribute('x1', pIn.x);
+      line.setAttribute('y1', pIn.y);
+      line.setAttribute('x2', pOut.x);
+      line.setAttribute('y2', pOut.y);
+      line.setAttribute('stroke', 'rgba(255,255,255,0.7)');
+      line.setAttribute('stroke-width', '1.5');
+      svg.appendChild(line);
+
+      const label = createSvgElement('text');
+      label.setAttribute('x', pOut.x);
+      label.setAttribute('y', pOut.y - 6);
+      label.setAttribute('font-size', '12');
+      label.setAttribute('fill', SYOP_COLORS.subtext);
+      label.setAttribute('text-anchor', 'middle');
+      label.textContent = tick;
+      svg.appendChild(label);
+    });
+
+    wrapper.appendChild(svg);
+
+    const labelWrapper = document.createElement('div');
+    labelWrapper.className = 'syop-gauge-label';
+    const labelTitle = document.createElement('span');
+    labelTitle.textContent = gauge.key;
+    const labelValue = document.createElement('span');
+    labelValue.className = 'syop-gauge-value';
+    labelValue.style.color = gauge.color;
+    labelValue.textContent = gauge.value.toFixed(2);
+    labelWrapper.append(labelTitle, labelValue);
+    wrapper.appendChild(labelWrapper);
+
+    container.appendChild(wrapper);
+  });
+}
+
+function renderHighlights(list) {
+  if (!list) return;
+  list.innerHTML = '';
+  const peaks = {};
+  SYOP_SERIES.forEach((series) => {
+    let best = { syop: SYOP_DATA[0].SYOP, value: SYOP_DATA[0][series.key] };
+    SYOP_DATA.forEach((row) => {
+      const v = row[series.key];
+      if (v > best.value) {
+        best = { syop: row.SYOP, value: v };
+      }
+    });
+    peaks[series.key] = best;
+  });
+
+  const statements = [
+    {
+      label: 'QB',
+      color: SYOP_COLORS.qb,
+      text: `peaks at ${peaks['QB %'].value.toFixed(2)}% in SYOP ${peaks['QB %'].syop}.`,
+    },
+    {
+      label: 'RB',
+      color: SYOP_COLORS.rb,
+      text: `concentrates early with ${peaks['RB %'].value.toFixed(2)}% in SYOP ${peaks['RB %'].syop}.`,
+    },
+    {
+      label: 'WR',
+      color: SYOP_COLORS.wr,
+      text: `shows a dual hump (SYOP 3–7) highlighted by ${peaks['WR %'].value.toFixed(2)}%.`,
+    },
+    {
+      label: 'TE',
+      color: SYOP_COLORS.te,
+      text: `maintains steady value with residuals through 12+ years at ${peaks['TE %'].value.toFixed(2)}%.`,
+    },
+  ];
+
+  statements.forEach((item) => {
+    const li = document.createElement('li');
+    li.innerHTML = `<strong style="color:${item.color}">${item.label}</strong> ${item.text}`;
+    list.appendChild(li);
+  });
+}
+
+function renderQa(list) {
+  if (!list) return;
+  list.innerHTML = '';
+  const tests = [];
+  const gaugeKeys = GAUGES.map((g) => g.key).sort().join(',');
+  const required = ['QB', 'RB', 'WR', 'TE'].sort().join(',');
+  tests.push({ name: 'Gauge keys present', pass: gaugeKeys === required });
+  const rangeOk = GAUGES.every((g) => typeof g.value === 'number' && g.value >= 2 && g.value <= 8);
+  tests.push({ name: 'Gauge values between 2 and 8', pass: rangeOk });
+  const columnsOk = SYOP_DATA.every((row) => SYOP_SERIES.every((series) => typeof row[series.key] === 'number'));
+  tests.push({ name: 'SYOP rows include all series', pass: columnsOk });
+  const sunAligned = SUNBURST_DATA.labels.length === SUNBURST_DATA.parents.length && SUNBURST_DATA.parents.length === SUNBURST_DATA.values.length;
+  tests.push({ name: 'Sunburst arrays aligned', pass: sunAligned });
+  const splitTest = (() => {
+    const { label, paren } = splitLabelValue('SPΛ (7.2)');
+    return label === 'SPΛ' && paren === '7.2';
+  })();
+  tests.push({ name: 'Sunburst label/value split', pass: splitTest });
+  const centerSymbols = 'Mean | Λ & Mode | M'.includes('Λ') && 'Mean | Λ & Mode | M'.includes('M');
+  tests.push({ name: 'Center title uses Λ and M', pass: centerSymbols });
+  const arcTest = /^M\s/.test(arcPath(0, 0, 10, 20, 0, Math.PI / 2));
+  tests.push({ name: 'arcPath returns SVG path', pass: arcTest });
+  const seriesParse = seriesFromLabel('WR sample') === 'WR';
+  tests.push({ name: 'seriesFromLabel parses prefix', pass: seriesParse });
+
+  tests.forEach((test) => {
+    if (!test.pass) {
+      // eslint-disable-next-line no-console
+      console.warn(`SYOP QA failed: ${test.name}`);
+    }
+    const li = document.createElement('li');
+    li.className = `syop-qa-item ${test.pass ? 'pass' : 'fail'}`;
+    li.classList.add(test.pass ? 'pass' : 'fail');
+    li.innerHTML = `<span>${test.name}</span><span class="syop-qa-status">${test.pass ? 'PASS' : 'FAIL'}</span>`;
+    list.appendChild(li);
+  });
+}
+
+function renderDraftTiles(container) {
+  if (!container) return;
+  container.innerHTML = '';
+  DRAFT_OVERALL.forEach((row) => {
+    const tile = document.createElement('div');
+    tile.className = 'draft-tile';
+    tile.innerHTML = `<span class="round">${row.rd}</span><span>${row.hit.toFixed(1)}%</span>`;
+    container.appendChild(tile);
+  });
+}
+
+function createOverallChart(ctx) {
+  const ChartConstructor = window.Chart;
+  if (!ctx || !ChartConstructor) return null;
+  const labels = DRAFT_OVERALL.map((row) => row.rd);
+  return new ChartConstructor(ctx, {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: 'Hit %',
+          data: DRAFT_OVERALL.map((row) => row.hit),
+          borderRadius: 14,
+          borderSkipped: false,
+          backgroundColor(context) {
+            const chart = context.chart;
+            const { ctx: canvasCtx, chartArea } = chart;
+            if (!chartArea) {
+              return SYOP_COLORS.wr;
+            }
+            const gradient = canvasCtx.createLinearGradient(0, chartArea.bottom, 0, chartArea.top);
+            gradient.addColorStop(0, 'rgba(70,231,255,0.35)');
+            gradient.addColorStop(1, 'rgba(255,65,225,0.6)');
+            return gradient;
+          },
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        x: {
+          grid: { display: false },
+          ticks: { color: SYOP_COLORS.subtext },
+        },
+        y: {
+          beginAtZero: true,
+          max: 100,
+          grid: { color: 'rgba(148,163,184,0.14)' },
+          ticks: {
+            color: SYOP_COLORS.subtext,
+            callback: (value) => `${value}%`,
+          },
+        },
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          backgroundColor: 'rgba(15,23,42,0.92)',
+          borderColor: 'rgba(255,255,255,0.12)',
+          borderWidth: 1,
+          titleColor: '#E2E8F0',
+          bodyColor: '#E2E8F0',
+          callbacks: {
+            label(context) {
+              return `Hit %: ${Number(context.parsed.y || 0).toFixed(1)}%`;
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+function createPositionalChart(ctx) {
+  const ChartConstructor = window.Chart;
+  if (!ctx || !ChartConstructor) return null;
+  const labels = DRAFT_POSITIONAL.map((row) => row.rd);
+  const datasetConfig = [
+    { key: 'QB', var: '--draft-magenta', fallback: '#ff41e1' },
+    { key: 'RB', var: '--draft-green', fallback: '#20f7a7' },
+    { key: 'TE', var: '--draft-purple', fallback: '#9e5af7' },
+    { key: 'WR', var: '--draft-cyan', fallback: '#46e7ff' },
+  ];
+  return new ChartConstructor(ctx, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: datasetConfig.map((cfg) => ({
+        label: cfg.key,
+        data: DRAFT_POSITIONAL.map((row) => row[cfg.key]),
+        borderColor: getComputedStyle(document.documentElement).getPropertyValue(cfg.var) || cfg.fallback,
+        backgroundColor: 'transparent',
+        borderWidth: 3,
+        tension: 0.35,
+        pointRadius: 3,
+        pointHoverRadius: 5,
+      })),
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        x: {
+          grid: { color: 'rgba(148,163,184,0.12)' },
+          ticks: { color: SYOP_COLORS.subtext },
+        },
+        y: {
+          beginAtZero: true,
+          max: 100,
+          grid: { color: 'rgba(148,163,184,0.12)' },
+          ticks: {
+            color: SYOP_COLORS.subtext,
+            callback: (value) => `${value}%`,
+          },
+        },
+      },
+      plugins: {
+        legend: {
+          labels: {
+            color: SYOP_COLORS.subtext,
+            usePointStyle: true,
+          },
+        },
+        tooltip: {
+          backgroundColor: 'rgba(15,23,42,0.92)',
+          borderColor: 'rgba(255,255,255,0.12)',
+          borderWidth: 1,
+          titleColor: '#E2E8F0',
+          bodyColor: '#E2E8F0',
+          callbacks: {
+            label(context) {
+              return `${context.dataset.label}: ${Number(context.parsed.y || 0).toFixed(1)}%`;
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+function initSyopPage() {
+  const params = new URLSearchParams(window.location.search);
+  const username = params.get('username');
+  if (username) {
+    const usernameField = document.getElementById('usernameInput');
+    if (usernameField) {
+      usernameField.value = username;
+    }
+  }
+
+  const sunburst = document.getElementById('syop-sunburst');
+  renderSunburst(sunburst);
+
+  const columnCanvas = document.getElementById('syop-column-chart');
+  const columnChart = createColumnChart(columnCanvas?.getContext('2d'));
+
+  const toggleButtons = document.querySelectorAll('.syop-toggle .syop-switch');
+  toggleButtons.forEach((button) => {
+    button.addEventListener('click', () => toggleSeries(button, columnChart));
+  });
+
+  const stackButton = document.getElementById('syop-stack-toggle');
+  stackButton?.addEventListener('click', () => toggleStack(stackButton, columnChart));
+
+  const gaugeGrid = document.querySelector('.syop-gauge-grid');
+  renderGauges(gaugeGrid);
+
+  const highlightsList = document.getElementById('syop-highlights');
+  renderHighlights(highlightsList);
+
+  const qaList = document.getElementById('syop-qa');
+  renderQa(qaList);
+
+  const tiles = document.getElementById('draft-tiles');
+  renderDraftTiles(tiles);
+
+  const overallCanvas = document.getElementById('draft-overall-chart');
+  createOverallChart(overallCanvas?.getContext('2d'));
+
+  const positionalCanvas = document.getElementById('draft-positional-chart');
+  createPositionalChart(positionalCanvas?.getContext('2d'));
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initSyopPage);
+} else {
+  initSyopPage();
+}

--- a/DH_P3-5.21Gb/styles/syop.css
+++ b/DH_P3-5.21Gb/styles/syop.css
@@ -1,0 +1,500 @@
+:root {
+  --syop-bg: #0b0e16;
+  --syop-panel: rgba(26, 29, 44, 0.55);
+  --syop-panel-border: rgba(255, 255, 255, 0.08);
+  --syop-text: #e9ecf9;
+  --syop-subtext: #b6b9d6;
+  --syop-qb: #a855f7;
+  --syop-rb: #ec4899;
+  --syop-wr: #22d3ee;
+  --syop-te: #f472b6;
+  --syop-muted: #334155;
+  --draft-bg: rgba(15, 23, 42, 0.65);
+  --draft-border: rgba(148, 163, 184, 0.14);
+  --draft-cyan: #46e7ff;
+  --draft-magenta: #ff41e1;
+  --draft-purple: #9e5af7;
+  --draft-green: #20f7a7;
+}
+
+body[data-page="syop"] {
+  color: var(--syop-text);
+}
+
+.syop-content {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+  padding-bottom: 3rem;
+}
+
+.syop-top {
+  background: radial-gradient(circle at 0% 0%, rgba(108, 43, 217, 0.2), transparent 55%),
+    radial-gradient(circle at 100% 0%, rgba(6, 182, 212, 0.18), transparent 60%),
+    radial-gradient(circle at 15% 100%, rgba(236, 72, 153, 0.16), transparent 65%),
+    var(--syop-bg);
+  border-radius: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: 0 30px 80px rgba(5, 8, 16, 0.75);
+  padding: clamp(2rem, 4vw, 3rem);
+  backdrop-filter: blur(22px);
+  -webkit-backdrop-filter: blur(22px);
+}
+
+.syop-top-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.syop-pill,
+.draft-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 0.65rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--syop-subtext);
+}
+
+.syop-top h1 {
+  font-size: clamp(1.85rem, 3.6vw, 3rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-top: 0.75rem;
+}
+
+.syop-subtitle,
+.draft-subtitle,
+.syop-panel-sub {
+  color: var(--syop-subtext);
+  font-size: clamp(0.9rem, 1.8vw, 1.05rem);
+  max-width: 38rem;
+}
+
+.syop-badge {
+  align-self: flex-start;
+  padding: 0.6rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid var(--syop-panel-border);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--syop-subtext);
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+}
+
+.syop-top-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  margin-top: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.syop-panel {
+  border-radius: 1.75rem;
+  border: 1px solid var(--syop-panel-border);
+  background: var(--syop-panel);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.syop-panel header {
+  padding: clamp(1.25rem, 3vw, 1.75rem) clamp(1.25rem, 3vw, 1.75rem) 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.syop-panel header h2,
+.syop-panel header h3,
+.syop-panel header h4 {
+  font-size: clamp(1.1rem, 2.2vw, 1.45rem);
+  font-weight: 600;
+}
+
+.syop-panel-body {
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.syop-panel-body canvas {
+  width: 100% !important;
+  height: auto !important;
+}
+
+.syop-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+  padding: 0 clamp(1.25rem, 3vw, 1.75rem);
+  margin-top: 0.75rem;
+}
+
+.syop-toggle,
+.syop-stack {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: rgba(15, 23, 42, 0.35);
+  border-radius: 999px;
+  padding: 0.45rem 0.85rem 0.45rem 0.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 0.85rem;
+  color: var(--syop-subtext);
+}
+
+.syop-stack {
+  justify-content: space-between;
+}
+
+.syop-swatch,
+.legend-dot {
+  display: inline-block;
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 999px;
+}
+
+.syop-swatch.qb,
+.legend-dot.qb { background: var(--syop-qb); }
+.syop-swatch.rb,
+.legend-dot.rb { background: var(--syop-rb); }
+.syop-swatch.wr,
+.legend-dot.wr { background: var(--syop-wr); }
+.syop-swatch.te,
+.legend-dot.te { background: var(--syop-te); }
+
+.syop-switch {
+  border: none;
+  cursor: pointer;
+  border-radius: 999px;
+  padding: 0.25rem 0.85rem;
+  background: rgba(255, 255, 255, 0.16);
+  color: #0f172a;
+  font-weight: 600;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.syop-switch[aria-pressed="false"] {
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--syop-subtext);
+}
+
+.syop-gauge-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: clamp(1rem, 2.5vw, 1.75rem);
+  margin-top: clamp(2rem, 4vw, 3rem);
+}
+
+.syop-gauge {
+  background: var(--syop-panel);
+  border-radius: 1.5rem;
+  border: 1px solid var(--syop-panel-border);
+  padding: 1.5rem 1.25rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+}
+
+.syop-gauge svg {
+  width: 100%;
+  height: auto;
+}
+
+.syop-gauge-label {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.syop-gauge-label span:first-child {
+  font-size: 0.75rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--syop-subtext);
+}
+
+.syop-gauge-value {
+  font-size: 1.85rem;
+  font-weight: 600;
+}
+
+.syop-bottom-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(1.25rem, 3vw, 2rem);
+  margin-top: clamp(2rem, 4vw, 3rem);
+}
+
+.syop-highlights,
+.syop-qa {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.syop-highlights li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 1rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  line-height: 1.5;
+  color: var(--syop-subtext);
+}
+
+.syop-highlights strong {
+  color: var(--syop-text);
+}
+
+.syop-qa li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 1rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  color: var(--syop-subtext);
+  font-size: 0.95rem;
+}
+
+.syop-qa li.pass {
+  background: rgba(20, 83, 45, 0.35);
+  border-color: rgba(16, 185, 129, 0.4);
+  color: #a7f3d0;
+}
+
+.syop-qa li.fail {
+  background: rgba(88, 28, 28, 0.35);
+  border-color: rgba(248, 113, 113, 0.4);
+  color: #fecaca;
+}
+
+.syop-qa-status {
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.syop-footnote {
+  margin-top: clamp(2rem, 4vw, 3rem);
+  font-size: 0.8rem;
+  color: var(--syop-subtext);
+  text-align: center;
+}
+
+.draft-section {
+  background: rgba(10, 15, 30, 0.9);
+  border-radius: 2rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: clamp(2rem, 4vw, 3rem);
+  box-shadow: 0 40px 90px rgba(2, 6, 23, 0.75);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+.draft-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.draft-header h2 {
+  font-size: clamp(1.65rem, 3vw, 2.4rem);
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+
+.draft-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  margin-top: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.draft-card {
+  background: var(--draft-bg);
+  border-radius: 1.75rem;
+  border: 1px solid var(--draft-border);
+  padding: clamp(1.5rem, 3vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  min-height: 0;
+}
+
+.draft-card header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.draft-card header h3 {
+  font-size: clamp(1.2rem, 2.4vw, 1.6rem);
+  font-weight: 600;
+}
+
+.draft-card header p {
+  color: var(--syop-subtext);
+  font-size: 0.95rem;
+}
+
+.draft-legend {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, max-content));
+  gap: 0.5rem 1.25rem;
+  font-size: 0.85rem;
+  color: var(--syop-subtext);
+  margin: 0;
+  padding: 0;
+}
+
+.legend-dot {
+  width: 0.65rem;
+  height: 0.65rem;
+}
+
+.draft-chart-container {
+  position: relative;
+  width: 100%;
+  min-height: 220px;
+}
+
+.draft-chart-container canvas {
+  width: 100% !important;
+  height: auto !important;
+}
+
+.draft-tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.65rem;
+}
+
+.draft-tiles .draft-tile {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 1rem;
+  padding: 0.65rem 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--syop-subtext);
+  font-size: 0.9rem;
+}
+
+.draft-tile span.round {
+  display: inline-flex;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.75rem;
+  align-items: center;
+  justify-content: center;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--syop-text);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.draft-footnote {
+  font-size: 0.78rem;
+  color: var(--syop-subtext);
+  margin-top: -0.5rem;
+}
+
+.draft-banner {
+  margin-top: clamp(1.75rem, 3vw, 2.5rem);
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-size: 0.72rem;
+  padding: 0.65rem 1.75rem;
+  background: linear-gradient(90deg, rgba(70, 231, 255, 0.22), rgba(255, 65, 225, 0.22), rgba(158, 90, 247, 0.22));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  text-align: center;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+@media (max-width: 768px) {
+  .syop-top,
+  .draft-section {
+    border-radius: 1.5rem;
+    padding: clamp(1.5rem, 6vw, 2rem);
+  }
+
+  .syop-top-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .syop-badge {
+    align-self: stretch;
+    text-align: center;
+  }
+
+  .syop-controls {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+
+  .draft-card {
+    border-radius: 1.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .syop-pill,
+  .draft-pill {
+    letter-spacing: 0.2em;
+    font-size: 0.58rem;
+  }
+
+  .syop-switch {
+    padding: 0.25rem 0.65rem;
+  }
+
+  .syop-controls {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 0.5rem;
+  }
+
+  .syop-top-grid,
+  .draft-grid {
+    gap: 1.25rem;
+  }
+
+  .syop-gauge {
+    padding: 1.25rem;
+  }
+
+  .draft-banner {
+    font-size: 0.65rem;
+    letter-spacing: 0.25em;
+  }
+}

--- a/DH_P3-5.21Gb/syop/syop.html
+++ b/DH_P3-5.21Gb/syop/syop.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SYOP Analytics • Dynasty Hub</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@200;300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Product+Sans:wght@100;200;300;400;500;700;900&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css?family=Google+Sans:100,200,300,400,500,600,700" rel="stylesheet" />
+  <link rel="manifest" href="../manifest.webmanifest" />
+  <link rel="apple-touch-icon" sizes="180x180" href="../assets/icons/apple-touch-icon-180.png" />
+  <meta name="theme-color" content="#0D0E1B" />
+  <link rel="stylesheet" href="../styles/styles.css?v=20250827002411?v=20250826235225" />
+  <link rel="stylesheet" href="../styles/syop.css?v=20250827002411" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="icon" type="image/png" sizes="32x32" href="../assets/icons/favicon-32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="../assets/icons/favicon-16.png" />
+  <link rel="shortcut icon" href="../assets/icons/favicon.ico" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js" defer></script>
+  <script src="../scripts/syop.js" type="module" defer></script>
+</head>
+<body data-page="syop" class="p-2 sm:p-4">
+  <div id="starfield" aria-hidden="true">
+    <div id="stars"></div>
+    <div id="stars1"></div>
+    <div id="stars2"></div>
+    <div id="stars3"></div>
+  </div>
+  <div id="noise-overlay"></div>
+  <div class="relative z-10 content-wrapper">
+    <div id="header-container">
+      <header class="app-header glass-panel">
+        <div class="header-row">
+          <div class="menu-container">
+            <button id="menu-button" class="menu-button" aria-label="Open menu">
+              <svg viewBox="0 0 100 80" width="20" height="20" aria-hidden="true">
+                <rect width="100" height="15"></rect>
+                <rect y="30" width="100" height="15"></rect>
+                <rect y="60" width="100" height="15"></rect>
+              </svg>
+            </button>
+            <div id="dropdown-menu" class="dropdown-menu hidden">
+              <a href="../">Home</a>
+              <a href="#" id="menu-rosters">Rosters</a>
+              <a href="#" id="menu-ownership">Ownership</a>
+              <a href="#" id="menu-analyzer">League Analyzer</a>
+              <a href="#" id="menu-syop" class="active">SYOP</a>
+            </div>
+          </div>
+          <div class="username-area">
+            <input type="text" name="username" id="usernameInput" placeholder="SLPR Username..." value="The_Oracle" autocomplete="username" autocorrect="off" autocapitalize="none" inputmode="text" />
+          </div>
+          <div class="app-view-switcher primary-switcher">
+            <button id="fetchRostersButton">Rosters</button>
+            <button id="fetchOwnershipButton">Ownership %</button>
+          </div>
+        </div>
+      </header>
+    </div>
+    <main id="content" class="container mx-auto syop-content">
+      <section class="syop-top" aria-labelledby="syop-heading">
+        <div class="syop-top-header">
+          <div>
+            <p class="syop-pill">Career Length Analytics</p>
+            <h1 id="syop-heading">Significant Years of Production</h1>
+            <p class="syop-subtitle">Decomposed visualization of position longevity using Dynasty Hub research inputs.</p>
+          </div>
+          <div class="syop-badge" aria-hidden="true">SYOP • Insights</div>
+        </div>
+        <div class="syop-top-grid">
+          <article class="syop-panel" aria-labelledby="sunburst-title">
+            <header>
+              <h2 id="sunburst-title">Mean (Λ) &amp; Mode (M) Distribution</h2>
+              <p class="syop-panel-sub">Per-position proportional share</p>
+            </header>
+            <div id="syop-sunburst" class="syop-panel-body" role="img" aria-label="Sunburst showing mean and mode distribution by position"></div>
+          </article>
+          <article class="syop-panel" aria-labelledby="column-title">
+            <header>
+              <h2 id="column-title">SYOP Bin Breakdown</h2>
+              <p class="syop-panel-sub">Percentage of positional hits per SYOP bucket</p>
+            </header>
+            <div class="syop-controls" aria-label="Toggle position series visibility">
+              <div class="syop-toggle" data-series="QB">
+                <span class="syop-swatch qb"></span>
+                <span>QB %</span>
+                <button type="button" class="syop-switch" aria-pressed="true">On</button>
+              </div>
+              <div class="syop-toggle" data-series="RB">
+                <span class="syop-swatch rb"></span>
+                <span>RB %</span>
+                <button type="button" class="syop-switch" aria-pressed="true">On</button>
+              </div>
+              <div class="syop-toggle" data-series="WR">
+                <span class="syop-swatch wr"></span>
+                <span>WR %</span>
+                <button type="button" class="syop-switch" aria-pressed="true">On</button>
+              </div>
+              <div class="syop-toggle" data-series="TE">
+                <span class="syop-swatch te"></span>
+                <span>TE %</span>
+                <button type="button" class="syop-switch" aria-pressed="true">On</button>
+              </div>
+              <div class="syop-stack">
+                <span>Stacked</span>
+                <button type="button" id="syop-stack-toggle" class="syop-switch" aria-pressed="false">Off</button>
+              </div>
+            </div>
+            <div class="syop-panel-body">
+              <canvas id="syop-column-chart" aria-describedby="column-title"></canvas>
+            </div>
+          </article>
+        </div>
+        <div class="syop-gauge-grid" aria-label="Average SYOP by position"></div>
+        <div class="syop-bottom-grid">
+          <article class="syop-panel" aria-labelledby="syop-highlights-title">
+            <header>
+              <h2 id="syop-highlights-title">Highlights</h2>
+              <p class="syop-panel-sub">Quick takeaways from SYOP distributions</p>
+            </header>
+            <div class="syop-panel-body">
+              <ul id="syop-highlights" class="syop-highlights"></ul>
+            </div>
+          </article>
+          <article class="syop-panel" aria-labelledby="syop-qa-title">
+            <header>
+              <h2 id="syop-qa-title">QA Checks</h2>
+              <p class="syop-panel-sub">Automated validation of infographic data integrity</p>
+            </header>
+            <div class="syop-panel-body">
+              <ul id="syop-qa" class="syop-qa"></ul>
+            </div>
+          </article>
+        </div>
+        <p class="syop-footnote">Built for Dynasty Hub · Visual style blends glassmorphism + neon dark. Data provided by internal SYOP research.</p>
+      </section>
+      <section class="draft-section" aria-labelledby="draft-heading">
+        <div class="draft-header">
+          <p class="draft-pill">NFL Draft – Player Hit Rates</p>
+          <h2 id="draft-heading">Round-by-Round Hit Probability</h2>
+          <p class="draft-subtitle">2008-2020 Draft class outcomes using Dynasty Hub curated data.</p>
+        </div>
+        <div class="draft-grid">
+          <article class="draft-card" aria-labelledby="draft-overall-title">
+            <header>
+              <div>
+                <h3 id="draft-overall-title">Overall Hit Probability</h3>
+                <p>Hit percentage for all positions by draft round</p>
+              </div>
+            </header>
+            <div class="draft-chart-container">
+              <canvas id="draft-overall-chart" aria-describedby="draft-overall-title"></canvas>
+            </div>
+            <div class="draft-tiles" id="draft-tiles" aria-label="Summary of hit percentages by round"></div>
+          </article>
+          <article class="draft-card" aria-labelledby="draft-positional-title">
+            <header>
+              <div>
+                <h3 id="draft-positional-title">Positional Hit Rate Trends</h3>
+                <p>Comparative round trends for QB, RB, TE, and WR</p>
+              </div>
+              <ul class="draft-legend" aria-hidden="true">
+                <li><span class="legend-dot qb"></span>QB</li>
+                <li><span class="legend-dot rb"></span>RB</li>
+                <li><span class="legend-dot te"></span>TE</li>
+                <li><span class="legend-dot wr"></span>WR</li>
+              </ul>
+            </header>
+            <div class="draft-chart-container">
+              <canvas id="draft-positional-chart" aria-describedby="draft-positional-title"></canvas>
+            </div>
+            <p class="draft-footnote">*Values are exact percentages provided. Lines show hit rate trends across rounds.</p>
+          </article>
+        </div>
+        <div class="draft-banner" aria-hidden="true">Hit Rate • All Positions &amp; By Position</div>
+      </section>
+    </main>
+  </div>
+  <script src="../scripts/app.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build a SYOP analytics page that reconstructs the infographic and NFL draft data sections inside the app shell
- add dedicated styling and scripting for custom sunburst, charts, gauges, and QA/highlight callouts
- update navigation so the hamburger menu opens the new SYOP experience from every page

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ce50ecbf90832e9fecd2f495a6e6c8