### PR TITLE
Refine SYOP visuals and add research navigation

### DIFF
--- a/DH_P3-5.21Gb/analyzer/analyzer.html
+++ b/DH_P3-5.21Gb/analyzer/analyzer.html
@@ -151,8 +151,8 @@
                             <a href="../">Home</a>
                             <a href="#" id="menu-rosters">Rosters</a>
                             <a href="#" id="menu-ownership">Ownership</a>
-                            <a href="#" id="menu-analyzer">League Analyzer</a>
-                            <a href="#">Placeholder</a>
+        <a href="#" id="menu-analyzer">League Analyzer</a>
+        <a href="#" id="menu-syop">SYOP</a>
                         </div>
                     </div>
                     <div class="username-area">

--- a/DH_P3-5.21Gb/index.html
+++ b/DH_P3-5.21Gb/index.html
@@ -44,7 +44,7 @@
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
         <a href="#" id="menu-analyzer">League Analyzer</a>
-        <a href="#">Coming Soon..</a>
+        <a href="#" id="menu-syop">SYOP</a>
     </div>
 </div>
 <div class="username-area">

--- a/DH_P3-5.21Gb/ownership/ownership.html
+++ b/DH_P3-5.21Gb/ownership/ownership.html
@@ -41,7 +41,7 @@
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
         <a href="#" id="menu-analyzer">League Analyzer</a>
-        <a href="#">Placeholder</a>
+        <a href="#" id="menu-syop">SYOP</a>
     </div>
 </div>
 <div class="username-area">

--- a/DH_P3-5.21Gb/rosters/rosters.html
+++ b/DH_P3-5.21Gb/rosters/rosters.html
@@ -43,7 +43,7 @@
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
         <a href="#" id="menu-analyzer">League Analyzer</a>
-        <a href="#">Placeholder</a>
+        <a href="#" id="menu-syop">SYOP</a>
     </div>
 </div>
 <div class="username-area">
@@ -56,6 +56,12 @@
 </div>
 <div class="hidden" id="contextual-controls">
 <div class="header-row" id="secondary-header-row">
+<div class="research-button-container">
+<button aria-label="Open Dynasty Hub Research" class="menu-button analyzer-button research-button" id="researchButton" type="button">
+<i class="fa-solid fa-flask-vial research-icon" aria-hidden="true"></i>
+<span class="analyzer-label">Research</span>
+</button>
+</div>
 <div class="analyzer-button-container">
 <button aria-label="Open League Analyzer" class="menu-button analyzer-button" id="analyzeLeagueButton" type="button">
 <i class="fa-solid fa-square-poll-vertical analyzer-icon" aria-hidden="true"></i>
@@ -87,10 +93,6 @@
                 <span class="clear-filters-label">Clear</span>
             </span>
         </button>
-    </div>
-    <div class="compare-controls">
-        <button class="control-button" disabled="" id="compareButton"><span class="button-text">Preview</span></button>
-        <button class="control-button-subtle hidden" id="clearCompareButton"><i class="fa-solid fa-circle-xmark"></i></button>
     </div>
 </div>
 </div>

--- a/DH_P3-5.21Gb/scripts/app.js
+++ b/DH_P3-5.21Gb/scripts/app.js
@@ -50,7 +50,9 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const menuRosters = document.getElementById('menu-rosters');
         const menuOwnership = document.getElementById('menu-ownership');
         const menuAnalyzer = document.getElementById('menu-analyzer');
+        const menuSyop = document.getElementById('menu-syop');
         const analyzeLeagueButton = document.getElementById('analyzeLeagueButton');
+        const researchButton = document.getElementById('researchButton');
 
         menuButton?.addEventListener('click', (e) => {
             e.stopPropagation();
@@ -103,6 +105,20 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             window.location.href = `../analyzer/analyzer.html?username=${encodeURIComponent(username)}&leagueId=${state.currentLeagueId}`;
         });
 
+        researchButton?.addEventListener('click', () => {
+            const username = usernameInput.value.trim();
+            const suffix = username ? `?username=${encodeURIComponent(username)}` : '';
+            let url;
+            if (pageType === 'welcome') {
+                url = `syop/syop.html${suffix}`;
+            } else if (pageType === 'syop') {
+                url = `syop.html${suffix}`;
+            } else {
+                url = `../syop/syop.html${suffix}`;
+            }
+            window.location.href = url;
+        });
+
         menuOwnership?.addEventListener('click', () => {
             const username = usernameInput.value.trim();
             if (!username) return;
@@ -120,6 +136,23 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 }
                 window.location.href = url;
             }
+            dropdownMenu.classList.add('hidden');
+        });
+
+        menuSyop?.addEventListener('click', () => {
+            if (pageType === 'syop') {
+                dropdownMenu.classList.add('hidden');
+                return;
+            }
+            const username = usernameInput.value.trim();
+            const suffix = username ? `?username=${encodeURIComponent(username)}` : '';
+            let url;
+            if (pageType === 'welcome') {
+                url = `syop/syop.html${suffix}`;
+            } else {
+                url = `../syop/syop.html${suffix}`;
+            }
+            window.location.href = url;
             dropdownMenu.classList.add('hidden');
         });
 
@@ -160,6 +193,17 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 const username = usernameInput.value.trim();
                 if (!username) return;
                 window.location.href = `ownership/ownership.html?username=${encodeURIComponent(username)}`;
+            });
+        } else if (pageType === 'syop') {
+            fetchRostersButton?.addEventListener('click', () => {
+                const username = usernameInput.value.trim();
+                if (!username) return;
+                window.location.href = `../rosters/rosters.html?username=${encodeURIComponent(username)}`;
+            });
+            fetchOwnershipButton?.addEventListener('click', () => {
+                const username = usernameInput.value.trim();
+                if (!username) return;
+                window.location.href = `../ownership/ownership.html?username=${encodeURIComponent(username)}`;
             });
         } else if (pageType === 'rosters') {
             fetchRostersButton?.addEventListener('click', handleFetchRosters);
@@ -239,6 +283,14 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         // --- Initialization ---
         document.addEventListener('DOMContentLoaded', async () => {
             if (pageType === 'analyzer') return;
+            if (pageType === 'syop') {
+                const params = new URLSearchParams(window.location.search);
+                const uname = params.get('username');
+                if (uname) {
+                    usernameInput.value = uname;
+                }
+                return;
+            }
             setLoading(true, 'Loading initial data...');
             await Promise.all([ fetchSleeperPlayers(), fetchDataFromGoogleSheet(), fetchPlayerStatsSheets() ]);
             setLoading(false);
@@ -500,6 +552,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         }
 
         function updateCompareButtonState() {
+            if (!compareButton || !clearCompareButton) return;
             const count = state.teamsToCompare.size;
             compareButton.disabled = count < 2;
             clearCompareButton.classList.toggle('hidden', count === 0);

--- a/DH_P3-5.21Gb/scripts/syop.js
+++ b/DH_P3-5.21Gb/scripts/syop.js
@@ -1,0 +1,986 @@
+(function () {
+  const PAGE_ID = 'syop';
+  const SVG_NS = 'http://www.w3.org/2000/svg';
+
+  const colors = {
+    bg: '#0B0E16',
+    panel: 'rgba(18, 21, 38, 0.78)',
+    panelBorder: 'rgba(132, 146, 255, 0.16)',
+    text: '#F5F7FF',
+    subtext: '#A7AFD4',
+    muted: '#303854',
+    grid: 'rgba(120, 144, 255, 0.18)',
+    accentA: '#54F0FF',
+    accentB: '#6C9BFF',
+    accentC: '#FF5AE0',
+    qb: '#FF8E6E',
+    rb: '#3FE1B0',
+    wr: '#6FA6FF',
+    te: '#D68BFF'
+  };
+
+  const SUNBURST_NODES = [
+    { id: 'root', parent: null, label: 'SYOP Averages', subtitle: 'Mean Λ vs Mode M', value: 51.6 },
+    { id: 'qb', parent: 'root', label: 'QB', subtitle: 'Quarterbacks', value: 16.46, series: 'QB' },
+    { id: 'qb-prime-lambda', parent: 'qb', label: 'Prime Λ', subtitle: '7.2 yrs', value: 6.5, abbr: 'SPΛ', stat: '7.2' },
+    { id: 'qb-breakout-lambda', parent: 'qb', label: 'Breakout Λ', subtitle: '2.3 yrs', value: 2.49, abbr: 'BOΛ', stat: '2.3' },
+    { id: 'qb-prime-mode', parent: 'qb', label: 'Prime M', subtitle: '6.0 yrs', value: 5.35, abbr: 'SPM', stat: '6.0' },
+    { id: 'qb-baseline-mode', parent: 'qb', label: 'Baseline M', subtitle: '1.0 yrs', value: 2.1, abbr: 'BOM', stat: '1.0' },
+    { id: 'rb', parent: 'root', label: 'RB', subtitle: 'Running Backs', value: 9.8, series: 'RB' },
+    { id: 'rb-prime-lambda', parent: 'rb', label: 'Prime Λ', subtitle: '3.4 yrs', value: 3.31, abbr: 'SPΛ', stat: '3.4' },
+    { id: 'rb-breakout-lambda', parent: 'rb', label: 'Breakout Λ', subtitle: '2.2 yrs', value: 2.5, abbr: 'BOΛ', stat: '2.2' },
+    { id: 'rb-prime-mode', parent: 'rb', label: 'Prime M', subtitle: '0.7 yrs', value: 1.89, abbr: 'SPM', stat: '0.7' },
+    { id: 'rb-baseline-mode', parent: 'rb', label: 'Baseline M', subtitle: '1.7 yrs', value: 2.1, abbr: 'BOM', stat: '1.7' },
+    { id: 'wr', parent: 'root', label: 'WR', subtitle: 'Wide Receivers', value: 12.82, series: 'WR' },
+    { id: 'wr-prime-lambda', parent: 'wr', label: 'Prime Λ', subtitle: '4.9 yrs', value: 4.92, abbr: 'SPΛ', stat: '4.9' },
+    { id: 'wr-breakout-lambda', parent: 'wr', label: 'Breakout Λ', subtitle: '2.9 yrs', value: 2.84, abbr: 'BOΛ', stat: '2.9' },
+    { id: 'wr-prime-mode', parent: 'wr', label: 'Prime M', subtitle: '3.0 yrs', value: 3, abbr: 'SPM', stat: '3.0' },
+    { id: 'wr-baseline-mode', parent: 'wr', label: 'Baseline M', subtitle: '2.0 yrs', value: 2, abbr: 'BOM', stat: '2.0' },
+    { id: 'te', parent: 'root', label: 'TE', subtitle: 'Tight Ends', value: 12.5, series: 'TE' },
+    { id: 'te-prime-lambda', parent: 'te', label: 'Prime Λ', subtitle: '4.0 yrs', value: 4.01, abbr: 'SPΛ', stat: '4.0' },
+    { id: 'te-breakout-lambda', parent: 'te', label: 'Breakout Λ', subtitle: '3.5 yrs', value: 3.49, abbr: 'BOΛ', stat: '3.5' },
+    { id: 'te-prime-mode', parent: 'te', label: 'Prime M', subtitle: '2.0 yrs', value: 2, abbr: 'SPM', stat: '2.0' },
+    { id: 'te-baseline-mode', parent: 'te', label: 'Baseline M', subtitle: '3.0 yrs', value: 3, abbr: 'BOM', stat: '3.0' }
+  ];
+
+  const SYOP_DATA = [
+    { SYOP: '1', 'QB %': 6.67, 'RB %': 27.54, 'WR %': 13.0, 'TE %': 26.92 },
+    { SYOP: '2', 'QB %': 11.11, 'RB %': 20.29, 'WR %': 14.1, 'TE %': 26.92 },
+    { SYOP: '3', 'QB %': 8.89, 'RB %': 11.59, 'WR %': 14.1, 'TE %': 7.69 },
+    { SYOP: '4', 'QB %': 8.89, 'RB %': 11.4, 'WR %': 12.0, 'TE %': 7.69 },
+    { SYOP: '5', 'QB %': 4.44, 'RB %': 13.04, 'WR %': 5.4, 'TE %': 0.4 },
+    { SYOP: '6', 'QB %': 13.33, 'RB %': 5.8, 'WR %': 7.6, 'TE %': 7.69 },
+    { SYOP: '7', 'QB %': 8.89, 'RB %': 1.45, 'WR %': 13.0, 'TE %': 7.69 },
+    { SYOP: '8', 'QB %': 4.44, 'RB %': 2.9, 'WR %': 9.8, 'TE %': 0.4 },
+    { SYOP: '9', 'QB %': 11.11, 'RB %': 3.3, 'WR %': 2.2, 'TE %': 3.85 },
+    { SYOP: '10', 'QB %': 2.22, 'RB %': 1.45, 'WR %': 4.49, 'TE %': 3.51 },
+    { SYOP: '11', 'QB %': 0.4, 'RB %': 1.45, 'WR %': 2.2, 'TE %': 3.85 },
+    { SYOP: '12+', 'QB %': 20.0, 'RB %': 0.4, 'WR %': 2.2, 'TE %': 3.85 }
+  ];
+
+  const GAUGES = [
+    { key: 'TE', value: 4.0, color: colors.te },
+    { key: 'RB', value: 3.39, color: colors.rb },
+    { key: 'WR', value: 4.9, color: colors.wr },
+    { key: 'QB', value: 7.22, color: colors.qb }
+  ];
+
+  const DRAFT_OVERALL = [
+    { rd: '1', hit: 78.4 },
+    { rd: '2', hit: 47.7 },
+    { rd: '3', hit: 38.5 },
+    { rd: '4', hit: 18.0 },
+    { rd: '5', hit: 15.0 },
+    { rd: '6', hit: 14.1 },
+    { rd: '7', hit: 9.4 }
+  ];
+
+  const DRAFT_POSITIONAL = [
+    { rd: '1', QB: 78, RB: 83, TE: 78, WR: 76 },
+    { rd: '2', QB: 42, RB: 50, TE: 40, WR: 51 },
+    { rd: '3', QB: 31, RB: 62, TE: 36, WR: 30 },
+    { rd: '4', QB: 20, RB: 27, TE: 23, WR: 9 },
+    { rd: '5', QB: 7, RB: 27, TE: 9, WR: 13 },
+    { rd: '6', QB: 11, RB: 18, TE: 8, WR: 15 },
+    { rd: '7', QB: 13, RB: 9, TE: 4, WR: 11 }
+  ];
+
+  const DRAFT_SERIES = [
+    { key: 'QB', color: '#FF41E1' },
+    { key: 'RB', color: '#20F7A7' },
+    { key: 'TE', color: '#9E5AF7' },
+    { key: 'WR', color: '#46E7FF' }
+  ];
+
+  const SYOP_SERIES = [
+    { key: 'QB %', label: 'QB', color: colors.qb },
+    { key: 'RB %', label: 'RB', color: colors.rb },
+    { key: 'WR %', label: 'WR', color: colors.wr },
+    { key: 'TE %', label: 'TE', color: colors.te }
+  ];
+
+  let resizeTimer = null;
+
+  function createEl(tag, attrs, ...children) {
+    const el = document.createElement(tag);
+    if (attrs) {
+      Object.entries(attrs).forEach(([key, value]) => {
+        if (key === 'class') {
+          el.className = value;
+        } else if (key === 'dataset') {
+          Object.entries(value).forEach(([dKey, dValue]) => {
+            el.dataset[dKey] = dValue;
+          });
+        } else if (key === 'style' && typeof value === 'object') {
+          Object.assign(el.style, value);
+        } else if (key in el) {
+          try {
+            el[key] = value;
+          } catch (_) {
+            el.setAttribute(key, value);
+          }
+        } else {
+          el.setAttribute(key, value);
+        }
+      });
+    }
+    children.forEach((child) => {
+      if (child == null) return;
+      if (Array.isArray(child)) {
+        child.forEach((nested) => nested != null && el.appendChild(typeof nested === 'string' ? document.createTextNode(nested) : nested));
+      } else {
+        el.appendChild(typeof child === 'string' ? document.createTextNode(child) : child);
+      }
+    });
+    return el;
+  }
+
+  function createSVG(tag, attrs, ...children) {
+    const el = document.createElementNS(SVG_NS, tag);
+    if (attrs) {
+      Object.entries(attrs).forEach(([key, value]) => {
+        el.setAttribute(key, value);
+      });
+    }
+    children.forEach((child) => {
+      if (child == null) return;
+      el.appendChild(child);
+    });
+    return el;
+  }
+
+  const sunburstNodeById = new Map(SUNBURST_NODES.map((node) => [node.id, node]));
+
+  function childrenOf(id) {
+    return SUNBURST_NODES.filter((node) => node.parent === id);
+  }
+
+  function polar(cx, cy, r, a) {
+    return { x: cx + r * Math.cos(a), y: cy + r * Math.sin(a) };
+  }
+
+  function arcPath(cx, cy, rInner, rOuter, a0, a1) {
+    const p0 = polar(cx, cy, rOuter, a0);
+    const p1 = polar(cx, cy, rOuter, a1);
+    const p2 = polar(cx, cy, rInner, a1);
+    const p3 = polar(cx, cy, rInner, a0);
+    const large = a1 - a0 > Math.PI ? 1 : 0;
+    return `M ${p0.x} ${p0.y} A ${rOuter} ${rOuter} 0 ${large} 1 ${p1.x} ${p1.y} L ${p2.x} ${p2.y} A ${rInner} ${rInner} 0 ${large} 0 ${p3.x} ${p3.y} Z`;
+  }
+
+  function labelAt(cx, cy, r, a) {
+    return polar(cx, cy, r, a);
+  }
+
+  function seriesColor(series) {
+    switch (series) {
+      case 'QB':
+        return colors.qb;
+      case 'RB':
+        return colors.rb;
+      case 'WR':
+        return colors.wr;
+      case 'TE':
+        return colors.te;
+      default:
+        return '#6b7280';
+    }
+  }
+
+  function hexToRgba(hex, alpha) {
+    const normalized = hex.replace('#', '');
+    const value = parseInt(normalized, 16);
+    const r = (value >> 16) & 255;
+    const g = (value >> 8) & 255;
+    const b = value & 255;
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
+  function renderSunburst() {
+    const container = document.getElementById('syop-sunburst');
+    if (!container) return;
+
+    const root = sunburstNodeById.get('root');
+    const ring1Nodes = childrenOf(root?.id || 'root');
+    const ring1Total = ring1Nodes.reduce((sum, node) => sum + node.value, 0) || 1;
+    const baseSize = 480;
+    const containerWidth = container.clientWidth || baseSize;
+    const constrained = Math.max(260, containerWidth);
+    const size = Math.min(baseSize, constrained);
+    const rawScale = size / baseSize;
+    const scale = Math.pow(rawScale, 0.88);
+    const pad = 28 * scale;
+    const cx = size / 2;
+    const cy = size / 2;
+    const inner1 = 96 * scale;
+    const outer1 = 168 * scale;
+    const inner2 = 176 * scale;
+    const outer2 = 232 * scale;
+    const centerRadius = 78 * scale;
+    const textStroke = 'rgba(11, 14, 22, 0.7)';
+    const fontSize = (value, floor = 13) => Math.max(value * scale, floor);
+    const startAngle = -Math.PI / 2;
+
+    const svg = createSVG('svg', {
+      viewBox: `${-pad} ${-pad} ${size + pad * 2} ${size + pad * 2}`,
+      width: String(size),
+      height: String(size),
+      class: 'syop-sunburst-svg',
+      role: 'img',
+      'aria-labelledby': 'syop-infographic-heading'
+    });
+
+    let cursor = startAngle;
+    const ring1Segments = ring1Nodes.map((node) => {
+      const span = (node.value / ring1Total) * Math.PI * 2;
+      const segment = { node, a0: cursor, a1: cursor + span };
+      cursor += span;
+      return segment;
+    });
+
+    const ring2Segments = [];
+    ring1Segments.forEach((segment) => {
+      const children = childrenOf(segment.node.id);
+      const total = children.reduce((sum, child) => sum + child.value, 0) || 1;
+      let childCursor = segment.a0;
+      children.forEach((child) => {
+        const span = (child.value / total) * (segment.a1 - segment.a0);
+        ring2Segments.push({ parent: segment, node: child, a0: childCursor, a1: childCursor + span });
+        childCursor += span;
+      });
+    });
+
+    ring1Segments.forEach((segment) => {
+      const color = seriesColor(segment.node.series);
+      const path = createSVG('path', {
+        d: arcPath(cx, cy, inner1, outer1, segment.a0, segment.a1),
+        fill: hexToRgba(color, 0.9),
+        stroke: colors.bg,
+        'stroke-width': (1.2 * scale).toFixed(3)
+      });
+      svg.appendChild(path);
+
+      const mid = (segment.a0 + segment.a1) / 2;
+      const pos = labelAt(cx, cy, (inner1 + outer1) / 2, mid);
+      const text = createSVG('text', {
+        x: pos.x,
+        y: pos.y - 6 * scale,
+        fill: colors.text,
+        'text-anchor': 'middle',
+        'dominant-baseline': 'middle',
+        'font-size': fontSize(22, 16),
+        'font-weight': '800',
+        'paint-order': 'stroke',
+        stroke: textStroke,
+        'stroke-width': Math.max(0.45, 0.6 * scale).toFixed(3)
+      });
+      text.appendChild(document.createTextNode(segment.node.label));
+      if (segment.node.subtitle) {
+        const subtitle = createSVG('tspan', {
+          x: pos.x,
+          dy: `${17 * scale}`,
+          'font-size': fontSize(15, 13),
+          'font-weight': '600',
+          fill: colors.subtext
+        }, document.createTextNode(segment.node.subtitle));
+        text.appendChild(subtitle);
+      }
+      svg.appendChild(text);
+    });
+
+    ring2Segments.forEach((segment) => {
+      const parentColor = seriesColor(segment.parent.node.series);
+      const path = createSVG('path', {
+        d: arcPath(cx, cy, inner2, outer2, segment.a0, segment.a1),
+        fill: hexToRgba(parentColor, 0.78),
+        stroke: colors.bg,
+        'stroke-width': (1.1 * scale).toFixed(3)
+      });
+      svg.appendChild(path);
+
+      const mid = (segment.a0 + segment.a1) / 2;
+      const radius = (inner2 + outer2) / 2;
+      const center = labelAt(cx, cy, radius, mid);
+      const label = createSVG('text', {
+        x: center.x,
+        y: center.y - 2 * scale,
+        fill: colors.text,
+        'text-anchor': 'middle',
+        'dominant-baseline': 'middle',
+        'font-size': fontSize(20, 15),
+        'font-weight': '700',
+        'paint-order': 'stroke',
+        stroke: textStroke,
+        'stroke-width': Math.max(0.4, 0.52 * scale).toFixed(3)
+      });
+      label.appendChild(document.createTextNode(segment.node.abbr || segment.node.label));
+      const stat = segment.node.stat || (segment.node.subtitle ? segment.node.subtitle.replace(/[^0-9.]+/g, '') : '');
+      if (stat) {
+        label.appendChild(createSVG('tspan', {
+          x: center.x,
+          dy: `${15 * scale}`,
+          'font-size': fontSize(16, 13),
+          'font-weight': '600',
+          fill: colors.subtext
+        }, document.createTextNode(`${stat} yrs`)));
+      }
+      svg.appendChild(label);
+    });
+
+    const centerCircle = createSVG('circle', {
+      cx,
+      cy,
+      r: centerRadius,
+      fill: '#111628',
+      stroke: colors.bg,
+      'stroke-width': (1.2 * scale).toFixed(3)
+    });
+    svg.appendChild(centerCircle);
+
+    const titleTop = createSVG('text', {
+      x: cx,
+      y: cy - 20 * scale,
+      fill: colors.text,
+      'font-size': fontSize(22, 17),
+      'font-weight': '800',
+      'text-anchor': 'middle',
+      'paint-order': 'stroke',
+      stroke: textStroke,
+      'stroke-width': Math.max(0.45, 0.6 * scale).toFixed(3)
+    }, document.createTextNode('Mean | Λ'));
+    svg.appendChild(titleTop);
+
+    const titleBottom = createSVG('text', {
+      x: cx,
+      y: cy + 4 * scale,
+      fill: colors.text,
+      'font-size': fontSize(20, 15),
+      'font-weight': '800',
+      'text-anchor': 'middle',
+      'paint-order': 'stroke',
+      stroke: textStroke,
+      'stroke-width': Math.max(0.45, 0.6 * scale).toFixed(3)
+    }, document.createTextNode('Mode | M'));
+    svg.appendChild(titleBottom);
+
+    if (root?.subtitle) {
+    svg.appendChild(createSVG('text', {
+      x: cx,
+      y: cy + 30 * scale,
+      fill: colors.subtext,
+      'font-size': fontSize(14, 12),
+      'font-weight': '600',
+      'text-anchor': 'middle'
+    }, document.createTextNode(root.subtitle)));
+    }
+
+    container.innerHTML = '';
+    container.appendChild(svg);
+  }
+
+  function renderSyopDistribution() {
+    const container = document.getElementById('syop-distribution-chart');
+    if (!container) return;
+    container.innerHTML = '';
+
+    const legend = createEl('div', { class: 'syop-distribution-legend' });
+    SYOP_SERIES.forEach((series) => {
+      legend.appendChild(createEl('span', { class: 'legend-item' },
+        createEl('span', { class: 'legend-swatch', style: { backgroundColor: series.color } }),
+        createEl('span', { class: 'legend-label' }, series.label)
+      ));
+    });
+    container.appendChild(legend);
+
+    const containerWidth = container.clientWidth || 0;
+    const fallbackWidth = 340;
+    const width = containerWidth > 0 ? containerWidth : fallbackWidth;
+    const height = width < 520 ? 300 : 340;
+    const margin = width < 520
+      ? { top: 60, right: 18, bottom: 58, left: 54 }
+      : { top: 66, right: 26, bottom: 64, left: 70 };
+    const chartWidth = width - margin.left - margin.right;
+    const chartHeight = height - margin.top - margin.bottom;
+
+    const svg = createSVG('svg', {
+      viewBox: `0 0 ${width} ${height}`,
+      width: String(width),
+      height: String(height)
+    });
+
+    const g = createSVG('g', { transform: `translate(${margin.left},${margin.top})` });
+    svg.appendChild(g);
+
+    const maxValue = Math.max(...SYOP_DATA.map((row) => Math.max(...SYOP_SERIES.map((series) => row[series.key] || 0))));
+    const niceMax = Math.max(10, Math.ceil(maxValue / 5) * 5);
+    const yTicks = [];
+    for (let value = 0; value <= niceMax + 0.0001; value += 5) {
+      yTicks.push(value);
+    }
+
+    yTicks.forEach((tick) => {
+      const y = chartHeight - (tick / niceMax) * chartHeight;
+      g.appendChild(createSVG('line', {
+        x1: 0,
+        x2: chartWidth,
+        y1: y,
+        y2: y,
+        stroke: tick === 0 ? 'rgba(255,255,255,0.22)' : colors.grid
+      }));
+      g.appendChild(createSVG('text', {
+        x: -14,
+        y: y + 4,
+        fill: colors.subtext,
+        'font-size': '12',
+        'text-anchor': 'end'
+      }, document.createTextNode(`${tick}%`)));
+    });
+
+    const stepX = chartWidth / (SYOP_DATA.length - 1 || 1);
+    SYOP_DATA.forEach((row, index) => {
+      const x = index * stepX;
+      g.appendChild(createSVG('text', {
+        x,
+        y: chartHeight + 28,
+        fill: colors.subtext,
+        'font-size': '12',
+        'text-anchor': 'middle'
+      }, document.createTextNode(row.SYOP)));
+    });
+
+    const dotRadius = width < 560 ? 3.8 : 4.4;
+
+    SYOP_SERIES.forEach((series) => {
+      const points = SYOP_DATA.map((row, index) => ({
+        x: index * stepX,
+        y: chartHeight - (row[series.key] / niceMax) * chartHeight,
+        value: row[series.key]
+      }));
+
+      const path = createSVG('path', {
+        d: catmullRomPath(points),
+        fill: 'none',
+        stroke: series.color,
+        'stroke-width': '3.2',
+        'stroke-linecap': 'round'
+      });
+      g.appendChild(path);
+
+      points.forEach((point) => {
+        g.appendChild(createSVG('circle', {
+          cx: point.x,
+          cy: point.y,
+          r: String(dotRadius),
+          fill: colors.bg,
+          stroke: series.color,
+          'stroke-width': '2'
+        }));
+        g.appendChild(createSVG('text', {
+          x: point.x,
+          y: point.y - (width < 520 ? 10 : 12),
+          fill: colors.text,
+          stroke: 'rgba(11, 14, 22, 0.65)',
+          'stroke-width': '0.6',
+          'font-size': '10',
+          'font-weight': '600',
+          'text-anchor': 'middle'
+        }, document.createTextNode(`${point.value.toFixed(1)}%`)));
+      });
+    });
+
+    g.appendChild(createSVG('line', {
+      x1: 0,
+      x2: chartWidth,
+      y1: chartHeight,
+      y2: chartHeight,
+      stroke: 'rgba(255,255,255,0.22)'
+    }));
+
+    container.appendChild(svg);
+  }
+
+  function renderGauges() {
+    const container = document.getElementById('syop-gauges');
+    if (!container) return;
+    container.innerHTML = '';
+
+    GAUGES.forEach((gauge) => {
+      const gaugeWrapper = createEl('div', { class: 'syop-gauge-card' });
+      const svg = renderGaugeSVG(gauge);
+      const label = createEl('div', { class: 'syop-gauge-label' },
+        createEl('span', { class: 'gauge-value', style: { color: gauge.color } }, gauge.key),
+        createEl('span', { class: 'gauge-title', style: { color: colors.subtext } }, 'Avg SYOP (yrs)')
+      );
+      gaugeWrapper.appendChild(svg);
+      gaugeWrapper.appendChild(label);
+      container.appendChild(gaugeWrapper);
+    });
+  }
+
+  function renderGaugeSVG(gauge) {
+    const min = 2;
+    const max = 8;
+    const width = 236;
+    const height = 148;
+    const cx = width / 2;
+    const cy = height - 16;
+    const radius = 104;
+    const trackWidth = 18;
+
+    const start = -Math.PI;
+    const end = 0;
+    const map = (value) => start + ((value - min) / (max - min)) * (end - start);
+    const valueAngle = map(Math.max(min, Math.min(max, gauge.value)));
+
+    const svg = createSVG('svg', {
+      viewBox: `0 0 ${width} ${height}`,
+      class: 'syop-gauge-svg'
+    });
+
+    const defs = createSVG('defs');
+    const gradient = createSVG('linearGradient', {
+      id: `gauge-gradient-${gauge.key}`,
+      x1: '0',
+      y1: '1',
+      x2: '1',
+      y2: '0'
+    });
+    gradient.appendChild(createSVG('stop', { offset: '0%', 'stop-color': hexToRgba(gauge.color, 0.4) }));
+    gradient.appendChild(createSVG('stop', { offset: '100%', 'stop-color': gauge.color }));
+    defs.appendChild(gradient);
+    svg.appendChild(defs);
+
+    const track = createSVG('path', {
+      d: describeArc(cx, cy, radius, start, end),
+      stroke: 'rgba(31, 36, 55, 0.8)',
+      'stroke-width': trackWidth,
+      'stroke-linecap': 'round',
+      fill: 'none'
+    });
+    svg.appendChild(track);
+
+    const valuePath = createSVG('path', {
+      d: describeArc(cx, cy, radius, start, valueAngle),
+      stroke: `url(#gauge-gradient-${gauge.key})`,
+      'stroke-width': trackWidth,
+      'stroke-linecap': 'round',
+      fill: 'none'
+    });
+    svg.appendChild(valuePath);
+
+    const ticks = [2, 3.5, 5, 6.5, 8];
+    ticks.forEach((tick) => {
+      const angle = map(tick);
+      const inner = polar(cx, cy, radius - trackWidth / 2 - 4, angle);
+      const outer = polar(cx, cy, radius + trackWidth / 2 + 4, angle);
+      const line = createSVG('line', {
+        x1: inner.x,
+        y1: inner.y,
+        x2: outer.x,
+        y2: outer.y,
+        stroke: 'rgba(255,255,255,0.7)',
+        'stroke-width': '1.5'
+      });
+      svg.appendChild(line);
+
+      const label = createSVG('text', {
+        x: outer.x,
+        y: outer.y - 6,
+        fill: colors.subtext,
+        'font-size': '11',
+        'text-anchor': 'middle'
+      }, document.createTextNode(tick.toString()));
+      svg.appendChild(label);
+    });
+
+    const valueText = createSVG('text', {
+      x: cx,
+      y: cy - 40,
+      fill: colors.text,
+      'font-size': '44',
+      'font-weight': '700',
+      'text-anchor': 'middle',
+      'paint-order': 'stroke',
+      stroke: 'rgba(11, 14, 22, 0.68)',
+      'stroke-width': '0.7'
+    }, document.createTextNode(gauge.value.toFixed(2)));
+    svg.appendChild(valueText);
+
+    svg.appendChild(createSVG('text', {
+      x: cx,
+      y: cy - 12,
+      fill: colors.subtext,
+      'font-size': '13',
+      'font-weight': '600',
+      'text-anchor': 'middle'
+    }, document.createTextNode('yrs')));
+
+    return svg;
+  }
+
+  function describeArc(cx, cy, radius, a0, a1) {
+    const start = polar(cx, cy, radius, a0);
+    const end = polar(cx, cy, radius, a1);
+    const large = a1 - a0 > Math.PI ? 1 : 0;
+    return `M ${start.x} ${start.y} A ${radius} ${radius} 0 ${large} 1 ${end.x} ${end.y}`;
+  }
+
+  function renderDraftOverall() {
+    const container = document.getElementById('draft-overall-chart');
+    if (!container) return;
+    container.innerHTML = '';
+
+    const containerWidth = container.clientWidth || 0;
+    const fallbackWidth = 360;
+    const width = containerWidth > 0 ? containerWidth : fallbackWidth;
+    const height = width < 520 ? 270 : 320;
+    const margin = width < 520
+      ? { top: 26, right: 14, bottom: 48, left: 46 }
+      : { top: 32, right: 24, bottom: 56, left: 60 };
+    const chartWidth = width - margin.left - margin.right;
+    const chartHeight = height - margin.top - margin.bottom;
+    const svg = createSVG('svg', {
+      viewBox: `0 0 ${width} ${height}`,
+      width: String(width),
+      height: String(height)
+    });
+
+    const defs = createSVG('defs');
+    const gradient = createSVG('linearGradient', { id: 'draft-bar-fill', x1: '0', x2: '0', y1: '0', y2: '1' });
+    gradient.appendChild(createSVG('stop', { offset: '0%', 'stop-color': colors.accentA }));
+    gradient.appendChild(createSVG('stop', { offset: '100%', 'stop-color': colors.accentC }));
+    defs.appendChild(gradient);
+    svg.appendChild(defs);
+
+    const g = createSVG('g', { transform: `translate(${margin.left},${margin.top})` });
+    svg.appendChild(g);
+
+    const groupWidth = chartWidth / DRAFT_OVERALL.length;
+    const maxValue = Math.max(...DRAFT_OVERALL.map((row) => row.hit));
+    const niceMax = Math.ceil(maxValue / 10) * 10;
+
+    const ticks = [];
+    for (let value = 0; value <= niceMax + 0.0001; value += 10) {
+      ticks.push(value);
+    }
+
+    ticks.forEach((tick) => {
+      const y = chartHeight - (tick / niceMax) * chartHeight;
+      g.appendChild(createSVG('line', {
+        x1: 0,
+        x2: chartWidth,
+        y1: y,
+        y2: y,
+        stroke: tick === 0 ? 'rgba(255,255,255,0.16)' : colors.grid
+      }));
+      g.appendChild(createSVG('text', {
+        x: -12,
+        y: y + 4,
+        fill: colors.subtext,
+        'font-size': '12',
+        'text-anchor': 'end'
+      }, document.createTextNode(`${tick}%`)));
+    });
+
+    DRAFT_OVERALL.forEach((row, index) => {
+      const baseX = index * groupWidth;
+      const barWidth = Math.min(54, groupWidth * 0.62);
+      const barHeight = (row.hit / niceMax) * chartHeight;
+      const y = chartHeight - barHeight;
+      const rect = createSVG('rect', {
+        x: baseX + (groupWidth - barWidth) / 2,
+        y,
+        width: barWidth,
+        height: Math.max(0, barHeight),
+        fill: 'url(#draft-bar-fill)',
+        rx: 12,
+        ry: 12,
+        opacity: '0.95'
+      });
+      g.appendChild(rect);
+
+      g.appendChild(createSVG('text', {
+        x: baseX + groupWidth / 2,
+        y: y - 8,
+        fill: colors.text,
+        'font-size': '12',
+        'text-anchor': 'middle',
+        'font-weight': '600'
+      }, document.createTextNode(`${row.hit.toFixed(1)}%`)));
+
+      g.appendChild(createSVG('text', {
+        x: baseX + groupWidth / 2,
+        y: chartHeight + 26,
+        fill: colors.subtext,
+        'font-size': '12',
+        'text-anchor': 'middle'
+      }, document.createTextNode(`RD ${row.rd}`)));
+    });
+
+    g.appendChild(createSVG('line', {
+      x1: 0,
+      x2: chartWidth,
+      y1: chartHeight,
+      y2: chartHeight,
+      stroke: 'rgba(255,255,255,0.2)'
+    }));
+
+    g.appendChild(createSVG('text', {
+      x: chartWidth / 2,
+      y: chartHeight + 42,
+      fill: colors.subtext,
+      'font-size': '12',
+      'text-anchor': 'middle'
+    }, document.createTextNode('Draft Round')));
+
+    container.appendChild(svg);
+
+    const tiles = document.getElementById('draft-round-tiles');
+    if (tiles) {
+      tiles.innerHTML = '';
+      DRAFT_OVERALL.forEach((row) => {
+        const tile = createEl('div', { class: 'draft-tile' },
+          createEl('span', { class: 'draft-tile-round' }, row.rd),
+          createEl('span', { class: 'draft-tile-value' }, `${row.hit.toFixed(1)}%`)
+        );
+        tiles.appendChild(tile);
+      });
+    }
+  }
+
+  function catmullRomPath(points) {
+    if (points.length === 0) return '';
+    if (points.length === 1) return `M ${points[0].x} ${points[0].y}`;
+    const segments = [`M ${points[0].x} ${points[0].y}`];
+    for (let i = 0; i < points.length - 1; i++) {
+      const p0 = points[i - 1] || points[i];
+      const p1 = points[i];
+      const p2 = points[i + 1];
+      const p3 = points[i + 2] || p2;
+      const cp1x = p1.x + (p2.x - p0.x) / 6;
+      const cp1y = p1.y + (p2.y - p0.y) / 6;
+      const cp2x = p2.x - (p3.x - p1.x) / 6;
+      const cp2y = p2.y - (p3.y - p1.y) / 6;
+      segments.push(`C ${cp1x} ${cp1y}, ${cp2x} ${cp2y}, ${p2.x} ${p2.y}`);
+    }
+    return segments.join(' ');
+  }
+
+  function renderDraftPositional() {
+    const container = document.getElementById('draft-positional-chart');
+    if (!container) return;
+    container.innerHTML = '';
+
+    const legend = createEl('div', { class: 'syop-line-legend' });
+    DRAFT_SERIES.forEach((series) => {
+      legend.appendChild(createEl('span', { class: 'legend-item' },
+        createEl('span', { class: 'legend-swatch', style: { backgroundColor: series.color } }),
+        createEl('span', { class: 'legend-label' }, series.key)
+      ));
+    });
+    container.appendChild(legend);
+
+    const containerWidth = container.clientWidth || 0;
+    const fallbackWidth = 360;
+    const width = containerWidth > 0 ? containerWidth : fallbackWidth;
+    const height = width < 540 ? 300 : 360;
+    const margin = width < 540
+      ? { top: 52, right: 20, bottom: 48, left: 54 }
+      : { top: 52, right: 28, bottom: 56, left: 68 };
+    const chartWidth = width - margin.left - margin.right;
+    const chartHeight = height - margin.top - margin.bottom;
+    const svg = createSVG('svg', {
+      viewBox: `0 0 ${width} ${height}`,
+      width: String(width),
+      height: String(height)
+    });
+
+    const g = createSVG('g', { transform: `translate(${margin.left},${margin.top})` });
+    svg.appendChild(g);
+
+    const rounds = DRAFT_POSITIONAL.map((row) => row.rd);
+    const stepX = chartWidth / (rounds.length - 1 || 1);
+    const yTicks = [0, 20, 40, 60, 80, 100];
+
+    yTicks.forEach((tick) => {
+      const y = chartHeight - (tick / 100) * chartHeight;
+      g.appendChild(createSVG('line', {
+        x1: 0,
+        x2: chartWidth,
+        y1: y,
+        y2: y,
+        stroke: tick === 0 ? 'rgba(255,255,255,0.16)' : colors.grid
+      }));
+      g.appendChild(createSVG('text', {
+        x: -12,
+        y: y + 4,
+        fill: colors.subtext,
+        'font-size': '12',
+        'text-anchor': 'end'
+      }, document.createTextNode(`${tick}%`)));
+    });
+
+    rounds.forEach((round, index) => {
+      const x = index * stepX;
+      g.appendChild(createSVG('text', {
+        x,
+        y: chartHeight + 28,
+        fill: colors.subtext,
+        'font-size': '12',
+        'text-anchor': 'middle'
+      }, document.createTextNode(`RD ${round}`)));
+    });
+
+    const dotRadius = width < 560 ? 3.6 : 4.4;
+
+    DRAFT_SERIES.forEach((series) => {
+      const points = DRAFT_POSITIONAL.map((row, index) => ({
+        x: index * stepX,
+        y: chartHeight - (row[series.key] / 100) * chartHeight,
+        value: row[series.key]
+      }));
+
+      const path = createSVG('path', {
+        d: catmullRomPath(points),
+        fill: 'none',
+        stroke: series.color,
+        'stroke-width': '3',
+        'stroke-linecap': 'round'
+      });
+      g.appendChild(path);
+
+      points.forEach((point) => {
+        g.appendChild(createSVG('circle', {
+          cx: point.x,
+          cy: point.y,
+          r: String(dotRadius),
+          fill: colors.bg,
+          stroke: series.color,
+          'stroke-width': '2'
+        }));
+        g.appendChild(createSVG('text', {
+          x: point.x,
+          y: point.y - (width < 560 ? 9 : 11),
+          fill: colors.text,
+          'font-size': '10',
+          'text-anchor': 'middle'
+        }, document.createTextNode(`${point.value}%`)));
+      });
+    });
+
+    g.appendChild(createSVG('line', {
+      x1: 0,
+      x2: chartWidth,
+      y1: chartHeight,
+      y2: chartHeight,
+      stroke: 'rgba(255,255,255,0.18)'
+    }));
+
+    container.appendChild(svg);
+  }
+
+  function handleResize() {
+    if (document.body.dataset.page !== PAGE_ID) return;
+    if (resizeTimer) {
+      window.clearTimeout(resizeTimer);
+    }
+    resizeTimer = window.setTimeout(() => {
+      renderSunburst();
+      renderSyopDistribution();
+      renderGauges();
+      renderDraftOverall();
+      renderDraftPositional();
+    }, 180);
+  }
+
+  function setupTabs() {
+    const tabs = Array.from(document.querySelectorAll('.syop-tab'));
+    if (tabs.length === 0) return;
+
+    const panels = new Map();
+    tabs.forEach((tab) => {
+      const target = tab.dataset.target;
+      if (target) {
+        const panel = document.getElementById(target);
+        if (panel) {
+          panels.set(target, panel);
+        }
+      }
+    });
+
+    const activate = (tab, { focusTab } = { focusTab: false }) => {
+      tabs.forEach((btn) => {
+        const isActive = btn === tab;
+        btn.classList.toggle('active', isActive);
+        btn.setAttribute('aria-selected', String(isActive));
+        btn.setAttribute('tabindex', isActive ? '0' : '-1');
+        const target = btn.dataset.target;
+        const panel = target ? panels.get(target) : null;
+        if (panel) {
+          if (isActive) {
+            panel.classList.add('active');
+            panel.removeAttribute('hidden');
+          } else {
+            panel.classList.remove('active');
+            panel.setAttribute('hidden', '');
+          }
+        }
+      });
+      if (focusTab) {
+        tab.focus();
+      }
+
+      window.requestAnimationFrame(() => {
+        if (tab.dataset.target === 'draft-tab-panel') {
+          renderDraftOverall();
+          renderDraftPositional();
+        } else {
+          renderSunburst();
+          renderSyopDistribution();
+          renderGauges();
+        }
+      });
+    };
+
+    tabs.forEach((tab, index) => {
+      tab.addEventListener('click', () => activate(tab, { focusTab: false }));
+      tab.addEventListener('keydown', (event) => {
+        if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+          event.preventDefault();
+          const delta = event.key === 'ArrowRight' ? 1 : -1;
+          const nextIndex = (index + delta + tabs.length) % tabs.length;
+          activate(tabs[nextIndex], { focusTab: true });
+        }
+      });
+    });
+
+    const currentActive = tabs.find((tab) => tab.classList.contains('active')) || tabs[0];
+    if (currentActive) {
+      activate(currentActive, { focusTab: false });
+    }
+  }
+
+  function applyUsernameFromQuery() {
+    const input = document.getElementById('usernameInput');
+    if (!input) return;
+    const params = new URLSearchParams(window.location.search);
+    const uname = params.get('username');
+    if (uname) {
+      input.value = uname;
+    }
+  }
+
+  function init() {
+    if (document.body.dataset.page !== PAGE_ID) return;
+    applyUsernameFromQuery();
+    setupTabs();
+    renderSunburst();
+    renderSyopDistribution();
+    renderGauges();
+    renderDraftOverall();
+    renderDraftPositional();
+    window.addEventListener('resize', handleResize);
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/DH_P3-5.21Gb/styles/styles.css
+++ b/DH_P3-5.21Gb/styles/styles.css
@@ -254,7 +254,8 @@
         }
 
         #primary-header-row .menu-container,
-        #secondary-header-row .analyzer-button-container {
+        #secondary-header-row .analyzer-button-container,
+        #secondary-header-row .research-button-container {
             width: var(--header-icon-size);
             height: var(--header-control-height);
             display: flex;
@@ -306,6 +307,13 @@
             font-weight: 500;
             line-height: 1;
             color: inherit;
+        }
+        #secondary-header-row .research-button .research-icon {
+            color: var(--color-accent-secondary);
+        }
+        #secondary-header-row .research-button:hover .research-icon,
+        #secondary-header-row .research-button:focus-visible .research-icon {
+            color: var(--color-text-primary);
         }
         #secondary-header-row .analyzer-button:hover .analyzer-icon,
         #secondary-header-row .analyzer-button:focus-visible .analyzer-icon {
@@ -4097,3 +4105,621 @@ img.team-logo.glow[alt="WAS"] {
 
 
 
+
+/* =========================
+   SYOP PAGE LAYOUT & VISUALS
+   ========================= */
+body[data-page="syop"] {
+  background-color: #0a0f1e;
+}
+
+body[data-page="syop"] .app-header {
+  margin-bottom: 1.05rem;
+}
+
+.syop-main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding-bottom: 1.5rem;
+}
+
+.syop-hero {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0.9rem 1rem;
+  background: radial-gradient(circle at 20% 18%, rgba(96, 165, 250, 0.18), transparent 58%),
+              radial-gradient(circle at 82% 56%, rgba(192, 132, 252, 0.2), transparent 68%),
+              rgba(18, 21, 38, 0.78);
+  border: 1px solid rgba(132, 146, 255, 0.16);
+  border-radius: 20px;
+  box-shadow: 0 14px 28px rgba(7, 10, 20, 0.5);
+}
+
+.syop-hero-intro {
+  flex: 1 1 250px;
+  min-width: 210px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.syop-hero-summary {
+  flex: 1 1 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  align-items: stretch;
+}
+
+.syop-hero h1 {
+  font-size: clamp(1.85rem, 1.5rem + 1.3vw, 2.45rem);
+  margin: 0.35rem 0 0.15rem;
+  letter-spacing: -0.02em;
+}
+
+.syop-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.32rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(15, 18, 32, 0.6);
+  letter-spacing: 0.24em;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  color: rgba(182, 185, 214, 0.85);
+}
+
+
+.syop-key-grid {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.syop-hero-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.28rem;
+  padding: 0.7rem 0.9rem;
+  border-radius: 14px;
+  background: rgba(12, 15, 28, 0.78);
+  border: 1px solid rgba(132, 146, 255, 0.14);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.syop-hero-card .label {
+  font-size: 0.68rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(182, 185, 214, 0.75);
+}
+
+.syop-hero-card .value {
+  font-size: 0.92rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: #f4f6ff;
+}
+
+
+.syop-hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  padding: 0.45rem 0.6rem;
+  border-radius: 12px;
+  background: rgba(15, 18, 32, 0.72);
+  border: 1px solid rgba(132, 146, 255, 0.1);
+}
+
+.syop-hero-meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.32rem;
+  padding: 0.22rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(20, 24, 40, 0.8);
+  border: 1px solid rgba(132, 146, 255, 0.14);
+  color: rgba(226, 232, 240, 0.88);
+  font-size: 0.74rem;
+  line-height: 1.3;
+}
+
+.syop-hero-meta-item .meta-label {
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-size: 0.62rem;
+  color: rgba(182, 185, 214, 0.75);
+}
+
+.syop-hero-meta-item .meta-value {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  font-size: 0.8rem;
+}
+
+.syop-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  align-self: stretch;
+  justify-content: center;
+  gap: 0.3rem;
+  padding: 0.1rem;
+  border-radius: 12px;
+  background: rgba(12, 15, 28, 0.72);
+  border: 1px solid rgba(132, 146, 255, 0.16);
+  box-shadow: 0 10px 20px rgba(5, 8, 16, 0.42);
+}
+
+.syop-tab {
+  flex: 1 1 200px;
+  border: none;
+  border-radius: 10px;
+  padding: 0.45rem 0.7rem;
+  background: transparent;
+  color: rgba(182, 185, 214, 0.82);
+  font-size: 0.86rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: background 0.2s ease, color 0.2s ease;
+  cursor: pointer;
+}
+
+.syop-tab:hover,
+.syop-tab:focus {
+  color: #f5f7ff;
+}
+
+.syop-tab:focus-visible {
+  outline: 2px solid rgba(70, 231, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.syop-tab.active {
+  background: linear-gradient(120deg, rgba(70, 231, 255, 0.25), rgba(255, 65, 225, 0.22));
+  color: #f5f7ff;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+}
+
+.syop-tab-panels {
+  width: 100%;
+}
+
+.syop-tab-panel {
+  display: none;
+  width: 100%;
+}
+
+.syop-tab-panel.active {
+  display: flex;
+}
+
+.syop-tab-panel[hidden] {
+  display: none !important;
+}
+
+.syop-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.syop-section-heading h2 {
+  font-size: clamp(1.4rem, 1.1rem + 0.8vw, 1.95rem);
+  margin: 0;
+}
+
+.syop-section-heading p {
+  margin: 0.15rem 0 0;
+  color: rgba(182, 185, 214, 0.8);
+  max-width: 60ch;
+}
+
+.syop-panels-grid {
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.syop-panel {
+  position: relative;
+  padding: 1rem;
+  background: rgba(18, 21, 38, 0.78);
+  border-radius: 18px;
+  border: 1px solid rgba(132, 146, 255, 0.16);
+  box-shadow: 0 14px 32px rgba(4, 7, 16, 0.48);
+  backdrop-filter: blur(12px);
+}
+
+.syop-panel header h3 {
+  font-size: 1rem;
+  margin: 0;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #f4f5fb;
+}
+
+.syop-panel header p {
+  margin: 0.3rem 0 0.7rem;
+  color: rgba(182, 185, 214, 0.8);
+  font-size: 0.88rem;
+}
+
+.syop-panel-wide {
+  grid-column: span 1;
+}
+
+.syop-panel-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.syop-gauges {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.65rem;
+  padding: 0.95rem;
+}
+
+.syop-gauge-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 0.65rem 0.85rem;
+  border-radius: 16px;
+  background: rgba(15, 18, 32, 0.78);
+  border: 1px solid rgba(132, 146, 255, 0.14);
+}
+
+.syop-gauge-label {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.12rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.62rem;
+}
+
+.syop-gauge-svg {
+  width: 100%;
+  height: auto;
+}
+
+.syop-gauge-label .gauge-value {
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+.syop-chart {
+  width: 100%;
+  min-height: 220px;
+}
+
+.syop-chart svg {
+  width: 100%;
+  height: auto;
+}
+
+.syop-chart svg text,
+.syop-sunburst-svg text {
+  font-family: inherit;
+  font-variant-numeric: tabular-nums;
+}
+
+.syop-distribution-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-bottom: 0.6rem;
+  justify-content: center;
+}
+
+.syop-sunburst-svg {
+  width: 100%;
+  height: auto;
+  max-width: 540px;
+  margin: 0 auto;
+  overflow: visible;
+}
+
+.syop-empty-state {
+  margin: 2rem auto;
+  text-align: center;
+  color: rgba(233, 236, 249, 0.8);
+}
+
+.syop-highlight-list,
+.syop-qa-list {
+  display: grid;
+  gap: 0.85rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.syop-highlight-list li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.65rem;
+  align-items: baseline;
+  color: rgba(233, 236, 249, 0.82);
+  font-size: 0.95rem;
+}
+
+.syop-highlight-list .highlight-label {
+  font-weight: 600;
+}
+
+.syop-qa-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.65rem 0.85rem;
+  border-radius: 14px;
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
+}
+
+.syop-qa-list .qa-name {
+  font-weight: 600;
+}
+
+.syop-qa-list .qa-status {
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+.syop-qa-list .qa-pass {
+  background: rgba(16, 94, 72, 0.35);
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  color: rgba(212, 255, 230, 0.92);
+}
+
+.syop-qa-list .qa-fail {
+  background: rgba(127, 29, 29, 0.35);
+  border: 1px solid rgba(239, 68, 68, 0.32);
+  color: rgba(255, 228, 230, 0.9);
+}
+
+.syop-footnote {
+  margin: 0.4rem 0 0;
+  font-size: 0.82rem;
+  color: rgba(182, 185, 214, 0.75);
+  text-align: center;
+}
+
+.syop-bottom-keys {
+  display: grid;
+  gap: 0.6rem;
+  margin-top: 1.05rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.syop-key-chip {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 14px;
+  background: rgba(12, 15, 28, 0.78);
+  border: 1px solid rgba(132, 146, 255, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.syop-key-chip .key-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(182, 185, 214, 0.76);
+}
+
+.syop-key-chip .key-value {
+  font-size: 0.9rem;
+  line-height: 1.35;
+  color: #f4f6ff;
+}
+
+.syop-line-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  margin-bottom: 0.75rem;
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: rgba(233, 236, 249, 0.85);
+}
+
+.legend-swatch {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 999px;
+}
+
+.draft-round-tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.6rem;
+  margin-top: 0.75rem;
+}
+
+.draft-tile {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 16px;
+  background: rgba(17, 20, 35, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.draft-tile-round {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  background: rgba(9, 11, 24, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.draft-tile-value {
+  font-weight: 600;
+  color: #e9ecf9;
+}
+
+.syop-chart-footnote {
+  margin: 0.25rem 0 0;
+  font-size: 0.8rem;
+  color: rgba(182, 185, 214, 0.78);
+}
+
+.draft-pill {
+  align-self: center;
+  padding: 0.55rem 1.6rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(70, 231, 255, 0.24), rgba(255, 65, 225, 0.24));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  letter-spacing: 0.22em;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: rgba(233, 236, 249, 0.92);
+  text-align: center;
+}
+
+/* Responsive refinements */
+@media (min-width: 1024px) {
+  .syop-panel-wide {
+    grid-column: span 2;
+  }
+
+  .syop-lower-panels {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .syop-draft-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .syop-hero {
+    padding: 0.9rem 1rem 1rem;
+    gap: 0.65rem;
+  }
+
+  .syop-hero-card {
+    padding: 0.68rem 0.85rem;
+  }
+
+  .syop-hero-card .value {
+    font-size: 0.88rem;
+  }
+
+  .syop-hero-meta {
+    gap: 0.35rem;
+    padding: 0.45rem 0.55rem;
+  }
+
+  .syop-hero-meta-item {
+    flex: 1 1 100%;
+    justify-content: space-between;
+  }
+
+  .syop-tabs {
+    padding: 0.12rem;
+  }
+
+  .syop-tab {
+    flex: 1 1 150px;
+    font-size: 0.82rem;
+  }
+
+  .syop-panel,
+  .syop-gauges {
+    padding: 0.85rem 0.9rem;
+  }
+}
+
+@media (max-width: 540px) {
+  .syop-hero {
+    padding: 0.85rem 0.85rem 0.95rem;
+  }
+
+  .syop-hero-summary {
+    gap: 0.5rem;
+  }
+
+  .syop-hero-card {
+    padding: 0.6rem 0.75rem;
+  }
+
+  .syop-hero-card .label {
+    font-size: 0.6rem;
+    letter-spacing: 0.15em;
+  }
+
+  .syop-hero-card .value {
+    font-size: 0.82rem;
+  }
+
+  .syop-hero-meta {
+    gap: 0.3rem;
+    padding: 0.4rem 0.5rem;
+  }
+
+  .syop-hero-meta-item {
+    padding: 0.22rem 0.55rem;
+    font-size: 0.72rem;
+  }
+
+  .syop-hero-meta-item .meta-label {
+    font-size: 0.58rem;
+  }
+
+  .syop-tab {
+    flex: 1 1 135px;
+    padding: 0.38rem 0.58rem;
+    font-size: 0.78rem;
+  }
+
+  .syop-panel,
+  .syop-gauges {
+    padding: 0.7rem 0.78rem;
+  }
+
+  .syop-section-heading p {
+    font-size: 0.88rem;
+  }
+
+  .syop-chart {
+    min-height: 200px;
+  }
+
+  .syop-line-legend {
+    justify-content: center;
+  }
+
+  .draft-pill {
+    width: 100%;
+  }
+
+  .syop-bottom-keys {
+    grid-template-columns: 1fr;
+  }
+}

--- a/DH_P3-5.21Gb/syop/syop.html
+++ b/DH_P3-5.21Gb/syop/syop.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>SYOP Analytics • Dynasty Hub</title>
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@200;300;400;500;600;700&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Product+Sans:wght@100;200;300;400;500;700;900&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css?family=Google+Sans:100,200,300,400,500,600,700" rel="stylesheet"/>
+<link href="../manifest.webmanifest?v=20250827002411?v=20250826235225" rel="manifest"/>
+<link rel="apple-touch-icon" sizes="180x180" href="../assets/icons/apple-touch-icon-180.png?v=20250827002411?v=20250826235225" />
+<meta content="#0D0E1B" name="theme-color"/>
+<link href="../styles/styles.css?v=20250827002411?v=20250826235225" rel="stylesheet"/>
+<script src="https://cdn.tailwindcss.com"></script>
+<link rel="icon" type="image/png" sizes="32x32" href="../assets/icons/favicon-32.png?v=20250827002411?v=20250826235225" />
+<link rel="icon" type="image/png" sizes="16x16" href="../assets/icons/favicon-16.png?v=20250827002411?v=20250826235225" />
+<link rel="shortcut icon" href="../assets/icons/favicon.ico?v=20250827002411?v=20250826235225" />
+</head>
+<body data-page="syop" class="p-2 sm:p-4">
+<div aria-hidden="true" id="starfield">
+  <div id="stars"></div>
+  <div id="stars1"></div>
+  <div id="stars2"></div>
+  <div id="stars3"></div>
+</div>
+<div id="noise-overlay"></div>
+<div class="relative z-10 content-wrapper">
+  <div id="header-container">
+    <header class="app-header glass-panel">
+      <div class="header-row">
+        <div class="menu-container">
+          <button id="menu-button" class="menu-button" aria-label="Toggle navigation">
+            <svg viewBox="0 0 100 80" width="20" height="20" aria-hidden="true">
+              <rect width="100" height="15"></rect>
+              <rect y="30" width="100" height="15"></rect>
+              <rect y="60" width="100" height="15"></rect>
+            </svg>
+          </button>
+          <div id="dropdown-menu" class="dropdown-menu hidden">
+            <a href="../index.html">Home</a>
+            <a href="#" id="menu-rosters">Rosters</a>
+            <a href="#" id="menu-ownership">Ownership</a>
+            <a href="#" id="menu-analyzer">League Analyzer</a>
+            <a href="#" id="menu-syop" class="active">SYOP</a>
+          </div>
+        </div>
+        <div class="username-area">
+          <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
+        </div>
+        <div class="app-view-switcher primary-switcher">
+          <button id="fetchRostersButton">Rosters</button>
+          <button id="fetchOwnershipButton">Ownership %</button>
+        </div>
+      </div>
+    </header>
+  </div>
+  <main class="container mx-auto syop-main" id="content">
+    <div class="syop-tabs" role="tablist" aria-label="SYOP dashboards">
+      <button class="syop-tab active" id="syop-tab-button" type="button" role="tab" aria-selected="true" tabindex="0" data-target="syop-tab-panel">SYOP</button>
+      <button class="syop-tab" id="draft-tab-button" type="button" role="tab" aria-selected="false" tabindex="-1" data-target="draft-tab-panel">NFL Draft &mdash; Player Hit Rates</button>
+    </div>
+
+    <div class="syop-tab-panels">
+      <section class="syop-section syop-tab-panel active" id="syop-tab-panel" role="tabpanel" aria-labelledby="syop-tab-button">
+        <section class="syop-hero">
+          <div class="syop-hero-intro">
+            <div class="syop-pill">Dynasty Hub Research</div>
+            <h1>Significant Years of Production (SYOP)</h1>
+          </div>
+          <div class="syop-hero-summary">
+            <div class="syop-hero-meta">
+              <div class="syop-hero-meta-item">
+                <span class="meta-label">Sample</span>
+                <span class="meta-value">297 players &bull; 2008 &ndash; 2018</span>
+              </div>
+              <div class="syop-hero-meta-item">
+                <span class="meta-label">Qualification</span>
+                <span class="meta-value">Met positional SYOP + BoA thresholds</span>
+              </div>
+              <div class="syop-hero-meta-item">
+                <span class="meta-label">Benchmarks</span>
+                <span class="meta-value">QB ≥ 179 &bull; RB ≥ 182 &bull; WR ≥ 176 &bull; TE ≥ 161</span>
+              </div>
+              <div class="syop-hero-meta-item">
+                <span class="meta-label">Derived Insight</span>
+                <span class="meta-value">Derived from average minimum QB2, RB2, WR2, TE1 PPR production.</span>
+              </div>
+            </div>
+          </div>
+        </section>
+        <div class="syop-section-heading">
+          <h2 id="syop-infographic-heading">SYOP Infographic</h2>
+          <p>Position-specific longevity with interactive distributions and streamlined visual summaries.</p>
+        </div>
+        <div class="syop-panels-grid">
+          <article class="syop-panel" id="syop-sunburst-panel">
+            <header>
+              <h3>AVG [Mean | Λ] · Majority [Mode | M]</h3>
+              <p>(per-position breakdown)</p>
+            </header>
+            <div id="syop-sunburst" class="syop-panel-body"></div>
+          </article>
+          <article class="syop-panel syop-panel-wide" id="syop-distribution-panel">
+            <header>
+              <h3>Positional SYOP Distribution</h3>
+              <p>(Share of players within each SYOP bucket)</p>
+            </header>
+            <div class="syop-panel-body">
+              <div class="syop-chart" id="syop-distribution-chart" role="img" aria-label="SYOP positional distribution chart"></div>
+            </div>
+          </article>
+        </div>
+        <div class="syop-panel syop-gauges" id="syop-gauges" aria-label="Average SYOP gauges"></div>
+        <p class="syop-footnote">Data sourced from Dynasty Hub SYOP research feeds. Visualization rebuilt for the League HQ experience.</p>
+        <div class="syop-bottom-keys" aria-label="SYOP key definitions">
+          <div class="syop-key-chip">
+            <span class="key-label">SYOP [S]</span>
+            <span class="key-value">Significant Year(s) of Production</span>
+          </div>
+          <div class="syop-key-chip">
+            <span class="key-label">BoA [B]</span>
+            <span class="key-value">Breakout &mdash; player&rsquo;s initial SYOP</span>
+          </div>
+          <div class="syop-key-chip">
+            <span class="key-label">Mean [Λ]</span>
+            <span class="key-value">Average qualifying production span</span>
+          </div>
+          <div class="syop-key-chip">
+            <span class="key-label">Mode [M]</span>
+            <span class="key-value">Most frequent season count</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="syop-section syop-tab-panel" id="draft-tab-panel" role="tabpanel" aria-labelledby="draft-tab-button" hidden>
+        <div class="syop-section-heading">
+          <h2 id="draft-data-heading">NFL Draft &mdash; Player Hit Rates</h2>
+          <p>Overall and positional hit probabilities across draft rounds.</p>
+        </div>
+        <div class="syop-panels-grid syop-draft-grid">
+          <article class="syop-panel" id="draft-overall-panel">
+            <header>
+              <h3>Overall Hit Probability</h3>
+              <p>All positions &times; round</p>
+            </header>
+            <div class="syop-panel-body">
+              <div class="syop-chart" id="draft-overall-chart" role="img" aria-label="Overall draft hit probability bar chart"></div>
+              <div class="draft-round-tiles" id="draft-round-tiles"></div>
+            </div>
+          </article>
+          <article class="syop-panel" id="draft-positional-panel">
+            <header>
+              <h3>Positional Hit Rate Trends by Round</h3>
+              <p>Exact percentages by position and draft round</p>
+            </header>
+            <div class="syop-panel-body">
+              <div class="syop-chart" id="draft-positional-chart" role="img" aria-label="Positional draft hit rate line chart"></div>
+              <p class="syop-chart-footnote">Values reflect provided hit-rate percentages for each round.</p>
+            </div>
+          </article>
+        </div>
+        <div class="draft-pill">HIT RATE &bull; All Positions &amp; By Position</div>
+      </section>
+    </div>
+  </main>
+</div>
+<script defer src="../scripts/app.js?v=20250826235225"></script>
+<script defer src="../scripts/syop.js?v=20250826235225"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- tighten the SYOP hero layout, move the glossary chips to the footer, and add derived benchmarking context for quicker scanning
- replace the positional bar chart with a mobile-friendly multi-line distribution, enlarge sunburst and gauge typography, and refresh the color palette
- add a Research shortcut in the roster header that links directly to the SYOP page while hardening compare-button guards for pages without it

## Testing
- node --check scripts/syop.js

------
https://chatgpt.com/codex/tasks/task_e_68ce50ecbf90832e9fecd2f495a6e6c8