### PR TITLE
Adjust SYOP dashboard layout for mobile

### DIFF
--- a/P30920/scripts/syop.js
+++ b/P30920/scripts/syop.js
@@ -59,10 +59,10 @@
   ];
 
   const GAUGES = [
-    { key: 'TE', value: 4.0, color: colors.te },
+    { key: 'QB', value: 7.22, color: colors.qb },
     { key: 'RB', value: 3.39, color: colors.rb },
     { key: 'WR', value: 4.9, color: colors.wr },
-    { key: 'QB', value: 7.22, color: colors.qb }
+    { key: 'TE', value: 4.0, color: colors.te }
   ];
 
   const DRAFT_OVERALL = [
@@ -227,7 +227,7 @@
       height: String(size),
       class: 'syop-sunburst-svg',
       role: 'img',
-      'aria-labelledby': 'syop-infographic-heading'
+      'aria-label': 'SYOP positional production summary'
     });
 
     let cursor = startAngle;
@@ -276,17 +276,6 @@
         'font-family': '"Quicksand", "Product Sans", sans-serif'
       });
       text.appendChild(document.createTextNode(segment.node.label));
-      if (segment.node.subtitle) {
-        const subtitle = createSVG('tspan', {
-          x: pos.x,
-          dy: `${18 * scale}`,
-          'font-size': fontSize(14, 12.5),
-          'font-weight': '600',
-          fill: colors.subtext,
-          'font-family': '"Quicksand", "Product Sans", sans-serif'
-        }, document.createTextNode(segment.node.subtitle));
-        text.appendChild(subtitle);
-      }
       svg.appendChild(text);
     });
 
@@ -319,14 +308,21 @@
       label.appendChild(document.createTextNode(segment.node.abbr || segment.node.label));
       const stat = segment.node.stat || (segment.node.subtitle ? segment.node.subtitle.replace(/[^0-9.]+/g, '') : '');
       if (stat) {
+        const statNumber = Number(stat);
+        const statLabel = Number.isFinite(statNumber)
+          ? statNumber.toFixed(1)
+          : stat;
         label.appendChild(createSVG('tspan', {
           x: center.x,
-          dy: `${18 * scale}`,
-          'font-size': fontSize(16, 13.5),
-          'font-weight': '700',
-          fill: colors.subtext,
+          dy: `${20 * scale}`,
+          'font-size': fontSize(18, 15),
+          'font-weight': '800',
+          fill: colors.text,
+          'paint-order': 'stroke',
+          stroke: textStroke,
+          'stroke-width': Math.max(0.4, 0.62 * scale).toFixed(3),
           'font-family': '"Quicksand", "Product Sans", sans-serif'
-        }, document.createTextNode(`${stat} yrs`)));
+        }, document.createTextNode(statLabel)));
       }
       svg.appendChild(label);
     });
@@ -448,7 +444,7 @@
       const svg = renderGaugeSVG(gauge);
       const label = createEl('div', { class: 'syop-gauge-label' },
         createEl('span', { class: 'gauge-value', style: { color: gauge.color } }, gauge.key),
-        createEl('span', { class: 'gauge-title', style: { color: colors.subtext } }, 'Avg SYOP (yrs)')
+        createEl('span', { class: 'gauge-title', style: { color: colors.subtext } }, 'AVG SYOP (YRS)')
       );
       gaugeWrapper.appendChild(svg);
       gaugeWrapper.appendChild(label);
@@ -552,7 +548,7 @@
       'font-size': '15',
       'font-weight': '700',
       'text-anchor': 'middle'
-    }, document.createTextNode('yrs')));
+    }, document.createTextNode('YRS')));
 
     return svg;
   }

--- a/P30920/styles/styles.css
+++ b/P30920/styles/styles.css
@@ -4384,11 +4384,12 @@ body[data-page="syop"] .app-header {
   gap: 0.55rem;
 }
 
+
 .syop-gauges {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.75rem;
-  padding: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+  padding: 1.1rem;
   background: rgba(18, 21, 38, 0.78);
   border-radius: 16px;
   border: 1px solid rgba(132, 146, 255, 0.16);
@@ -4400,16 +4401,16 @@ body[data-page="syop"] .app-header {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.45rem;
 }
 
 .syop-gauge-label {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.1rem;
+  gap: 0.14rem;
   text-transform: uppercase;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.22em;
   font-size: 0.62rem;
 }
 
@@ -4421,6 +4422,12 @@ body[data-page="syop"] .app-header {
 .syop-gauge-label .gauge-value {
   font-size: 1.05rem;
   font-weight: 700;
+  letter-spacing: 0.14em;
+}
+
+.syop-gauge-label .gauge-title {
+  font-size: 0.6rem;
+  letter-spacing: 0.28em;
 }
 
 .syop-bar-controls {
@@ -4510,7 +4517,7 @@ body[data-page="syop"] .app-header {
 
 .syop-heatmap-scroll {
   width: 100%;
-  overflow-x: auto;
+  overflow-x: hidden;
   padding-bottom: 0.35rem;
 }
 
@@ -4524,10 +4531,11 @@ body[data-page="syop"] .app-header {
 }
 
 .syop-heatmap {
-  min-width: 520px;
+  min-width: 0;
+  width: 100%;
   display: grid;
-  gap: 0.35rem;
-  padding: 0.65rem;
+  gap: 0.28rem;
+  padding: 0.55rem;
   background: rgba(12, 15, 28, 0.72);
   border-radius: 14px;
   border: 1px solid rgba(132, 146, 255, 0.14);
@@ -4536,8 +4544,8 @@ body[data-page="syop"] .app-header {
 
 .syop-heatmap-row {
   display: grid;
-  grid-template-columns: minmax(56px, 0.75fr) repeat(4, minmax(100px, 1fr));
-  gap: 0.35rem;
+  grid-template-columns: minmax(48px, 0.75fr) repeat(4, minmax(72px, 1fr));
+  gap: 0.28rem;
   align-items: stretch;
 }
 
@@ -4848,23 +4856,37 @@ body[data-page="syop"] .app-header {
     font-size: 0.8rem;
   }
 
-  .syop-panel,
-  .syop-gauges {
+  .syop-panel {
     padding: 0.8rem;
   }
 
+  .syop-gauges {
+    padding: 0.85rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.85rem;
+  }
+
+  .syop-gauge-svg {
+    max-width: 230px;
+  }
+
   .syop-heatmap {
-    min-width: 480px;
-    padding: 0.55rem;
-    gap: 0.3rem;
+    min-width: 0;
+    padding: 0.48rem;
+    gap: 0.26rem;
+  }
+
+  .syop-heatmap-row {
+    grid-template-columns: minmax(44px, 0.7fr) repeat(4, minmax(60px, 1fr));
   }
 
   .syop-heatmap-cell {
-    min-height: 44px;
+    min-height: 42px;
+    padding: 0.42rem 0.36rem;
   }
 
   .syop-heatmap-cell.value-cell {
-    font-size: 0.84rem;
+    font-size: 0.82rem;
   }
 
   .syop-key-legend {
@@ -4914,33 +4936,61 @@ body[data-page="syop"] .app-header {
     font-size: 0.76rem;
   }
 
-  .syop-panel,
-  .syop-gauges {
+  .syop-panel {
     padding: 0.72rem;
   }
 
-  .syop-section-heading p {
-    font-size: 0.86rem;
+  .syop-gauges {
+    padding: 0.78rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+  }
+
+  .syop-gauge-svg {
+    max-width: 210px;
+  }
+
+  .syop-gauge-label .gauge-value {
+    font-size: 0.98rem;
   }
 
   .syop-heatmap {
-    min-width: 440px;
-    padding: 0.45rem;
+    min-width: 0;
+    padding: 0.4rem;
+  }
+
+  .syop-heatmap-row {
+    grid-template-columns: minmax(40px, 0.68fr) repeat(4, minmax(52px, 1fr));
   }
 
   .syop-heatmap-cell {
-    min-height: 42px;
+    min-height: 40px;
+    padding: 0.36rem 0.3rem;
   }
 
   .syop-heatmap-cell.bucket-cell {
-    font-size: 0.72rem;
+    font-size: 0.7rem;
   }
 
   .syop-heatmap-cell.value-cell {
-    font-size: 0.8rem;
+    font-size: 0.74rem;
+  }
+
+  .syop-heatmap-row.syop-heatmap-header {
+    font-size: 0.64rem;
   }
 
   .syop-key-legend {
     padding: 0.58rem 0.65rem;
+  }
+}
+
+@media (max-width: 400px) {
+  .syop-gauges {
+    grid-template-columns: 1fr;
+  }
+
+  .syop-gauge-svg {
+    max-width: 190px;
   }
 }

--- a/P30920/syop/syop.html
+++ b/P30920/syop/syop.html
@@ -90,10 +90,6 @@
             </div>
           </div>
         </section>
-        <div class="syop-section-heading">
-          <h2 id="syop-infographic-heading">SYOP Infographic</h2>
-          <p>Position-specific longevity with interactive distributions and streamlined visual summaries.</p>
-        </div>
         <div class="syop-panels-grid">
           <article class="syop-panel" id="syop-sunburst-panel">
             <header>


### PR DESCRIPTION
## Summary
- reorder and restyle the SYOP gauge cards to emphasize QB through TE values and tighten the supporting labels
- shrink the positional bucket heatmap and tune breakpoints so it fits small screens without horizontal scrolling
- clarify sunburst labeling by removing redundant subtitles, enlarging the stats, and dropping the "yrs" suffix while also trimming the extra heading copy

## Testing
- not run (static page updates)


------
https://chatgpt.com/codex/tasks/task_e_68cf48d135bc832e9d3f269bd548b1d2