### PR TITLE
Rename SYOP page to Research and refresh visuals

### DIFF
--- a/P30920/analyzer/analyzer.html
+++ b/P30920/analyzer/analyzer.html
@@ -152,7 +152,7 @@
                             <a href="#" id="menu-rosters">Rosters</a>
                             <a href="#" id="menu-ownership">Ownership</a>
         <a href="#" id="menu-analyzer">League Analyzer</a>
-        <a href="#" id="menu-syop">SYOP</a>
+        <a href="#" id="menu-research">Research</a>
                         </div>
                     </div>
                     <div class="username-area">

--- a/P30920/index.html
+++ b/P30920/index.html
@@ -44,7 +44,7 @@
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
         <a href="#" id="menu-analyzer">League Analyzer</a>
-        <a href="#" id="menu-syop">SYOP</a>
+        <a href="#" id="menu-research">Research</a>
     </div>
 </div>
 <div class="username-area">

--- a/P30920/ownership/ownership.html
+++ b/P30920/ownership/ownership.html
@@ -41,7 +41,7 @@
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
         <a href="#" id="menu-analyzer">League Analyzer</a>
-        <a href="#" id="menu-syop">SYOP</a>
+        <a href="#" id="menu-research">Research</a>
     </div>
 </div>
 <div class="username-area">

--- a/P30920/research/research.html
+++ b/P30920/research/research.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>SYOP Analytics • Dynasty Hub</title>
+<title>Research • Dynasty Hub</title>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
 <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@200;300;400;500;600;700&amp;display=swap" rel="stylesheet"/>
@@ -18,7 +18,7 @@
 <link rel="icon" type="image/png" sizes="16x16" href="../assets/icons/favicon-16.png?v=20250827002411?v=20250826235225" />
 <link rel="shortcut icon" href="../assets/icons/favicon.ico?v=20250827002411?v=20250826235225" />
 </head>
-<body data-page="syop" class="p-2 sm:p-4">
+<body data-page="research" class="p-2 sm:p-4">
 <div aria-hidden="true" id="starfield">
   <div id="stars"></div>
   <div id="stars1"></div>
@@ -43,7 +43,7 @@
             <a href="#" id="menu-rosters">Rosters</a>
             <a href="#" id="menu-ownership">Ownership</a>
             <a href="#" id="menu-analyzer">League Analyzer</a>
-            <a href="#" id="menu-syop" class="active">SYOP</a>
+            <a href="#" id="menu-research" class="active">Research</a>
           </div>
         </div>
         <div class="username-area">
@@ -57,8 +57,8 @@
     </header>
   </div>
   <main class="container mx-auto syop-main" id="content">
-    <div class="syop-tabs" role="tablist" aria-label="SYOP dashboards">
-      <button class="syop-tab active" id="syop-tab-button" type="button" role="tab" aria-selected="true" tabindex="0" data-target="syop-tab-panel">SYOP</button>
+    <div class="syop-tabs" role="tablist" aria-label="Research dashboards">
+      <button class="syop-tab active" id="syop-tab-button" type="button" role="tab" aria-selected="true" tabindex="0" data-target="syop-tab-panel">Research</button>
       <button class="syop-tab" id="draft-tab-button" type="button" role="tab" aria-selected="false" tabindex="-1" data-target="draft-tab-panel">NFL Draft &mdash; Player Hit Rates</button>
     </div>
 
@@ -90,19 +90,16 @@
             </div>
           </div>
         </section>
-        <div class="syop-section-heading">
-          <h2 id="syop-infographic-heading">SYOP Infographic</h2>
-          <p>Position-specific longevity with interactive distributions and streamlined visual summaries.</p>
-        </div>
+        <div class="sr-only" id="syop-infographic-heading">Research Infographic</div>
         <div class="syop-panels-grid">
-          <article class="syop-panel" id="syop-sunburst-panel">
+          <article class="syop-panel glass-panel" id="syop-sunburst-panel">
             <header>
               <h3>AVG [Mean | Λ] · Majority [Mode | M]</h3>
               <p>(per-position breakdown)</p>
             </header>
             <div id="syop-sunburst" class="syop-panel-body"></div>
           </article>
-          <article class="syop-panel syop-panel-wide" id="syop-bar-panel">
+          <article class="syop-panel syop-panel-wide glass-panel" id="syop-bar-panel">
             <header>
               <h3>Positional | Significant Years of Production</h3>
               <p>(% of position within each SYOP bucket)</p>
@@ -112,7 +109,7 @@
             </div>
           </article>
         </div>
-        <div class="syop-panel syop-gauges" id="syop-gauges" aria-label="Average SYOP gauges"></div>
+        <div class="syop-panel syop-gauges glass-panel" id="syop-gauges" aria-label="Average SYOP gauges"></div>
         <p class="syop-footnote">Data sourced from Dynasty Hub SYOP research feeds. Visualization rebuilt for the League HQ experience.</p>
         <section class="syop-key-legend" aria-label="SYOP metrics key">
           <div class="syop-key-grid">
@@ -142,7 +139,7 @@
           <p>Overall and positional hit probabilities across draft rounds.</p>
         </div>
         <div class="syop-panels-grid syop-draft-grid">
-          <article class="syop-panel" id="draft-overall-panel">
+          <article class="syop-panel glass-panel" id="draft-overall-panel">
             <header>
               <h3>Overall Hit Probability</h3>
               <p>All positions &times; round</p>
@@ -152,7 +149,7 @@
               <div class="draft-round-tiles" id="draft-round-tiles"></div>
             </div>
           </article>
-          <article class="syop-panel" id="draft-positional-panel">
+          <article class="syop-panel glass-panel" id="draft-positional-panel">
             <header>
               <h3>Positional Hit Rate Trends by Round</h3>
               <p>Exact percentages by position and draft round</p>
@@ -169,6 +166,6 @@
   </main>
 </div>
 <script defer src="../scripts/app.js?v=20250826235225"></script>
-<script defer src="../scripts/syop.js?v=20250826235225"></script>
+<script defer src="../scripts/research.js?v=20250826235225"></script>
 </body>
 </html>

--- a/P30920/rosters/rosters.html
+++ b/P30920/rosters/rosters.html
@@ -43,7 +43,7 @@
         <a href="#" id="menu-rosters">Rosters</a>
         <a href="#" id="menu-ownership">Ownership</a>
         <a href="#" id="menu-analyzer">League Analyzer</a>
-        <a href="#" id="menu-syop">SYOP</a>
+        <a href="#" id="menu-research">Research</a>
     </div>
 </div>
 <div class="username-area">
@@ -74,7 +74,7 @@
 </div>
 <div class="header-row" id="filters-row">
     <div class="research-button-container">
-        <button class="menu-button analyzer-button research-button" id="syopResearchButton" type="button" aria-label="Open SYOP research">
+        <button class="menu-button analyzer-button research-button" id="researchButton" type="button" aria-label="Open Research">
             <i class="fa-solid fa-flask-vial analyzer-icon" aria-hidden="true"></i>
             <span class="analyzer-label">Research</span>
         </button>

--- a/P30920/scripts/app.js
+++ b/P30920/scripts/app.js
@@ -26,7 +26,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const tradeSimulator = document.getElementById('tradeSimulator');
         const mainContent = document.getElementById('content');
         const pageType = document.body.dataset.page || 'welcome';
-        const researchButton = document.getElementById('syopResearchButton');
+        const researchButton = document.getElementById('researchButton');
 
         const gameLogsModal = document.getElementById('game-logs-modal');
         const modalCloseBtn = document.querySelector('.modal-close-btn');
@@ -51,18 +51,18 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const menuRosters = document.getElementById('menu-rosters');
         const menuOwnership = document.getElementById('menu-ownership');
         const menuAnalyzer = document.getElementById('menu-analyzer');
-        const menuSyop = document.getElementById('menu-syop');
+        const menuResearch = document.getElementById('menu-research');
         const analyzeLeagueButton = document.getElementById('analyzeLeagueButton');
-        const resolveSyopUrl = () => {
+        const resolveResearchUrl = () => {
             const username = usernameInput.value.trim();
             const suffix = username ? `?username=${encodeURIComponent(username)}` : '';
             if (pageType === 'welcome') {
-                return `syop/syop.html${suffix}`;
+                return `research/research.html${suffix}`;
             }
-            if (pageType === 'syop') {
-                return `syop/syop.html${suffix}`;
+            if (pageType === 'research') {
+                return `research/research.html${suffix}`;
             }
-            return `../syop/syop.html${suffix}`;
+            return `../research/research.html${suffix}`;
         };
 
         menuButton?.addEventListener('click', (e) => {
@@ -136,21 +136,21 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             dropdownMenu.classList.add('hidden');
         });
 
-        menuSyop?.addEventListener('click', () => {
-            if (pageType === 'syop') {
+        menuResearch?.addEventListener('click', () => {
+            if (pageType === 'research') {
                 dropdownMenu.classList.add('hidden');
                 return;
             }
-            const url = resolveSyopUrl();
+            const url = resolveResearchUrl();
             window.location.href = url;
             dropdownMenu.classList.add('hidden');
         });
 
         researchButton?.addEventListener('click', () => {
-            if (pageType === 'syop') {
+            if (pageType === 'research') {
                 return;
             }
-            const url = resolveSyopUrl();
+            const url = resolveResearchUrl();
             window.location.href = url;
         });
 
@@ -192,7 +192,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 if (!username) return;
                 window.location.href = `ownership/ownership.html?username=${encodeURIComponent(username)}`;
             });
-        } else if (pageType === 'syop') {
+        } else if (pageType === 'research') {
             fetchRostersButton?.addEventListener('click', () => {
                 const username = usernameInput.value.trim();
                 if (!username) return;
@@ -281,7 +281,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         // --- Initialization ---
         document.addEventListener('DOMContentLoaded', async () => {
             if (pageType === 'analyzer') return;
-            if (pageType === 'syop') {
+            if (pageType === 'research') {
                 const params = new URLSearchParams(window.location.search);
                 const uname = params.get('username');
                 if (uname) {

--- a/P30920/scripts/research.js
+++ b/P30920/scripts/research.js
@@ -1,5 +1,5 @@
 (function () {
-  const PAGE_ID = 'syop';
+  const PAGE_ID = 'research';
   const SVG_NS = 'http://www.w3.org/2000/svg';
 
   const colors = {
@@ -17,6 +17,13 @@
     rb: '#3BE6C4',
     wr: '#8B7CFF',
     te: '#FF7AC7'
+  };
+
+  const sunburstPalette = {
+    QB: '#6311ee',
+    RB: '#730fff',
+    WR: '#8021ff',
+    TE: '#922fff'
   };
 
   const SUNBURST_NODES = [
@@ -59,10 +66,10 @@
   ];
 
   const GAUGES = [
-    { key: 'TE', value: 4.0, color: colors.te },
+    { key: 'QB', value: 7.22, color: colors.qb },
     { key: 'RB', value: 3.39, color: colors.rb },
     { key: 'WR', value: 4.9, color: colors.wr },
-    { key: 'QB', value: 7.22, color: colors.qb }
+    { key: 'TE', value: 4.0, color: colors.te }
   ];
 
   const DRAFT_OVERALL = [
@@ -173,18 +180,7 @@
   }
 
   function seriesColor(series) {
-    switch (series) {
-      case 'QB':
-        return colors.qb;
-      case 'RB':
-        return colors.rb;
-      case 'WR':
-        return colors.wr;
-      case 'TE':
-        return colors.te;
-      default:
-        return '#6b7280';
-    }
+    return sunburstPalette[series] || '#6b7280';
   }
 
   function hexToRgba(hex, alpha) {
@@ -194,6 +190,11 @@
     const g = (value >> 8) & 255;
     const b = value & 255;
     return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
+  function stripYearSuffix(text) {
+    if (typeof text !== 'string') return text;
+    return text.replace(/\s*yrs?\.?/gi, '').trim();
   }
 
   function renderSunburst() {
@@ -254,7 +255,7 @@
       const color = seriesColor(segment.node.series);
       const path = createSVG('path', {
         d: arcPath(cx, cy, inner1, outer1, segment.a0, segment.a1),
-        fill: hexToRgba(color, 0.9),
+        fill: color,
         stroke: colors.bg,
         'stroke-width': (1.2 * scale).toFixed(3)
       });
@@ -276,15 +277,16 @@
         'font-family': '"Quicksand", "Product Sans", sans-serif'
       });
       text.appendChild(document.createTextNode(segment.node.label));
-      if (segment.node.subtitle) {
+      const subtitleText = stripYearSuffix(segment.node.subtitle);
+      if (subtitleText && !segment.node.series) {
         const subtitle = createSVG('tspan', {
           x: pos.x,
           dy: `${18 * scale}`,
-          'font-size': fontSize(14, 12.5),
-          'font-weight': '600',
-          fill: colors.subtext,
+          'font-size': fontSize(15, 13),
+          'font-weight': '700',
+          fill: colors.text,
           'font-family': '"Quicksand", "Product Sans", sans-serif'
-        }, document.createTextNode(segment.node.subtitle));
+        }, document.createTextNode(subtitleText));
         text.appendChild(subtitle);
       }
       svg.appendChild(text);
@@ -294,7 +296,7 @@
       const parentColor = seriesColor(segment.parent.node.series);
       const path = createSVG('path', {
         d: arcPath(cx, cy, inner2, outer2, segment.a0, segment.a1),
-        fill: hexToRgba(parentColor, 0.78),
+        fill: hexToRgba(parentColor, 0.5),
         stroke: colors.bg,
         'stroke-width': (1.1 * scale).toFixed(3)
       });
@@ -309,24 +311,28 @@
         fill: colors.text,
         'text-anchor': 'middle',
         'dominant-baseline': 'middle',
-        'font-size': fontSize(20, 14),
-        'font-weight': '700',
+        'font-size': fontSize(22, 15),
+        'font-weight': '800',
         'paint-order': 'stroke',
         stroke: textStroke,
         'stroke-width': Math.max(0.4, 0.6 * scale).toFixed(3),
         'font-family': '"Quicksand", "Product Sans", sans-serif'
       });
       label.appendChild(document.createTextNode(segment.node.abbr || segment.node.label));
-      const stat = segment.node.stat || (segment.node.subtitle ? segment.node.subtitle.replace(/[^0-9.]+/g, '') : '');
+      const statRaw = segment.node.stat || (segment.node.subtitle ? segment.node.subtitle.replace(/[^0-9.]+/g, '') : '');
+      const stat = stripYearSuffix(statRaw);
       if (stat) {
         label.appendChild(createSVG('tspan', {
           x: center.x,
           dy: `${18 * scale}`,
-          'font-size': fontSize(16, 13.5),
-          'font-weight': '700',
-          fill: colors.subtext,
+          'font-size': fontSize(18, 14.5),
+          'font-weight': '800',
+          fill: colors.text,
+          'paint-order': 'stroke',
+          stroke: textStroke,
+          'stroke-width': Math.max(0.35, 0.55 * scale).toFixed(3),
           'font-family': '"Quicksand", "Product Sans", sans-serif'
-        }, document.createTextNode(`${stat} yrs`)));
+        }, document.createTextNode(stat)));
       }
       svg.appendChild(label);
     });
@@ -448,7 +454,7 @@
       const svg = renderGaugeSVG(gauge);
       const label = createEl('div', { class: 'syop-gauge-label' },
         createEl('span', { class: 'gauge-value', style: { color: gauge.color } }, gauge.key),
-        createEl('span', { class: 'gauge-title', style: { color: colors.subtext } }, 'Avg SYOP (yrs)')
+        createEl('span', { class: 'gauge-title', style: { color: colors.subtext } }, 'AVG SYOP (YRS)')
       );
       gaugeWrapper.appendChild(svg);
       gaugeWrapper.appendChild(label);
@@ -534,25 +540,25 @@
 
     const valueText = createSVG('text', {
       x: cx,
-      y: cy - 64,
+      y: cy - 52,
       fill: colors.text,
-      'font-size': '48',
+      'font-size': '44',
       'font-weight': '800',
       'text-anchor': 'middle',
       'paint-order': 'stroke',
-      stroke: 'rgba(11, 14, 22, 0.65)',
-      'stroke-width': '0.72'
+      stroke: 'rgba(11, 14, 22, 0.72)',
+      'stroke-width': '0.75'
     }, document.createTextNode(gauge.value.toFixed(2)));
     svg.appendChild(valueText);
 
     svg.appendChild(createSVG('text', {
       x: cx,
-      y: cy - 28,
+      y: cy - 22,
       fill: colors.subtext,
       'font-size': '15',
       'font-weight': '700',
       'text-anchor': 'middle'
-    }, document.createTextNode('yrs')));
+    }, document.createTextNode('YRS')));
 
     return svg;
   }

--- a/P30920/styles/styles.css
+++ b/P30920/styles/styles.css
@@ -57,6 +57,18 @@
         overflow-x: hidden;
         position: relative;
       }
+
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
       
         button:focus,
         input:focus,
@@ -202,10 +214,10 @@
         -webkit-backdrop-filter: blur(6px) saturate(120%) brightness(120%);
         backdrop-filter: blur(6px) saturate(120%) brightness(120%);
         box-shadow: inset 0 0 0 0px rgba(255,255,255, 0.05), inset 0 0 0 3px rgba(200,200,200, 0.025), 0 10px 26px rgba(0,0,0, var(--outerA, .22));
-        
+
         /* · · Frame · · */
         border: 1px solid rgba(128, 138, 189, 0.2);
-        border-radius: 10px;
+        border-radius: var(--glass-radius, 16px);
         box-shadow: rgba(255, 255, 255, 0.05) 0px 0px 0px 0px inset, rgba(200, 200, 200, 0.025) 0px 0px 0px 3px inset, rgba(0, 0, 0, 0.22) 0px 10px 26px 0px;
         }
 /* ⬇︎  HEADER & CONTROLS (3-ROW REDESIGN)  ⬇︎ */
@@ -4129,11 +4141,11 @@ img.team-logo.glow[alt="WAS"] {
 /* =========================
    SYOP PAGE LAYOUT & VISUALS
    ========================= */
-body[data-page="syop"] {
+body[data-page="research"] {
   background-color: #0a0f1e;
 }
 
-body[data-page="syop"] .app-header {
+body[data-page="research"] .app-header {
   margin-bottom: 1.05rem;
 }
 
@@ -4353,11 +4365,13 @@ body[data-page="syop"] .app-header {
 .syop-panel {
   position: relative;
   padding: 0.85rem;
-  background: rgba(18, 21, 38, 0.78);
   border-radius: 16px;
-  border: 1px solid rgba(132, 146, 255, 0.16);
-  box-shadow: 0 12px 26px rgba(4, 7, 16, 0.44);
-  backdrop-filter: blur(12px);
+  background: transparent;
+}
+
+.syop-panel.glass-panel,
+.syop-gauges.glass-panel {
+  --glass-radius: 16px;
 }
 
 .syop-panel header h3 {
@@ -4386,41 +4400,45 @@ body[data-page="syop"] .app-header {
 
 .syop-gauges {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.75rem;
-  padding: 1rem;
-  background: rgba(18, 21, 38, 0.78);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  padding: 1.1rem 1.25rem 1.2rem;
+  background: transparent;
   border-radius: 16px;
-  border: 1px solid rgba(132, 146, 255, 0.16);
-  box-shadow: 0 12px 26px rgba(4, 7, 16, 0.44);
-  backdrop-filter: blur(12px);
 }
 
 .syop-gauge-card {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.45rem;
+  padding: 0.4rem 0.35rem 0.6rem;
+}
+
+.syop-gauge-svg {
+  width: 100%;
+  height: auto;
+  max-width: 260px;
 }
 
 .syop-gauge-label {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.1rem;
+  gap: 0.15rem;
   text-transform: uppercase;
-  letter-spacing: 0.18em;
-  font-size: 0.62rem;
-}
-
-.syop-gauge-svg {
-  width: 100%;
-  height: auto;
+  letter-spacing: 0.24em;
+  font-size: 0.64rem;
 }
 
 .syop-gauge-label .gauge-value {
-  font-size: 1.05rem;
+  font-size: 1.08rem;
   font-weight: 700;
+}
+
+.syop-gauge-label .gauge-title {
+  font-size: 0.58rem;
+  letter-spacing: 0.32em;
 }
 
 .syop-bar-controls {
@@ -4508,9 +4526,10 @@ body[data-page="syop"] .app-header {
   flex: 1 1 auto;
 }
 
+
 .syop-heatmap-scroll {
   width: 100%;
-  overflow-x: auto;
+  overflow-x: hidden;
   padding-bottom: 0.35rem;
 }
 
@@ -4524,10 +4543,10 @@ body[data-page="syop"] .app-header {
 }
 
 .syop-heatmap {
-  min-width: 520px;
+  width: 100%;
   display: grid;
-  gap: 0.35rem;
-  padding: 0.65rem;
+  gap: 0.3rem;
+  padding: 0.55rem;
   background: rgba(12, 15, 28, 0.72);
   border-radius: 14px;
   border: 1px solid rgba(132, 146, 255, 0.14);
@@ -4536,8 +4555,8 @@ body[data-page="syop"] .app-header {
 
 .syop-heatmap-row {
   display: grid;
-  grid-template-columns: minmax(56px, 0.75fr) repeat(4, minmax(100px, 1fr));
-  gap: 0.35rem;
+  grid-template-columns: minmax(48px, 0.8fr) repeat(4, minmax(0, 1fr));
+  gap: 0.3rem;
   align-items: stretch;
 }
 
@@ -4574,17 +4593,17 @@ body[data-page="syop"] .app-header {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0.55rem 0.6rem;
+  padding: 0.5rem 0.55rem;
   border-radius: 12px;
   background: rgba(12, 15, 28, 0.72);
   border: 1px solid rgba(132, 146, 255, 0.12);
-  min-height: 48px;
+  min-height: 46px;
 }
 
 .syop-heatmap-cell.bucket-cell {
   justify-content: center;
   font-weight: 700;
-  font-size: 0.78rem;
+  font-size: 0.76rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: rgba(182, 185, 214, 0.85);
@@ -4594,7 +4613,7 @@ body[data-page="syop"] .app-header {
 .syop-heatmap-cell.value-cell {
   color: #f5f7ff;
   font-weight: 600;
-  font-size: 0.88rem;
+  font-size: 0.84rem;
   border: 1px solid rgba(132, 146, 255, 0.18);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
 }
@@ -4850,21 +4869,30 @@ body[data-page="syop"] .app-header {
 
   .syop-panel,
   .syop-gauges {
-    padding: 0.8rem;
+    padding: 0.85rem;
+  }
+
+  .syop-gauges {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 0.85rem;
   }
 
   .syop-heatmap {
-    min-width: 480px;
-    padding: 0.55rem;
-    gap: 0.3rem;
+    padding: 0.48rem;
+    gap: 0.28rem;
+  }
+
+  .syop-heatmap-row {
+    grid-template-columns: minmax(42px, 0.75fr) repeat(4, minmax(0, 1fr));
   }
 
   .syop-heatmap-cell {
-    min-height: 44px;
+    min-height: 42px;
+    padding: 0.45rem 0.5rem;
   }
 
   .syop-heatmap-cell.value-cell {
-    font-size: 0.84rem;
+    font-size: 0.8rem;
   }
 
   .syop-key-legend {
@@ -4919,28 +4947,65 @@ body[data-page="syop"] .app-header {
     padding: 0.72rem;
   }
 
+  .syop-gauges {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+  }
+
   .syop-section-heading p {
     font-size: 0.86rem;
   }
 
   .syop-heatmap {
-    min-width: 440px;
-    padding: 0.45rem;
+    padding: 0.42rem;
+  }
+
+  .syop-heatmap-row {
+    grid-template-columns: minmax(38px, 0.7fr) repeat(4, minmax(0, 1fr));
   }
 
   .syop-heatmap-cell {
-    min-height: 42px;
+    min-height: 40px;
+    padding: 0.42rem 0.46rem;
   }
 
   .syop-heatmap-cell.bucket-cell {
-    font-size: 0.72rem;
+    font-size: 0.7rem;
   }
 
   .syop-heatmap-cell.value-cell {
-    font-size: 0.8rem;
+    font-size: 0.76rem;
   }
 
   .syop-key-legend {
     padding: 0.58rem 0.65rem;
+  }
+}
+
+@media (max-width: 380px) {
+  .syop-gauges {
+    grid-template-columns: 1fr;
+    gap: 0.65rem;
+  }
+
+  .syop-gauge-label .gauge-value {
+    font-size: 1rem;
+  }
+
+  .syop-gauge-label .gauge-title {
+    letter-spacing: 0.28em;
+  }
+
+  .syop-heatmap-row {
+    grid-template-columns: minmax(34px, 0.65fr) repeat(4, minmax(0, 1fr));
+  }
+
+  .syop-heatmap-cell {
+    padding: 0.38rem 0.42rem;
+    min-height: 38px;
+  }
+
+  .syop-heatmap-cell.value-cell {
+    font-size: 0.72rem;
   }
 }


### PR DESCRIPTION
## Summary
- rename the former SYOP page and navigation entries to "Research" while updating routing helpers
- apply the shared glass panel treatment to all Research tab panels and keep responsive two-across gauges
- restore the original sunburst palette with half-opacity leaves and lower the gauge value readouts for the requested spacing tweaks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf48d135bc832e9d3f269bd548b1d2