### PR TITLE
Refine research charts and header layout

### DIFF
--- a/P30920/analyzer/analyzer.html
+++ b/P30920/analyzer/analyzer.html
@@ -10,6 +10,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;700&family=Product+Sans:wght@400;700&display=swap" rel="stylesheet">
     <link href="../styles/styles.css?v=20250827002411?v=20250826235225" rel="stylesheet"/>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"/>
     <style>
         :root {
             --font-sans: 'Product Sans', 'Google Sans', 'Quicksand', sans-serif;
@@ -148,11 +149,26 @@
                             </svg>
                         </button>
                         <div id="dropdown-menu" class="dropdown-menu hidden">
-                            <a href="../">Home</a>
-                            <a href="#" id="menu-rosters">Rosters</a>
-                            <a href="#" id="menu-ownership">Ownership</a>
-        <a href="#" id="menu-analyzer">League Analyzer</a>
-        <a href="#" id="menu-syop">SYOP</a>
+                            <a href="../">
+                                <i class="fa-solid fa-house-user" aria-hidden="true"></i>
+                                <span>Home</span>
+                            </a>
+                            <a href="#" id="menu-rosters">
+                                <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
+                                <span>Rosters</span>
+                            </a>
+                            <a href="#" id="menu-ownership">
+                                <i class="fa-solid fa-percent" aria-hidden="true"></i>
+                                <span>Ownership</span>
+                            </a>
+            <a href="#" id="menu-analyzer">
+                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+                <span>League Analyzer</span>
+            </a>
+            <a href="#" id="menu-research">
+                <i class="fa-solid fa-flask" aria-hidden="true"></i>
+                <span>Research</span>
+            </a>
                         </div>
                     </div>
                     <div class="username-area">

--- a/P30920/index.html
+++ b/P30920/index.html
@@ -13,7 +13,7 @@
 <link href="manifest.webmanifest?v=20250827002411?v=20250826235225" rel="manifest"/><link rel="apple-touch-icon" sizes="180x180" href="assets/icons/apple-touch-icon-180.png?v=20250827002411?v=20250826235225" /><meta content="#0D0E1B" name="theme-color"/><link href="styles/styles.css?v=20250827002411?v=20250826235225" rel="stylesheet"/><script src="https://cdn.tailwindcss.com"></script>  <link rel="icon" type="image/png" sizes="32x32" href="assets/icons/favicon-32.png?v=20250827002411?v=20250826235225" />
   <link rel="icon" type="image/png" sizes="16x16" href="assets/icons/favicon-16.png?v=20250827002411?v=20250826235225" />
   <link rel="shortcut icon" href="assets/icons/favicon.ico?v=20250827002411?v=20250826235225" />
-<link rel="stylesheet"
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"/>
 
 
 </head>
@@ -40,11 +40,26 @@
         </svg>
     </button>
     <div id="dropdown-menu" class="dropdown-menu hidden">
-        <a href="index.html">Home</a>
-        <a href="#" id="menu-rosters">Rosters</a>
-        <a href="#" id="menu-ownership">Ownership</a>
-        <a href="#" id="menu-analyzer">League Analyzer</a>
-        <a href="#" id="menu-syop">SYOP</a>
+        <a href="index.html">
+            <i class="fa-solid fa-house-user" aria-hidden="true"></i>
+            <span>Home</span>
+        </a>
+        <a href="#" id="menu-rosters">
+            <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
+            <span>Rosters</span>
+        </a>
+        <a href="#" id="menu-ownership">
+            <i class="fa-solid fa-percent" aria-hidden="true"></i>
+            <span>Ownership</span>
+        </a>
+        <a href="#" id="menu-analyzer">
+            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+            <span>League Analyzer</span>
+        </a>
+        <a href="#" id="menu-research">
+            <i class="fa-solid fa-flask" aria-hidden="true"></i>
+            <span>Research</span>
+        </a>
     </div>
 </div>
 <div class="username-area">

--- a/P30920/ownership/ownership.html
+++ b/P30920/ownership/ownership.html
@@ -11,8 +11,9 @@
 <link href="https://fonts.googleapis.com/css2?family=Product+Sans:wght@100;200;300;400;500;700;900&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css?family=Google+Sans:100,200,300,400,500,600,700" rel="stylesheet"/>
 <link href="../manifest.webmanifest?v=20250827002411?v=20250826235225" rel="manifest"/><link rel="apple-touch-icon" sizes="180x180" href="../assets/icons/apple-touch-icon-180.png?v=20250827002411?v=20250826235225" /><meta content="#0D0E1B" name="theme-color"/><link href="../styles/styles.css?v=20250827002411?v=20250826235225" rel="stylesheet"/><script src="https://cdn.tailwindcss.com"></script>  <link rel="icon" type="image/png" sizes="32x32" href="../assets/icons/favicon-32.png?v=20250827002411?v=20250826235225" />
-  <link rel="icon" type="image/png" sizes="16x16" href="../assets/icons/favicon-16.png?v=20250827002411?v=20250826235225" />
-  <link rel="shortcut icon" href="../assets/icons/favicon.ico?v=20250827002411?v=20250826235225" />
+<link rel="icon" type="image/png" sizes="16x16" href="../assets/icons/favicon-16.png?v=20250827002411?v=20250826235225" />
+<link rel="shortcut icon" href="../assets/icons/favicon.ico?v=20250827002411?v=20250826235225" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"/>
 </head>
 <body data-page="ownership" class="p-2 sm:p-4">
 <!-- Replaced Background: Starfield -->
@@ -37,11 +38,26 @@
         </svg>
     </button>
     <div id="dropdown-menu" class="dropdown-menu hidden">
-        <a href="../">Home</a>
-        <a href="#" id="menu-rosters">Rosters</a>
-        <a href="#" id="menu-ownership">Ownership</a>
-        <a href="#" id="menu-analyzer">League Analyzer</a>
-        <a href="#" id="menu-syop">SYOP</a>
+        <a href="../">
+            <i class="fa-solid fa-house-user" aria-hidden="true"></i>
+            <span>Home</span>
+        </a>
+        <a href="#" id="menu-rosters">
+            <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
+            <span>Rosters</span>
+        </a>
+        <a href="#" id="menu-ownership">
+            <i class="fa-solid fa-percent" aria-hidden="true"></i>
+            <span>Ownership</span>
+        </a>
+            <a href="#" id="menu-analyzer">
+                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+                <span>League Analyzer</span>
+            </a>
+            <a href="#" id="menu-research">
+                <i class="fa-solid fa-flask" aria-hidden="true"></i>
+                <span>Research</span>
+            </a>
     </div>
 </div>
 <div class="username-area">

--- a/P30920/research/research.html
+++ b/P30920/research/research.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>SYOP Analytics • Dynasty Hub</title>
+<title>Research • Dynasty Hub</title>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
 <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@200;300;400;500;600;700&amp;display=swap" rel="stylesheet"/>
@@ -17,8 +17,9 @@
 <link rel="icon" type="image/png" sizes="32x32" href="../assets/icons/favicon-32.png?v=20250827002411?v=20250826235225" />
 <link rel="icon" type="image/png" sizes="16x16" href="../assets/icons/favicon-16.png?v=20250827002411?v=20250826235225" />
 <link rel="shortcut icon" href="../assets/icons/favicon.ico?v=20250827002411?v=20250826235225" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"/>
 </head>
-<body data-page="syop" class="p-2 sm:p-4">
+<body data-page="research" class="p-2 sm:p-4">
 <div aria-hidden="true" id="starfield">
   <div id="stars"></div>
   <div id="stars1"></div>
@@ -39,11 +40,26 @@
             </svg>
           </button>
           <div id="dropdown-menu" class="dropdown-menu hidden">
-            <a href="../index.html">Home</a>
-            <a href="#" id="menu-rosters">Rosters</a>
-            <a href="#" id="menu-ownership">Ownership</a>
-            <a href="#" id="menu-analyzer">League Analyzer</a>
-            <a href="#" id="menu-syop" class="active">SYOP</a>
+            <a href="../index.html">
+              <i class="fa-solid fa-house-user" aria-hidden="true"></i>
+              <span>Home</span>
+            </a>
+            <a href="#" id="menu-rosters">
+              <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
+              <span>Rosters</span>
+            </a>
+            <a href="#" id="menu-ownership">
+              <i class="fa-solid fa-percent" aria-hidden="true"></i>
+              <span>Ownership</span>
+            </a>
+            <a href="#" id="menu-analyzer">
+              <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+              <span>League Analyzer</span>
+            </a>
+            <a href="#" id="menu-research" class="active">
+              <i class="fa-solid fa-flask" aria-hidden="true"></i>
+              <span>Research</span>
+            </a>
           </div>
         </div>
         <div class="username-area">
@@ -57,7 +73,7 @@
     </header>
   </div>
   <main class="container mx-auto syop-main" id="content">
-    <div class="syop-tabs" role="tablist" aria-label="SYOP dashboards">
+    <div class="syop-tabs" role="tablist" aria-label="Research dashboards">
       <button class="syop-tab active" id="syop-tab-button" type="button" role="tab" aria-selected="true" tabindex="0" data-target="syop-tab-panel">SYOP</button>
       <button class="syop-tab" id="draft-tab-button" type="button" role="tab" aria-selected="false" tabindex="-1" data-target="draft-tab-panel">NFL Draft &mdash; Player Hit Rates</button>
     </div>
@@ -72,37 +88,35 @@
           <div class="syop-hero-summary">
             <div class="syop-hero-meta">
               <div class="syop-hero-meta-item">
-                <span class="meta-label">Sample</span>
+                <span class="meta-label">SAMPLE SIZE AND QUALIFYING YEARS:</span>
                 <span class="meta-value">297 players &bull; 2008 &ndash; 2018</span>
               </div>
               <div class="syop-hero-meta-item">
-                <span class="meta-label">Qualification</span>
-                <span class="meta-value">Met positional SYOP + BoA thresholds</span>
+                <span class="meta-label">QUALIFICATION:</span>
+                <span class="meta-value">Meeting indicated Threshold ≥ 1 time within the qualifying years</span>
               </div>
               <div class="syop-hero-meta-item">
-                <span class="meta-label">Benchmarks</span>
-                <span class="meta-value">QB ≥ 179 &bull; RB ≥ 182 &bull; WR ≥ 176 &bull; TE ≥ 161</span>
+                <span class="meta-label">THRESHOLDS:</span>
+                <span class="meta-value">[PPR FPTS | QB ≥ 179 &bull; RB ≥ 182 &bull; WR ≥ 176 &bull; TE ≥ 161]</span>
               </div>
               <div class="syop-hero-meta-item">
-                <span class="meta-label">Context</span>
-                <span class="meta-value">Derived from average minimum QB2, RB2, WR2, TE1 PPR production.</span>
+                <span class="meta-label">BENCHMARKS:</span>
+                <span class="meta-value">Thresholds from average minimum QB2, RB2, WR2, TE1 PPR production.</span>
               </div>
             </div>
           </div>
         </section>
-        <div class="syop-section-heading">
-          <h2 id="syop-infographic-heading">SYOP Infographic</h2>
-          <p>Position-specific longevity with interactive distributions and streamlined visual summaries.</p>
-        </div>
+        <div class="sr-only" id="syop-infographic-heading">SYOP Infographic</div>
         <div class="syop-panels-grid">
-          <article class="syop-panel" id="syop-sunburst-panel">
+          <article class="syop-panel glass-panel" id="syop-sunburst-panel">
             <header>
               <h3>AVG [Mean | Λ] · Majority [Mode | M]</h3>
               <p>(per-position breakdown)</p>
             </header>
             <div id="syop-sunburst" class="syop-panel-body"></div>
           </article>
-          <article class="syop-panel syop-panel-wide" id="syop-bar-panel">
+          <div class="syop-panel syop-gauges glass-panel" id="syop-gauges" aria-label="Average SYOP gauges"></div>
+          <article class="syop-panel syop-panel-wide glass-panel" id="syop-bar-panel">
             <header>
               <h3>Positional | Significant Years of Production</h3>
               <p>(% of position within each SYOP bucket)</p>
@@ -112,7 +126,6 @@
             </div>
           </article>
         </div>
-        <div class="syop-panel syop-gauges" id="syop-gauges" aria-label="Average SYOP gauges"></div>
         <p class="syop-footnote">Data sourced from Dynasty Hub SYOP research feeds. Visualization rebuilt for the League HQ experience.</p>
         <section class="syop-key-legend" aria-label="SYOP metrics key">
           <div class="syop-key-grid">
@@ -142,7 +155,7 @@
           <p>Overall and positional hit probabilities across draft rounds.</p>
         </div>
         <div class="syop-panels-grid syop-draft-grid">
-          <article class="syop-panel" id="draft-overall-panel">
+          <article class="syop-panel glass-panel" id="draft-overall-panel">
             <header>
               <h3>Overall Hit Probability</h3>
               <p>All positions &times; round</p>
@@ -152,7 +165,7 @@
               <div class="draft-round-tiles" id="draft-round-tiles"></div>
             </div>
           </article>
-          <article class="syop-panel" id="draft-positional-panel">
+          <article class="syop-panel glass-panel" id="draft-positional-panel">
             <header>
               <h3>Positional Hit Rate Trends by Round</h3>
               <p>Exact percentages by position and draft round</p>

--- a/P30920/rosters/rosters.html
+++ b/P30920/rosters/rosters.html
@@ -13,8 +13,7 @@
 <link href="../manifest.webmanifest?v=20250827002411?v=20250826235225" rel="manifest"/><link rel="apple-touch-icon" sizes="180x180" href="../assets/icons/apple-touch-icon-180.png?v=20250827002411?v=20250826235225" /><meta content="#0D0E1B" name="theme-color"/><link href="../styles/styles.css?v=20250827002411?v=20250826235225" rel="stylesheet"/><script src="https://cdn.tailwindcss.com"></script>  <link rel="icon" type="image/png" sizes="32x32" href="../assets/icons/favicon-32.png?v=20250827002411?v=20250826235225" />
   <link rel="icon" type="image/png" sizes="16x16" href="../assets/icons/favicon-16.png?v=20250827002411?v=20250826235225" />
   <link rel="shortcut icon" href="../assets/icons/favicon.ico?v=20250827002411?v=20250826235225" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"> 
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"/>
  </head>
 <body data-page="rosters" class="p-2 sm:p-4">
 <!-- Replaced Background: Starfield -->
@@ -39,13 +38,29 @@
         </svg>
     </button>
     <div id="dropdown-menu" class="dropdown-menu hidden">
-        <a href="../">Home</a>
-        <a href="#" id="menu-rosters">Rosters</a>
-        <a href="#" id="menu-ownership">Ownership</a>
-        <a href="#" id="menu-analyzer">League Analyzer</a>
-        <a href="#" id="menu-syop">SYOP</a>
+        <a href="../">
+            <i class="fa-solid fa-house-user" aria-hidden="true"></i>
+            <span>Home</span>
+        </a>
+        <a href="#" id="menu-rosters">
+            <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
+            <span>Rosters</span>
+        </a>
+        <a href="#" id="menu-ownership">
+            <i class="fa-solid fa-percent" aria-hidden="true"></i>
+            <span>Ownership</span>
+        </a>
+            <a href="#" id="menu-analyzer">
+                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+                <span>League Analyzer</span>
+            </a>
+            <a href="#" id="menu-research">
+                <i class="fa-solid fa-flask" aria-hidden="true"></i>
+                <span>Research</span>
+            </a>
     </div>
 </div>
+<div class="header-quick-links" id="header-quick-links" aria-label="Research shortcuts"></div>
 <div class="username-area">
 <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
 </div>
@@ -56,11 +71,13 @@
 </div>
 <div class="hidden" id="contextual-controls">
 <div class="header-row" id="secondary-header-row">
+<div class="analyzer-button-slot" id="analyzer-button-slot">
 <div class="analyzer-button-container">
-<button aria-label="Open League Analyzer" class="menu-button analyzer-button" id="analyzeLeagueButton" type="button">
-<i class="fa-solid fa-square-poll-vertical analyzer-icon" aria-hidden="true"></i>
-<span class="analyzer-label">Lg.Anlz</span>
-</button>
+    <button aria-label="Open League Analyzer" class="menu-button analyzer-button" id="analyzeLeagueButton" type="button">
+        <i class="fa-solid fa-square-poll-vertical analyzer-icon" aria-hidden="true"></i>
+        <span class="analyzer-label">Analyzer</span>
+    </button>
+</div>
 </div>
 <div class="custom-select-wrapper">
 <select disabled="" id="leagueSelect">
@@ -73,11 +90,13 @@
 </div>
 </div>
 <div class="header-row" id="filters-row">
+    <div class="research-button-slot" id="research-button-slot">
     <div class="research-button-container">
-        <button class="menu-button analyzer-button research-button" id="syopResearchButton" type="button" aria-label="Open SYOP research">
+        <button class="menu-button analyzer-button research-button" id="researchButton" type="button" aria-label="Open Research insights">
             <i class="fa-solid fa-flask-vial analyzer-icon" aria-hidden="true"></i>
             <span class="analyzer-label">Research</span>
         </button>
+    </div>
     </div>
     <div class="filters-container">
         <div id="positional-filters">
@@ -89,8 +108,8 @@
         </div>
         <button class="control-button-subtle" id="clearFiltersButton">
             <span class="clear-filters-stack">
-                <i class="fa-solid fa-filter-circle-xmark"></i>
-                <span class="clear-filters-label">Clear</span>
+                <i class="fa-solid fa-filter-circle-xmark" aria-hidden="true"></i>
+                <span class="sr-only">Clear filters</span>
             </span>
         </button>
 
@@ -100,8 +119,8 @@
             <!-- Clear selections button -->
             <button class="control-button-subtle hidden" id="clearCompareButton" aria-label="Clear selections">
                 <span class="clear-filters-stack">
-                    <i class="fa-regular fa-rectangle-xmark"></i>
-                    <span class="clear-filters-label">Clear</span>
+                    <i class="fa-regular fa-rectangle-xmark" aria-hidden="true"></i>
+                    <span class="sr-only">Clear compare selections</span>
                 </span>
             </button>
         </div>

--- a/P30920/scripts/app.js
+++ b/P30920/scripts/app.js
@@ -26,7 +26,12 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const tradeSimulator = document.getElementById('tradeSimulator');
         const mainContent = document.getElementById('content');
         const pageType = document.body.dataset.page || 'welcome';
-        const researchButton = document.getElementById('syopResearchButton');
+        const researchButton = document.getElementById('researchButton');
+        const headerQuickLinks = document.getElementById('header-quick-links');
+        const analyzerButtonSlot = document.getElementById('analyzer-button-slot');
+        const researchButtonSlot = document.getElementById('research-button-slot');
+        const analyzerButtonContainer = analyzerButtonSlot?.querySelector('.analyzer-button-container') || null;
+        const researchButtonContainer = researchButtonSlot?.querySelector('.research-button-container') || null;
 
         const gameLogsModal = document.getElementById('game-logs-modal');
         const modalCloseBtn = document.querySelector('.modal-close-btn');
@@ -51,18 +56,18 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const menuRosters = document.getElementById('menu-rosters');
         const menuOwnership = document.getElementById('menu-ownership');
         const menuAnalyzer = document.getElementById('menu-analyzer');
-        const menuSyop = document.getElementById('menu-syop');
+        const menuResearch = document.getElementById('menu-research');
         const analyzeLeagueButton = document.getElementById('analyzeLeagueButton');
-        const resolveSyopUrl = () => {
+        const resolveResearchUrl = () => {
             const username = usernameInput.value.trim();
             const suffix = username ? `?username=${encodeURIComponent(username)}` : '';
             if (pageType === 'welcome') {
-                return `syop/syop.html${suffix}`;
+                return `research/research.html${suffix}`;
             }
-            if (pageType === 'syop') {
-                return `syop/syop.html${suffix}`;
+            if (pageType === 'research') {
+                return `research/research.html${suffix}`;
             }
-            return `../syop/syop.html${suffix}`;
+            return `../research/research.html${suffix}`;
         };
 
         menuButton?.addEventListener('click', (e) => {
@@ -136,23 +141,52 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             dropdownMenu.classList.add('hidden');
         });
 
-        menuSyop?.addEventListener('click', () => {
-            if (pageType === 'syop') {
+        menuResearch?.addEventListener('click', () => {
+            if (pageType === 'research') {
                 dropdownMenu.classList.add('hidden');
                 return;
             }
-            const url = resolveSyopUrl();
+            const url = resolveResearchUrl();
             window.location.href = url;
             dropdownMenu.classList.add('hidden');
         });
 
         researchButton?.addEventListener('click', () => {
-            if (pageType === 'syop') {
+            if (pageType === 'research') {
                 return;
             }
-            const url = resolveSyopUrl();
+            const url = resolveResearchUrl();
             window.location.href = url;
         });
+
+        if (headerQuickLinks && analyzerButtonSlot && researchButtonSlot && analyzerButtonContainer && researchButtonContainer) {
+            const quickLinksQuery = window.matchMedia('(min-width: 1024px)');
+            const placeQuickLinks = (isDesktop) => {
+                if (isDesktop) {
+                    if (!headerQuickLinks.contains(analyzerButtonContainer)) {
+                        headerQuickLinks.appendChild(analyzerButtonContainer);
+                    }
+                    if (!headerQuickLinks.contains(researchButtonContainer)) {
+                        headerQuickLinks.appendChild(researchButtonContainer);
+                    }
+                } else {
+                    if (!analyzerButtonSlot.contains(analyzerButtonContainer)) {
+                        analyzerButtonSlot.appendChild(analyzerButtonContainer);
+                    }
+                    if (!researchButtonSlot.contains(researchButtonContainer)) {
+                        researchButtonSlot.appendChild(researchButtonContainer);
+                    }
+                }
+            };
+
+            placeQuickLinks(quickLinksQuery.matches);
+            const quickLinksListener = (event) => placeQuickLinks(event.matches);
+            if (typeof quickLinksQuery.addEventListener === 'function') {
+                quickLinksQuery.addEventListener('change', quickLinksListener);
+            } else if (typeof quickLinksQuery.addListener === 'function') {
+                quickLinksQuery.addListener(quickLinksListener);
+            }
+        }
 
         // --- State ---
         let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), tradeBlock: {}, isTradeCollapsed: false, weeklyStats: {}, playerSeasonStats: {}, playerSeasonRanks: {}, playerWeeklyStats: {}, statsSheetsLoaded: false, seasonRankCache: null, isGameLogModalOpenFromComparison: false };
@@ -192,7 +226,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 if (!username) return;
                 window.location.href = `ownership/ownership.html?username=${encodeURIComponent(username)}`;
             });
-        } else if (pageType === 'syop') {
+        } else if (pageType === 'research') {
             fetchRostersButton?.addEventListener('click', () => {
                 const username = usernameInput.value.trim();
                 if (!username) return;
@@ -281,7 +315,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         // --- Initialization ---
         document.addEventListener('DOMContentLoaded', async () => {
             if (pageType === 'analyzer') return;
-            if (pageType === 'syop') {
+            if (pageType === 'research') {
                 const params = new URLSearchParams(window.location.search);
                 const uname = params.get('username');
                 if (uname) {

--- a/P30920/scripts/syop.js
+++ b/P30920/scripts/syop.js
@@ -1,5 +1,5 @@
 (function () {
-  const PAGE_ID = 'syop';
+  const PAGE_ID = 'research';
   const SVG_NS = 'http://www.w3.org/2000/svg';
 
   const colors = {
@@ -13,10 +13,10 @@
     accentA: '#3BE4E4',
     accentB: '#7C83FF',
     accentC: '#FF75D1',
-    qb: '#FFC857',
-    rb: '#3BE6C4',
-    wr: '#8B7CFF',
-    te: '#FF7AC7'
+    qb: '#6311ee',
+    rb: '#730fff',
+    wr: '#8021ff',
+    te: '#922fff'
   };
 
   const SUNBURST_NODES = [
@@ -59,10 +59,10 @@
   ];
 
   const GAUGES = [
-    { key: 'TE', value: 4.0, color: colors.te },
-    { key: 'RB', value: 3.39, color: colors.rb },
-    { key: 'WR', value: 4.9, color: colors.wr },
-    { key: 'QB', value: 7.22, color: colors.qb }
+    { key: 'QB', value: 7.22, color: colors.qb },
+    { key: 'RB', value: 3.39, color: colors.wr },
+    { key: 'WR', value: 4.9, color: colors.rb },
+    { key: 'TE', value: 4.0, color: colors.te }
   ];
 
   const DRAFT_OVERALL = [
@@ -91,6 +91,13 @@
     { key: 'TE', color: '#9E5AF7' },
     { key: 'WR', color: '#46E7FF' }
   ];
+
+  const SERIES_LABEL_OFFSETS = {
+    QB: { dx: -14, dy: { compact: -10, regular: -12 }, anchor: 'end' },
+    RB: { dx: 14, dy: { compact: -10, regular: -12 }, anchor: 'start' },
+    TE: { dx: -14, dy: { compact: 16, regular: 18 }, anchor: 'end' },
+    WR: { dx: 14, dy: { compact: 16, regular: 18 }, anchor: 'start' }
+  };
 
   const SERIES_CONFIG = [
     { key: 'QB %', label: 'QB %', color: colors.qb },
@@ -196,6 +203,36 @@
     return `rgba(${r}, ${g}, ${b}, ${alpha})`;
   }
 
+  function stripYearSuffix(text) {
+    if (typeof text !== 'string') return text;
+    return text.replace(/\s*yrs?\.?/gi, '').trim();
+  }
+
+  const labelAccent = '#9096C0';
+
+  function positionSyopKeyLegend() {
+    const key = document.querySelector('.syop-key-legend');
+    if (!key) return;
+
+    const panelsGrid = document.querySelector('#syop-tab-panel .syop-panels-grid');
+    const gaugesPanel = document.getElementById('syop-gauges');
+    const barPanel = document.getElementById('syop-bar-panel');
+    const footnote = document.querySelector('.syop-footnote');
+    const desktop = window.matchMedia('(min-width: 1024px)').matches;
+
+    if (desktop && panelsGrid && gaugesPanel && barPanel) {
+      if (key.parentElement !== panelsGrid || key.nextElementSibling !== barPanel) {
+        panelsGrid.insertBefore(key, barPanel);
+      }
+      key.classList.add('syop-key-inline');
+    } else if (footnote && footnote.parentElement) {
+      if (key.parentElement !== footnote.parentElement || footnote.nextElementSibling !== key) {
+        footnote.parentElement.insertBefore(key, footnote.nextElementSibling);
+      }
+      key.classList.remove('syop-key-inline');
+    }
+  }
+
   function renderSunburst() {
     const container = document.getElementById('syop-sunburst');
     if (!container) return;
@@ -209,13 +246,15 @@
     const size = Math.min(baseSize, constrained);
     const rawScale = size / baseSize;
     const scale = Math.pow(rawScale, 0.85);
-    const pad = 52 * scale;
+    const pad = 64 * scale;
     const cx = size / 2;
     const cy = size / 2;
     const inner1 = 104 * scale;
     const outer1 = 178 * scale;
-    const inner2 = 188 * scale;
-    const outer2 = 246 * scale;
+    const inner2 = 184 * scale;
+    const outer2 = 284 * scale;
+    const ring1Opacity = 0.9;
+    const ring2Opacity = 0.5;
     const centerRadius = 94 * scale;
     const textStroke = 'rgba(11, 14, 22, 0.68)';
     const fontSize = (value, floor = 12) => Math.max(value * scale, floor);
@@ -254,7 +293,7 @@
       const color = seriesColor(segment.node.series);
       const path = createSVG('path', {
         d: arcPath(cx, cy, inner1, outer1, segment.a0, segment.a1),
-        fill: hexToRgba(color, 0.9),
+        fill: hexToRgba(color, ring1Opacity),
         stroke: colors.bg,
         'stroke-width': (1.2 * scale).toFixed(3)
       });
@@ -276,15 +315,16 @@
         'font-family': '"Quicksand", "Product Sans", sans-serif'
       });
       text.appendChild(document.createTextNode(segment.node.label));
-      if (segment.node.subtitle) {
+      const subtitleText = stripYearSuffix(segment.node.subtitle);
+      if (subtitleText && !segment.node.series) {
         const subtitle = createSVG('tspan', {
           x: pos.x,
           dy: `${18 * scale}`,
-          'font-size': fontSize(14, 12.5),
-          'font-weight': '600',
-          fill: colors.subtext,
+          'font-size': fontSize(15, 13),
+          'font-weight': '700',
+          fill: colors.text,
           'font-family': '"Quicksand", "Product Sans", sans-serif'
-        }, document.createTextNode(segment.node.subtitle));
+        }, document.createTextNode(subtitleText));
         text.appendChild(subtitle);
       }
       svg.appendChild(text);
@@ -294,7 +334,7 @@
       const parentColor = seriesColor(segment.parent.node.series);
       const path = createSVG('path', {
         d: arcPath(cx, cy, inner2, outer2, segment.a0, segment.a1),
-        fill: hexToRgba(parentColor, 0.78),
+        fill: hexToRgba(parentColor, ring2Opacity),
         stroke: colors.bg,
         'stroke-width': (1.1 * scale).toFixed(3)
       });
@@ -306,27 +346,31 @@
       const label = createSVG('text', {
         x: center.x,
         y: center.y - 2 * scale,
-        fill: colors.text,
+        fill: labelAccent,
         'text-anchor': 'middle',
         'dominant-baseline': 'middle',
-        'font-size': fontSize(20, 14),
-        'font-weight': '700',
+        'font-size': fontSize(22, 15),
+        'font-weight': '800',
         'paint-order': 'stroke',
         stroke: textStroke,
         'stroke-width': Math.max(0.4, 0.6 * scale).toFixed(3),
         'font-family': '"Quicksand", "Product Sans", sans-serif'
       });
       label.appendChild(document.createTextNode(segment.node.abbr || segment.node.label));
-      const stat = segment.node.stat || (segment.node.subtitle ? segment.node.subtitle.replace(/[^0-9.]+/g, '') : '');
+      const statRaw = segment.node.stat || (segment.node.subtitle ? segment.node.subtitle.replace(/[^0-9.]+/g, '') : '');
+      const stat = stripYearSuffix(statRaw);
       if (stat) {
         label.appendChild(createSVG('tspan', {
           x: center.x,
-          dy: `${18 * scale}`,
-          'font-size': fontSize(16, 13.5),
-          'font-weight': '700',
-          fill: colors.subtext,
+          dy: `${26 * scale}`,
+          'font-size': fontSize(20, 16),
+          'font-weight': '800',
+          fill: colors.text,
+          'paint-order': 'stroke',
+          stroke: textStroke,
+          'stroke-width': Math.max(0.42, 0.65 * scale).toFixed(3),
           'font-family': '"Quicksand", "Product Sans", sans-serif'
-        }, document.createTextNode(`${stat} yrs`)));
+        }, document.createTextNode(stat)));
       }
       svg.appendChild(label);
     });
@@ -448,7 +492,7 @@
       const svg = renderGaugeSVG(gauge);
       const label = createEl('div', { class: 'syop-gauge-label' },
         createEl('span', { class: 'gauge-value', style: { color: gauge.color } }, gauge.key),
-        createEl('span', { class: 'gauge-title', style: { color: colors.subtext } }, 'Avg SYOP (yrs)')
+        createEl('span', { class: 'gauge-title', style: { color: colors.subtext } }, 'AVG SYOP (YRS)')
       );
       gaugeWrapper.appendChild(svg);
       gaugeWrapper.appendChild(label);
@@ -534,25 +578,25 @@
 
     const valueText = createSVG('text', {
       x: cx,
-      y: cy - 64,
-      fill: colors.text,
-      'font-size': '48',
+      y: cy - 40,
+      fill: gauge.color,
+      'font-size': '30',
       'font-weight': '800',
       'text-anchor': 'middle',
       'paint-order': 'stroke',
-      stroke: 'rgba(11, 14, 22, 0.65)',
-      'stroke-width': '0.72'
+      stroke: 'rgba(11, 14, 22, 0.72)',
+      'stroke-width': '0.6'
     }, document.createTextNode(gauge.value.toFixed(2)));
     svg.appendChild(valueText);
 
     svg.appendChild(createSVG('text', {
       x: cx,
-      y: cy - 28,
+      y: cy - 16,
       fill: colors.subtext,
-      'font-size': '15',
+      'font-size': '16',
       'font-weight': '700',
       'text-anchor': 'middle'
-    }, document.createTextNode('yrs')));
+    }, document.createTextNode('YRS')));
 
     return svg;
   }
@@ -723,6 +767,7 @@
     const fallbackWidth = 360;
     const width = containerWidth > 0 ? containerWidth : fallbackWidth;
     const height = width < 540 ? 300 : 360;
+    const isCompact = width < 560;
     const margin = width < 540
       ? { top: 52, right: 20, bottom: 48, left: 54 }
       : { top: 52, right: 28, bottom: 56, left: 68 };
@@ -770,13 +815,16 @@
       }, document.createTextNode(`RD ${round}`)));
     });
 
-    const dotRadius = width < 560 ? 3.6 : 4.4;
+    const dotRadius = isCompact ? 3.6 : 4.4;
 
-    DRAFT_SERIES.forEach((series) => {
+    const labelEntries = [];
+
+    DRAFT_SERIES.forEach((series, seriesIndex) => {
       const points = DRAFT_POSITIONAL.map((row, index) => ({
         x: index * stepX,
         y: chartHeight - (row[series.key] / 100) * chartHeight,
-        value: row[series.key]
+        value: row[series.key],
+        roundIndex: index
       }));
 
       const path = createSVG('path', {
@@ -788,6 +836,13 @@
       });
       g.appendChild(path);
 
+      const offsetConfig = SERIES_LABEL_OFFSETS[series.key] || null;
+      const labelAnchor = offsetConfig?.anchor || 'middle';
+      const offsetX = offsetConfig?.dx || 0;
+      const offsetY = offsetConfig
+        ? (isCompact ? offsetConfig.dy.compact : offsetConfig.dy.regular)
+        : (isCompact ? -10 : -12);
+
       points.forEach((point) => {
         g.appendChild(createSVG('circle', {
           cx: point.x,
@@ -797,14 +852,70 @@
           stroke: series.color,
           'stroke-width': '2'
         }));
-        g.appendChild(createSVG('text', {
-          x: point.x,
-          y: point.y - (width < 560 ? 9 : 11),
-          fill: colors.text,
-          'font-size': '10',
-          'text-anchor': 'middle'
-        }, document.createTextNode(`${point.value}%`)));
+        labelEntries.push({
+          series,
+          seriesIndex,
+          point,
+          offsetX,
+          baseOffsetY: offsetY,
+          labelAnchor,
+          fontSize: isCompact ? '9.5' : '10.5',
+          strokeWidth: isCompact ? '0.9' : '1.05',
+          targetY: point.y + offsetY,
+          roundIndex: point.roundIndex
+        });
       });
+    });
+
+    const minSeparation = isCompact ? 11 : 13;
+    const groupsByRound = new Map();
+    labelEntries.forEach((entry) => {
+      const list = groupsByRound.get(entry.roundIndex) || [];
+      list.push(entry);
+      groupsByRound.set(entry.roundIndex, list);
+    });
+
+    const distributeCluster = (cluster) => {
+      if (!cluster || cluster.length < 2) return;
+      const mean = cluster.reduce((sum, entry) => sum + entry.targetY, 0) / cluster.length;
+      const start = mean - (minSeparation * (cluster.length - 1)) / 2;
+      cluster.forEach((entry, index) => {
+        const desired = start + index * minSeparation;
+        entry.adjustedOffsetY = desired - entry.point.y;
+      });
+    };
+
+    groupsByRound.forEach((entries) => {
+      if (entries.length < 2) return;
+      entries.sort((a, b) => a.targetY - b.targetY);
+      let cluster = [entries[0]];
+      for (let i = 1; i < entries.length; i += 1) {
+        const previous = entries[i - 1];
+        const current = entries[i];
+        const gap = current.targetY - previous.targetY;
+        if (gap < minSeparation) {
+          cluster.push(current);
+        } else {
+          distributeCluster(cluster);
+          cluster = [current];
+        }
+      }
+      distributeCluster(cluster);
+    });
+
+    labelEntries.forEach((entry) => {
+      const offsetY = entry.adjustedOffsetY != null ? entry.adjustedOffsetY : entry.baseOffsetY;
+      g.appendChild(createSVG('text', {
+        x: entry.point.x + entry.offsetX,
+        y: entry.point.y + offsetY,
+        fill: entry.series.color,
+        'font-size': entry.fontSize,
+        'font-weight': '700',
+        'text-anchor': entry.labelAnchor,
+        'paint-order': 'stroke',
+        stroke: 'rgba(11, 14, 22, 0.78)',
+        'stroke-width': entry.strokeWidth
+      }, document.createTextNode(`${entry.point.value}%`)));
     });
 
     g.appendChild(createSVG('line', {
@@ -829,6 +940,7 @@
       renderGauges();
       renderDraftOverall();
       renderDraftPositional();
+      positionSyopKeyLegend();
     }, 180);
   }
 
@@ -878,6 +990,7 @@
           renderBarChart();
           renderGauges();
         }
+        positionSyopKeyLegend();
       });
     };
 
@@ -918,6 +1031,7 @@
     renderGauges();
     renderDraftOverall();
     renderDraftPositional();
+    positionSyopKeyLegend();
     window.addEventListener('resize', handleResize);
   }
 

--- a/P30920/styles/styles.css
+++ b/P30920/styles/styles.css
@@ -57,6 +57,18 @@
         overflow-x: hidden;
         position: relative;
       }
+
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
       
         button:focus,
         input:focus,
@@ -254,12 +266,27 @@
         }
 
         #primary-header-row .menu-container,
-        #secondary-header-row .analyzer-button-container {
-            width: var(--header-icon-size);
+        #secondary-header-row .analyzer-button-container,
+        .analyzer-button-slot,
+        .research-button-slot {
+            width: max(var(--header-icon-size), 2.6rem);
             height: var(--header-control-height);
             display: flex;
             align-items: center;
             justify-content: center;
+            flex-shrink: 0;
+        }
+
+        .header-quick-links {
+            display: none;
+            align-items: center;
+            gap: 0.35rem;
+        }
+
+        .header-quick-links .analyzer-button-container,
+        .header-quick-links .research-button-container {
+            width: var(--header-icon-size);
+            height: var(--header-control-height);
         }
 
         #primary-header-row .menu-container {
@@ -279,7 +306,9 @@
             height: 1.25rem;
         }
 
-        #secondary-header-row .analyzer-button {
+        #secondary-header-row .analyzer-button,
+        .header-quick-links .analyzer-button,
+        .header-quick-links .research-button {
             border: none;
             background: transparent;
             color: var(--color-text-secondary);
@@ -291,24 +320,33 @@
             gap: 0.1rem;
         }
 
-        #secondary-header-row .analyzer-button .analyzer-icon {
+        #secondary-header-row .analyzer-button .analyzer-icon,
+        .header-quick-links .analyzer-button .analyzer-icon,
+        .header-quick-links .research-button .analyzer-icon {
             display: block;
             margin: 0;
             line-height: 1;
-            font-size: 1.2rem;
+            font-size: 1.22rem;
         }
 
-        #secondary-header-row .analyzer-button .analyzer-label {
+        #secondary-header-row .analyzer-button .analyzer-label,
+        .header-quick-links .analyzer-button .analyzer-label,
+        .header-quick-links .research-button .analyzer-label {
             display: block;
             margin: -2px 0 0 0;
             padding: 0;
-            font-size: 0.5rem;
-            font-weight: 500;
+            font-size: 0.53rem;
+            font-weight: 600;
             line-height: 1;
             color: inherit;
+            white-space: nowrap;
         }
         #secondary-header-row .analyzer-button:hover .analyzer-icon,
-        #secondary-header-row .analyzer-button:focus-visible .analyzer-icon {
+        #secondary-header-row .analyzer-button:focus-visible .analyzer-icon,
+        .header-quick-links .analyzer-button:hover .analyzer-icon,
+        .header-quick-links .analyzer-button:focus-visible .analyzer-icon,
+        .header-quick-links .research-button:hover .analyzer-icon,
+        .header-quick-links .research-button:focus-visible .analyzer-icon {
             color: var(--color-text-primary);
         }
 
@@ -340,7 +378,9 @@
         #primary-header-row .menu-container,
         #primary-header-row .username-area,
         #secondary-header-row .analyzer-button-container,
-        #secondary-header-row .custom-select-wrapper {
+        #secondary-header-row .custom-select-wrapper,
+        .analyzer-button-slot,
+        .research-button-slot {
             margin-block: 0.075rem;
         }
 
@@ -351,6 +391,21 @@
         }
         #contextual-controls.hidden {
             display: none;
+        }
+
+        @media (min-width: 1024px) {
+            .header-quick-links {
+                display: flex;
+            }
+
+            #primary-header-row {
+                grid-template-columns: var(--header-icon-size) max-content minmax(120px, var(--header-field-max-width)) minmax(var(--header-switcher-width), 1fr);
+            }
+
+            .header-quick-links .analyzer-button,
+            .header-quick-links .research-button {
+                gap: 0.2rem;
+            }
         }
 
   /* · · Ensure hidden truly hides views regardless of ID display rules · · */
@@ -2324,22 +2379,36 @@ font-weight: 500 !important;
     position: absolute;
     top: 100%;
     left: 0;
-    background-color: var(--color-bg-light);
+    background-color: rgba(11, 15, 28, 0.94);
     border: 1px solid var(--color-panel-border);
     border-radius: var(--card-border-radius);
-    padding: 0.25rem;
+    padding: 0.4rem 0.5rem;
     display: flex;
     flex-direction: column;
-    gap: 0.25rem;
+    gap: 0.35rem;
     z-index: 20;
-    min-width: 150px;
+    min-width: 210px;
+    box-shadow: 0 12px 32px rgba(5, 7, 15, 0.5);
+    backdrop-filter: blur(8px) saturate(130%);
 }
 
 .dropdown-menu a {
     color: var(--color-text-secondary);
     text-decoration: none;
-    padding: 0.25rem 0.5rem;
+    padding: 0.35rem 0.55rem;
     border-radius: var(--card-border-radius);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+.dropdown-menu a i {
+    color: inherit;
+    font-size: 1.05rem;
+    min-width: 1.1rem;
+    text-align: center;
 }
 
 .dropdown-menu a:hover {
@@ -2369,8 +2438,9 @@ font-weight: 500 !important;
     display: flex;
     align-items: center;
     justify-content: center;
-    width: var(--header-icon-size);
+    width: max(var(--header-icon-size), 2.6rem);
     height: var(--header-control-height);
+    flex-shrink: 0;
 }
 
 .research-button {
@@ -2386,13 +2456,14 @@ font-weight: 500 !important;
 }
 
 .research-button .analyzer-icon {
-    font-size: 1.15rem;
+    font-size: 1.22rem;
 }
 
 .research-button .analyzer-label {
-    font-size: 0.5rem;
-    font-weight: 500;
+    font-size: 0.53rem;
+    font-weight: 600;
     color: inherit;
+    white-space: nowrap;
 }
 #clearFiltersButton {
     display: flex;
@@ -2414,7 +2485,7 @@ font-weight: 500 !important;
 #clearFiltersButton i {
     display: block;
     margin-top: 4px;
-    font-size: 1rem;
+    font-size: 1.2rem;
     line-height: 1;
 }
 
@@ -2460,6 +2531,30 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
     box-shadow: none;
     background: transparent;
     border: none;
+    color: var(--color-text-primary);
+}
+
+#primary-header-row .header-quick-links #analyzeLeagueButton,
+.header-quick-links #analyzeLeagueButton {
+    padding: 0;
+    border: none;
+    background: transparent !important;
+    box-shadow: none;
+    color: var(--color-text-secondary);
+}
+
+.header-quick-links #analyzeLeagueButton .analyzer-icon {
+    font-size: 1.22rem !important;
+    margin-top: 0 !important;
+}
+
+.header-quick-links #analyzeLeagueButton .analyzer-label {
+    margin-top: -2px !important;
+    color: inherit;
+}
+
+.header-quick-links #analyzeLeagueButton:hover .analyzer-icon,
+.header-quick-links #analyzeLeagueButton:focus-visible .analyzer-icon {
     color: var(--color-text-primary);
 }
 
@@ -4129,11 +4224,11 @@ img.team-logo.glow[alt="WAS"] {
 /* =========================
    SYOP PAGE LAYOUT & VISUALS
    ========================= */
-body[data-page="syop"] {
+body[data-page="research"] {
   background-color: #0a0f1e;
 }
 
-body[data-page="syop"] .app-header {
+body[data-page="research"] .app-header {
   margin-bottom: 1.05rem;
 }
 
@@ -4147,8 +4242,8 @@ body[data-page="syop"] .app-header {
 .syop-hero {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
-  padding: 0.85rem 1rem 0.95rem;
+  gap: 0.7rem;
+  padding: 0.7rem 0.9rem 0.78rem;
   background: radial-gradient(circle at 20% 18%, rgba(96, 165, 250, 0.18), transparent 58%),
               radial-gradient(circle at 82% 56%, rgba(192, 132, 252, 0.2), transparent 68%),
               rgba(18, 21, 38, 0.78);
@@ -4163,6 +4258,7 @@ body[data-page="syop"] .app-header {
   display: flex;
   flex-direction: column;
   gap: 0.45rem;
+  align-items: center;
 }
 
 .syop-hero-summary {
@@ -4174,8 +4270,8 @@ body[data-page="syop"] .app-header {
 }
 
 .syop-hero h1 {
-  font-size: clamp(1.78rem, 1.45rem + 1.3vw, 2.35rem);
-  margin: 0.3rem 0 0.1rem;
+  font-size: clamp(1.45rem, 1.18rem + 0.85vw, 1.9rem);
+  margin: 0.08rem 0 0.02rem;
   letter-spacing: -0.02em;
 }
 
@@ -4188,15 +4284,16 @@ body[data-page="syop"] .app-header {
 .syop-pill {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.35rem 0.9rem;
+  gap: 0.4rem;
+  padding: 0.28rem 0.68rem;
   border-radius: 999px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(15, 18, 32, 0.6);
-  letter-spacing: 0.24em;
-  font-size: 0.65rem;
+  letter-spacing: 0.18em;
+  font-size: 0.63rem;
   text-transform: uppercase;
   color: rgba(182, 185, 214, 0.85);
+  align-self: center;
 }
 
 
@@ -4234,36 +4331,43 @@ body[data-page="syop"] .app-header {
 
 .syop-hero-meta {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-  padding: 0.45rem 0.55rem;
-  border-radius: 14px;
-  background: rgba(15, 18, 32, 0.72);
-  border: 1px solid rgba(132, 146, 255, 0.1);
+  flex-direction: column;
+  gap: 0.38rem;
+  padding: 0;
+  width: 100%;
 }
 
 .syop-hero-meta-item {
-  display: inline-flex;
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.25rem 0.65rem;
+  gap: 0.28rem;
+  padding: 0.36rem 0.85rem;
+  min-height: 48px;
   border-radius: 999px;
-  background: rgba(20, 24, 40, 0.8);
-  border: 1px solid rgba(132, 146, 255, 0.14);
+  background: rgba(16, 20, 34, 0.32);
+  border: 1px solid rgba(132, 146, 255, 0.22);
   color: rgba(226, 232, 240, 0.9);
-  font-size: 0.76rem;
+  font-size: 0.74rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  text-align: center;
+  width: 100%;
+  max-width: 720px;
 }
 
 .syop-hero-meta-item .meta-label {
-  letter-spacing: 0.16em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  font-size: 0.63rem;
-  color: rgba(182, 185, 214, 0.75);
+  font-size: 0.61rem;
+  color: rgba(182, 185, 214, 0.8);
+  font-weight: 500;
 }
 
 .syop-hero-meta-item .meta-value {
-  font-weight: 600;
-  letter-spacing: 0.01em;
+  font-weight: 500;
+  font-size: 0.72rem;
+  line-height: 1.24;
 }
 
 .syop-tabs {
@@ -4348,16 +4452,22 @@ body[data-page="syop"] .app-header {
   display: grid;
   gap: 0.75rem;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-auto-flow: row;
 }
 
 .syop-panel {
   position: relative;
   padding: 0.85rem;
-  background: rgba(18, 21, 38, 0.78);
   border-radius: 16px;
-  border: 1px solid rgba(132, 146, 255, 0.16);
-  box-shadow: 0 12px 26px rgba(4, 7, 16, 0.44);
-  backdrop-filter: blur(12px);
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+.syop-panel.glass-panel {
+  border-radius: 16px;
+  --outerA: 0.32;
 }
 
 .syop-panel header h3 {
@@ -4374,8 +4484,10 @@ body[data-page="syop"] .app-header {
   font-size: 0.86rem;
 }
 
+#syop-sunburst-panel,
+#syop-gauges,
 .syop-panel-wide {
-  grid-column: span 1;
+  grid-column: 1 / -1;
 }
 
 .syop-panel-body {
@@ -4386,41 +4498,61 @@ body[data-page="syop"] .app-header {
 
 .syop-gauges {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.75rem;
-  padding: 1rem;
-  background: rgba(18, 21, 38, 0.78);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  padding: 1.1rem 1.25rem 1.2rem;
+  background: transparent;
   border-radius: 16px;
-  border: 1px solid rgba(132, 146, 255, 0.16);
-  box-shadow: 0 12px 26px rgba(4, 7, 16, 0.44);
-  backdrop-filter: blur(12px);
+  border: none;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+@media (min-width: 1024px) {
+  .syop-gauges {
+    column-gap: 0.3rem;
+    row-gap: 1.05rem;
+    padding-inline: 0.85rem;
+  }
+}
+
+.syop-gauges.glass-panel {
+  border-radius: 16px;
+  --outerA: 0.32;
 }
 
 .syop-gauge-card {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.45rem;
+  padding: 0.4rem 0.35rem 0.6rem;
+}
+
+.syop-gauge-svg {
+  width: 100%;
+  height: auto;
+  max-width: 260px;
 }
 
 .syop-gauge-label {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.1rem;
+  gap: 0.15rem;
   text-transform: uppercase;
-  letter-spacing: 0.18em;
-  font-size: 0.62rem;
-}
-
-.syop-gauge-svg {
-  width: 100%;
-  height: auto;
+  letter-spacing: 0.24em;
+  font-size: 0.64rem;
 }
 
 .syop-gauge-label .gauge-value {
-  font-size: 1.05rem;
+  font-size: 1.08rem;
   font-weight: 700;
+}
+
+.syop-gauge-label .gauge-title {
+  font-size: 0.58rem;
+  letter-spacing: 0.32em;
 }
 
 .syop-bar-controls {
@@ -4508,9 +4640,10 @@ body[data-page="syop"] .app-header {
   flex: 1 1 auto;
 }
 
+
 .syop-heatmap-scroll {
   width: 100%;
-  overflow-x: auto;
+  overflow-x: hidden;
   padding-bottom: 0.35rem;
 }
 
@@ -4524,10 +4657,10 @@ body[data-page="syop"] .app-header {
 }
 
 .syop-heatmap {
-  min-width: 520px;
+  width: 100%;
   display: grid;
-  gap: 0.35rem;
-  padding: 0.65rem;
+  gap: 0.3rem;
+  padding: 0.55rem;
   background: rgba(12, 15, 28, 0.72);
   border-radius: 14px;
   border: 1px solid rgba(132, 146, 255, 0.14);
@@ -4536,8 +4669,8 @@ body[data-page="syop"] .app-header {
 
 .syop-heatmap-row {
   display: grid;
-  grid-template-columns: minmax(56px, 0.75fr) repeat(4, minmax(100px, 1fr));
-  gap: 0.35rem;
+  grid-template-columns: minmax(48px, 0.8fr) repeat(4, minmax(0, 1fr));
+  gap: 0.3rem;
   align-items: stretch;
 }
 
@@ -4574,17 +4707,17 @@ body[data-page="syop"] .app-header {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0.55rem 0.6rem;
+  padding: 0.5rem 0.55rem;
   border-radius: 12px;
   background: rgba(12, 15, 28, 0.72);
   border: 1px solid rgba(132, 146, 255, 0.12);
-  min-height: 48px;
+  min-height: 46px;
 }
 
 .syop-heatmap-cell.bucket-cell {
   justify-content: center;
   font-weight: 700;
-  font-size: 0.78rem;
+  font-size: 0.76rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: rgba(182, 185, 214, 0.85);
@@ -4594,7 +4727,7 @@ body[data-page="syop"] .app-header {
 .syop-heatmap-cell.value-cell {
   color: #f5f7ff;
   font-weight: 600;
-  font-size: 0.88rem;
+  font-size: 0.84rem;
   border: 1px solid rgba(132, 146, 255, 0.18);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
 }
@@ -4716,6 +4849,17 @@ body[data-page="syop"] .app-header {
   backdrop-filter: blur(12px);
 }
 
+@media (min-width: 1024px) {
+  .syop-panels-grid .syop-key-legend.syop-key-inline {
+    grid-column: 1 / -1;
+    margin-top: 0.15rem;
+  }
+
+  .syop-key-legend.syop-key-inline {
+    padding: 0.85rem 1rem;
+  }
+}
+
 .syop-key-legend .syop-key-grid {
   gap: 0.5rem;
 }
@@ -4799,10 +4943,29 @@ body[data-page="syop"] .app-header {
   text-align: center;
 }
 
+@media (min-width: 768px) {
+  .syop-hero-intro {
+    align-items: flex-start;
+  }
+
+  .syop-pill {
+    align-self: flex-start;
+  }
+
+  .syop-hero-meta {
+    align-items: flex-start;
+  }
+
+  .syop-hero-meta-item {
+    align-items: flex-start;
+    text-align: left;
+  }
+}
+
 /* Responsive refinements */
 @media (min-width: 1024px) {
   .syop-panel-wide {
-    grid-column: span 2;
+    grid-column: 1 / -1;
   }
 
   .syop-lower-panels {
@@ -4816,8 +4979,24 @@ body[data-page="syop"] .app-header {
 
 @media (max-width: 768px) {
   .syop-hero {
-    padding: 0.75rem 0.85rem 0.9rem;
-    gap: 0.6rem;
+    padding: 0.6rem 0.75rem 0.66rem;
+    gap: 0.58rem;
+  }
+
+  .syop-hero-intro {
+    align-items: center;
+  }
+
+  .syop-hero h1 {
+    text-align: center;
+  }
+
+  .syop-pill {
+    align-self: center;
+  }
+
+  .syop-hero-summary {
+    align-items: center;
   }
 
   .syop-hero-card {
@@ -4829,13 +5008,12 @@ body[data-page="syop"] .app-header {
   }
 
   .syop-hero-meta {
-    gap: 0.3rem;
-    padding: 0.4rem 0.48rem;
+    gap: 0.28rem;
+    align-items: center;
   }
 
   .syop-hero-meta-item {
-    flex: 1 1 100%;
-    justify-content: space-between;
+    min-height: 42px;
   }
 
   .syop-tabs {
@@ -4850,21 +5028,30 @@ body[data-page="syop"] .app-header {
 
   .syop-panel,
   .syop-gauges {
-    padding: 0.8rem;
+    padding: 0.85rem;
+  }
+
+  .syop-gauges {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.85rem;
   }
 
   .syop-heatmap {
-    min-width: 480px;
-    padding: 0.55rem;
-    gap: 0.3rem;
+    padding: 0.48rem;
+    gap: 0.28rem;
+  }
+
+  .syop-heatmap-row {
+    grid-template-columns: minmax(42px, 0.75fr) repeat(4, minmax(0, 1fr));
   }
 
   .syop-heatmap-cell {
-    min-height: 44px;
+    min-height: 42px;
+    padding: 0.45rem 0.5rem;
   }
 
   .syop-heatmap-cell.value-cell {
-    font-size: 0.84rem;
+    font-size: 0.8rem;
   }
 
   .syop-key-legend {
@@ -4874,7 +5061,14 @@ body[data-page="syop"] .app-header {
 
 @media (max-width: 540px) {
   .syop-hero {
-    padding: 0.7rem 0.75rem 0.85rem;
+    padding: 0.54rem 0.65rem 0.6rem;
+  }
+
+  .syop-hero h1 {
+    font-size: clamp(0.9rem, 3.6vw, 1.18rem);
+    white-space: nowrap;
+    text-align: center;
+    letter-spacing: -0.018em;
   }
 
   .syop-hero-summary {
@@ -4895,13 +5089,13 @@ body[data-page="syop"] .app-header {
   }
 
   .syop-hero-meta {
-    gap: 0.26rem;
-    padding: 0.34rem 0.44rem;
+    gap: 0.24rem;
   }
 
   .syop-hero-meta-item {
-    padding: 0.2rem 0.5rem;
+    padding: 0.2rem 0.52rem;
     font-size: 0.7rem;
+    min-height: 36px;
   }
 
   .syop-hero-meta-item .meta-label {
@@ -4919,28 +5113,65 @@ body[data-page="syop"] .app-header {
     padding: 0.72rem;
   }
 
+  .syop-gauges {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+  }
+
   .syop-section-heading p {
     font-size: 0.86rem;
   }
 
   .syop-heatmap {
-    min-width: 440px;
-    padding: 0.45rem;
+    padding: 0.42rem;
+  }
+
+  .syop-heatmap-row {
+    grid-template-columns: minmax(38px, 0.7fr) repeat(4, minmax(0, 1fr));
   }
 
   .syop-heatmap-cell {
-    min-height: 42px;
+    min-height: 40px;
+    padding: 0.42rem 0.46rem;
   }
 
   .syop-heatmap-cell.bucket-cell {
-    font-size: 0.72rem;
+    font-size: 0.7rem;
   }
 
   .syop-heatmap-cell.value-cell {
-    font-size: 0.8rem;
+    font-size: 0.76rem;
   }
 
   .syop-key-legend {
     padding: 0.58rem 0.65rem;
+  }
+}
+
+@media (max-width: 380px) {
+  .syop-gauges {
+    grid-template-columns: 1fr;
+    gap: 0.65rem;
+  }
+
+  .syop-gauge-label .gauge-value {
+    font-size: 1rem;
+  }
+
+  .syop-gauge-label .gauge-title {
+    letter-spacing: 0.28em;
+  }
+
+  .syop-heatmap-row {
+    grid-template-columns: minmax(34px, 0.65fr) repeat(4, minmax(0, 1fr));
+  }
+
+  .syop-heatmap-cell {
+    padding: 0.38rem 0.42rem;
+    min-height: 38px;
+  }
+
+  .syop-heatmap-cell.value-cell {
+    font-size: 0.72rem;
   }
 }


### PR DESCRIPTION
## Summary
- color-match and stagger positional hit-rate labels while dynamically relocating the SYOP key beneath the gauges on desktop
- adjust desktop research styling so the gauge grid tightens horizontally and the key panel snaps into the chart grid
- align the League Analyzer quick-link icon treatment with the Research shortcut for consistent header buttons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf48d135bc832e9d3f269bd548b1d2