### PR TITLE
Refine SYOP distribution visualization

### DIFF
--- a/P30920/research/research.html
+++ b/P30920/research/research.html
@@ -142,7 +142,7 @@
               <p>(% of position within each SYOP bucket)</p>
             </header>
             <div class="syop-panel-body">
-              <div class="syop-chart" id="syop-bar-chart" role="img" aria-label="SYOP positional distribution chart"></div>
+            <div class="syop-chart" id="syop-bar-chart" role="region" aria-label="SYOP positional distribution explorer"></div>
             </div>
           </article>
         </div>

--- a/P30920/scripts/syop.js
+++ b/P30920/scripts/syop.js
@@ -106,6 +106,18 @@
     { key: 'TE %', label: 'TE %', color: colors.te }
   ];
 
+  const POSITION_META = [
+    { key: 'QB', label: 'Quarterbacks', short: 'QB', color: colors.qb },
+    { key: 'RB', label: 'Running Backs', short: 'RB', color: colors.rb },
+    { key: 'WR', label: 'Wide Receivers', short: 'WR', color: colors.wr },
+    { key: 'TE', label: 'Tight Ends', short: 'TE', color: colors.te }
+  ];
+
+  const DISTRIBUTION_RANGE = { min: 0, max: 12 };
+
+  let syopDistributionMode = 'chart';
+  let syopDistributionActive = new Set(POSITION_META.map((meta) => meta.key));
+
   let resizeTimer = null;
 
   function createEl(tag, attrs, ...children) {
@@ -202,6 +214,178 @@
     const b = value & 255;
     return `rgba(${r}, ${g}, ${b}, ${alpha})`;
   }
+
+  function bucketToValue(bucket) {
+    if (!bucket) return 0;
+    if (bucket.includes('+')) {
+      const base = parseFloat(bucket.replace('+', ''));
+      return Number.isFinite(base) ? base + 0.5 : 0;
+    }
+    const numeric = Number(bucket);
+    return Number.isFinite(numeric) ? numeric : 0;
+  }
+
+  function buildBucketsForPosition(positionKey) {
+    const seriesKey = `${positionKey} %`;
+    return SYOP_DATA.map((row) => ({
+      bucket: row.SYOP,
+      value: row[seriesKey] || 0,
+      numeric: bucketToValue(row.SYOP)
+    }));
+  }
+
+  function quantileFromBuckets(buckets, q) {
+    if (!Array.isArray(buckets) || buckets.length === 0) return 0;
+    const total = buckets.reduce((sum, bucket) => sum + bucket.value, 0);
+    if (total <= 0) return 0;
+    const target = q * total;
+    let cumulative = 0;
+    for (let i = 0; i < buckets.length; i++) {
+      const bucket = buckets[i];
+      const next = cumulative + bucket.value;
+      if (target <= next || i === buckets.length - 1) {
+        return bucket.numeric;
+      }
+      cumulative = next;
+    }
+    return buckets[buckets.length - 1].numeric;
+  }
+
+  function shareAtLeastYears(buckets, threshold) {
+    return buckets
+      .filter((bucket) => bucket.numeric >= threshold)
+      .reduce((sum, bucket) => sum + bucket.value, 0);
+  }
+
+  function computeDensityFromBuckets(buckets) {
+    const min = DISTRIBUTION_RANGE.min;
+    const max = DISTRIBUTION_RANGE.max;
+    const steps = 80;
+    const bandwidth = 0.6;
+    const total = buckets.reduce((sum, bucket) => sum + bucket.value, 0) || 1;
+    const points = [];
+
+    for (let i = 0; i <= steps; i++) {
+      const x = min + ((max - min) * i) / steps;
+      let sum = 0;
+      buckets.forEach((bucket) => {
+        const diff = x - bucket.numeric;
+        const weight = bucket.value / total;
+        const density = Math.exp(-0.5 * (diff / bandwidth) ** 2);
+        sum += weight * density;
+      });
+      points.push({ x, value: sum });
+    }
+
+    const maxDensity = points.reduce((maxValue, point) => Math.max(maxValue, point.value), 0) || 1;
+    return points.map((point) => ({
+      x: point.x,
+      value: maxDensity > 0 ? point.value / maxDensity : 0
+    }));
+  }
+
+  function generateSyntheticPlayers(buckets, meta) {
+    const totalPercent = buckets.reduce((sum, bucket) => sum + bucket.value, 0) || 1;
+    const baseCount = 100;
+    const raw = buckets.map((bucket) => (bucket.value / totalPercent) * baseCount);
+    const counts = raw.map((value, index) => {
+      const floored = Math.floor(value);
+      if (floored <= 0 && value > 0) return 1;
+      return floored;
+    });
+
+    let allocated = counts.reduce((sum, count) => sum + count, 0);
+    const target = baseCount;
+
+    if (allocated < target) {
+      const remainders = raw
+        .map((value, index) => ({ index, remainder: value - Math.floor(value) }))
+        .sort((a, b) => b.remainder - a.remainder);
+      let needed = target - allocated;
+      let pointer = 0;
+      while (needed > 0 && remainders.length > 0) {
+        const { index } = remainders[pointer % remainders.length];
+        counts[index] += 1;
+        needed -= 1;
+        pointer += 1;
+      }
+      allocated = counts.reduce((sum, count) => sum + count, 0);
+    }
+
+    if (allocated > target) {
+      const remainders = raw
+        .map((value, index) => ({ index, remainder: value - Math.floor(value) }))
+        .sort((a, b) => a.remainder - b.remainder);
+      let excess = allocated - target;
+      let pointer = 0;
+      while (excess > 0 && remainders.length > 0) {
+        const { index } = remainders[pointer % remainders.length];
+        if (counts[index] > 1) {
+          counts[index] -= 1;
+          excess -= 1;
+        }
+        pointer += 1;
+        if (pointer > remainders.length * 4) {
+          break;
+        }
+      }
+    }
+
+    const players = [];
+    counts.forEach((count, bucketIndex) => {
+      const bucket = buckets[bucketIndex];
+      const sharePerPlayer = count > 0 ? bucket.value / count : 0;
+      for (let i = 0; i < count; i++) {
+        const sequence = players.length + 1;
+        players.push({
+          id: `${meta.key}-${sequence}`,
+          name: `${meta.short} Player ${String(sequence).padStart(2, '0')}`,
+          years: bucket.numeric,
+          bucketLabel: bucket.bucket,
+          share: sharePerPlayer,
+          position: meta.key
+        });
+      }
+    });
+
+    return players;
+  }
+
+  function formatYearsLabel(bucketLabel) {
+    if (!bucketLabel) return '0';
+    if (bucketLabel.includes('+')) return `${bucketLabel} years`;
+    if (bucketLabel === '1') return '1 year';
+    return `${bucketLabel} years`;
+  }
+
+  function formatPercent(value) {
+    return `${value.toFixed(1)}%`;
+  }
+
+  const SYOP_DISTRIBUTIONS = new Map(POSITION_META.map((meta) => {
+    const buckets = buildBucketsForPosition(meta.key);
+    const density = computeDensityFromBuckets(buckets);
+    const players = generateSyntheticPlayers(buckets, meta);
+    const totalPercent = buckets.reduce((sum, bucket) => sum + bucket.value, 0);
+    const median = quantileFromBuckets(buckets, 0.5);
+    const q1 = quantileFromBuckets(buckets, 0.25);
+    const q3 = quantileFromBuckets(buckets, 0.75);
+    const shareTwoPlus = shareAtLeastYears(buckets, 2);
+
+    return [meta.key, {
+      meta,
+      buckets,
+      density,
+      players,
+      summary: {
+        totalPercent,
+        shareTwoPlus,
+        median,
+        q1,
+        q3
+      }
+    }];
+  }));
 
   function stripYearSuffix(text) {
     if (typeof text !== 'string') return text;
@@ -406,57 +590,437 @@
     container.appendChild(svg);
   }
 
-  function renderBarChart() {
+  function renderSyopDistribution() {
     const container = document.getElementById('syop-bar-chart');
     if (!container) return;
+
+    const activeMetas = POSITION_META.filter((meta) => syopDistributionActive.has(meta.key));
     container.innerHTML = '';
 
-    const scroll = createEl('div', { class: 'syop-heatmap-scroll' });
-    const grid = createEl('div', { class: 'syop-heatmap' });
+    const header = createEl('div', { class: 'syop-distribution-header' });
 
-    const headerRow = createEl('div', { class: 'syop-heatmap-row syop-heatmap-header' },
-      createEl('div', { class: 'syop-heatmap-cell bucket-cell' }, 'SYOP')
-    );
-    SERIES_CONFIG.forEach((series) => {
-      headerRow.appendChild(createEl('div', {
-        class: 'syop-heatmap-cell position-header',
-        style: { '--header-accent': series.color }
-      }, series.label.replace('%', '').trim()));
+    const legend = createEl('div', {
+      class: 'syop-distribution-legend',
+      role: 'group',
+      'aria-label': 'Filter positions'
     });
-    grid.appendChild(headerRow);
 
-    const maxValue = Math.max(...SYOP_DATA.flatMap((row) => SERIES_CONFIG.map((series) => row[series.key] || 0)));
+    POSITION_META.forEach((meta) => {
+      const isActive = syopDistributionActive.has(meta.key);
+      const button = createEl('button', {
+        type: 'button',
+        class: `syop-legend-button${isActive ? ' active' : ''}`,
+        style: { '--legend-color': meta.color },
+        'aria-pressed': String(isActive),
+        'data-position': meta.key
+      }, meta.short);
 
-    SYOP_DATA.forEach((row) => {
-      const rowEl = createEl('div', { class: 'syop-heatmap-row' });
-      rowEl.appendChild(createEl('div', { class: 'syop-heatmap-cell bucket-cell' }, row.SYOP));
-
-      SERIES_CONFIG.forEach((series) => {
-        const value = row[series.key] || 0;
-        const intensity = maxValue > 0 ? value / maxValue : 0;
-        const width = Math.max(12, Math.min(100, intensity * 100));
-        const fill = hexToRgba(series.color, 0.35 + 0.55 * intensity);
-        const bar = createEl('span', {
-          class: 'syop-heatmap-bar',
-          style: {
-            width: `${width}%`,
-            background: fill
-          }
-        });
-        const cell = createEl('div', {
-          class: 'syop-heatmap-cell value-cell',
-          style: { '--accent-color': series.color }
-        },
-        bar,
-        createEl('span', { class: 'syop-heatmap-value' }, `${value.toFixed(1)}%`));
-        rowEl.appendChild(cell);
+      button.addEventListener('click', () => {
+        const next = new Set(syopDistributionActive);
+        if (next.has(meta.key)) {
+          next.delete(meta.key);
+        } else {
+          next.add(meta.key);
+        }
+        if (next.size === 0) {
+          return;
+        }
+        syopDistributionActive = next;
+        renderSyopDistribution();
       });
 
-      grid.appendChild(rowEl);
+      legend.appendChild(button);
     });
 
-    scroll.appendChild(grid);
-    container.appendChild(scroll);
+    const viewToggle = createEl('button', {
+      type: 'button',
+      class: 'syop-view-toggle',
+      'aria-pressed': String(syopDistributionMode === 'table')
+    }, syopDistributionMode === 'table' ? 'View chart' : 'View as table');
+
+    viewToggle.addEventListener('click', () => {
+      syopDistributionMode = syopDistributionMode === 'table' ? 'chart' : 'table';
+      renderSyopDistribution();
+    });
+
+    header.appendChild(legend);
+    header.appendChild(viewToggle);
+    container.appendChild(header);
+
+    if (syopDistributionMode === 'table') {
+      renderDistributionTable(container, activeMetas);
+      return;
+    }
+
+    renderDistributionPanels(container, activeMetas);
+  }
+
+  function renderDistributionPanels(container, activeMetas) {
+    if (activeMetas.length === 0) {
+      container.appendChild(createEl('p', { class: 'syop-empty-state' }, 'Select at least one position to view the distribution.'));
+      return;
+    }
+
+    const grid = createEl('div', { class: 'syop-violin-grid' });
+    container.appendChild(grid);
+
+    const tooltip = createEl('div', {
+      class: 'syop-swarm-tooltip',
+      role: 'status',
+      'aria-hidden': 'true'
+    });
+    container.appendChild(tooltip);
+
+    const panels = activeMetas.map((meta) => {
+      const data = SYOP_DISTRIBUTIONS.get(meta.key);
+      const panel = createEl('section', {
+        class: 'syop-violin-panel',
+        'data-position': meta.key
+      });
+
+      const panelHeader = createEl('header', { class: 'syop-violin-panel-header' },
+        createEl('h4', null, meta.label),
+        createEl('span', {
+          class: 'syop-summary-chip',
+          style: { '--chip-accent': meta.color }
+        }, `≥2 SYOP: ${formatPercent(data.summary.shareTwoPlus)}`)
+      );
+
+      const description = createEl('p', { class: 'syop-violin-meta' },
+        `Median ${data.summary.median.toFixed(1)} yrs · IQR ${data.summary.q1.toFixed(1)} – ${data.summary.q3.toFixed(1)} yrs`
+      );
+
+      const chartWrapper = createEl('div', {
+        class: 'syop-violin-chart',
+        role: 'img',
+        'aria-label': `${meta.label} SYOP distribution`
+      });
+
+      panel.appendChild(panelHeader);
+      panel.appendChild(description);
+      panel.appendChild(chartWrapper);
+      grid.appendChild(panel);
+
+      return { meta, data, chartWrapper, panel };
+    });
+
+    panels.forEach((entry) => {
+      renderDistributionChart(entry, tooltip);
+    });
+  }
+
+  function renderDistributionTable(container, activeMetas) {
+    const tableWrapper = createEl('div', { class: 'syop-table-wrapper' });
+    const table = createEl('table', { class: 'syop-table' });
+    const caption = createEl('caption', null, 'SYOP positional distribution (share of players per bucket)');
+    table.appendChild(caption);
+
+    const thead = createEl('thead');
+    const headerRow = createEl('tr');
+    headerRow.appendChild(createEl('th', { scope: 'col' }, 'SYOP bucket'));
+    activeMetas.forEach((meta) => {
+      headerRow.appendChild(createEl('th', { scope: 'col' }, meta.short));
+    });
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
+
+    const tbody = createEl('tbody');
+    SYOP_DATA.forEach((row) => {
+      const tr = createEl('tr');
+      tr.appendChild(createEl('th', { scope: 'row' }, row.SYOP));
+      activeMetas.forEach((meta) => {
+        const buckets = SYOP_DISTRIBUTIONS.get(meta.key)?.buckets || [];
+        const bucket = buckets.find((item) => item.bucket === row.SYOP);
+        tr.appendChild(createEl('td', null, bucket ? formatPercent(bucket.value) : '—'));
+      });
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+
+    const tfoot = createEl('tfoot');
+    const summaryRow = createEl('tr', { class: 'syop-table-summary' });
+    summaryRow.appendChild(createEl('th', { scope: 'row' }, '≥2 SYOP share'));
+    activeMetas.forEach((meta) => {
+      const data = SYOP_DISTRIBUTIONS.get(meta.key);
+      summaryRow.appendChild(createEl('td', null, data ? formatPercent(data.summary.shareTwoPlus) : '—'));
+    });
+    tfoot.appendChild(summaryRow);
+    table.appendChild(tfoot);
+
+    tableWrapper.appendChild(table);
+    container.appendChild(tableWrapper);
+  }
+
+  function renderDistributionChart(entry, tooltip) {
+    const { meta, data, chartWrapper } = entry;
+    const bounds = chartWrapper.getBoundingClientRect();
+    const fallbackWidth = 320;
+    const width = Math.max(260, Math.round(bounds.width || fallbackWidth));
+    const height = width < 320 ? 220 : 260;
+    const margin = width < 320
+      ? { top: 28, right: 18, bottom: 38, left: 18 }
+      : { top: 32, right: 24, bottom: 42, left: 24 };
+
+    const chartWidth = width - margin.left - margin.right;
+    const chartHeight = height - margin.top - margin.bottom;
+    const centerY = margin.top + chartHeight / 2;
+    const amplitude = Math.max(24, chartHeight / 2 - 16);
+    const dotRadius = width < 280 ? 4.2 : width < 360 ? 5 : 6.2;
+
+    const scaleX = (value) => {
+      const domain = DISTRIBUTION_RANGE.max - DISTRIBUTION_RANGE.min;
+      if (domain <= 0) return margin.left;
+      const clamped = Math.min(DISTRIBUTION_RANGE.max, Math.max(DISTRIBUTION_RANGE.min, value));
+      return margin.left + ((clamped - DISTRIBUTION_RANGE.min) / domain) * chartWidth;
+    };
+
+    chartWrapper.innerHTML = '';
+    chartWrapper.style.height = `${height}px`;
+
+    const svg = createSVG('svg', {
+      class: 'syop-violin-svg',
+      viewBox: `0 0 ${width} ${height}`,
+      width: String(width),
+      height: String(height),
+      focusable: 'false',
+      'aria-hidden': 'true'
+    });
+
+    const defs = createSVG('defs');
+    const gradient = createSVG('linearGradient', {
+      id: `violin-gradient-${meta.key}`,
+      x1: '0',
+      x2: '0',
+      y1: '0',
+      y2: '1'
+    });
+    gradient.appendChild(createSVG('stop', { offset: '0%', 'stop-color': hexToRgba(meta.color, 0.75) }));
+    gradient.appendChild(createSVG('stop', { offset: '100%', 'stop-color': hexToRgba(meta.color, 0.2) }));
+    defs.appendChild(gradient);
+    svg.appendChild(defs);
+
+    const group = createSVG('g');
+    svg.appendChild(group);
+
+    const railsStart = Math.ceil(DISTRIBUTION_RANGE.min);
+    const railsEnd = Math.floor(DISTRIBUTION_RANGE.max);
+    for (let year = railsStart; year <= railsEnd; year++) {
+      const x = scaleX(year);
+      group.appendChild(createSVG('line', {
+        x1: x,
+        x2: x,
+        y1: margin.top - 4,
+        y2: margin.top + chartHeight + 6,
+        stroke: year === 0 ? 'rgba(255,255,255,0.32)' : colors.grid,
+        'stroke-dasharray': year % 2 === 0 ? '2 4' : '1 6'
+      }));
+
+      if (year % 2 === 0 || year <= 4) {
+        group.appendChild(createSVG('text', {
+          x,
+          y: height - 12,
+          fill: colors.subtext,
+          'font-size': '11',
+          'text-anchor': 'middle'
+        }, year >= 12 ? '12+' : String(year)));
+      }
+    }
+
+    group.appendChild(createSVG('line', {
+      x1: margin.left,
+      x2: margin.left + chartWidth,
+      y1: centerY,
+      y2: centerY,
+      stroke: 'rgba(148, 163, 255, 0.25)',
+      'stroke-dasharray': '4 6'
+    }));
+
+    const q1x = scaleX(data.summary.q1);
+    const q3x = scaleX(data.summary.q3);
+    group.appendChild(createSVG('rect', {
+      x: Math.min(q1x, q3x),
+      y: centerY - amplitude - 6,
+      width: Math.max(6, Math.abs(q3x - q1x)),
+      height: (amplitude + 6) * 2,
+      fill: hexToRgba(meta.color, 0.16),
+      rx: 10,
+      ry: 10
+    }));
+
+    const densityPath = describeDensityPath(data.density, scaleX, centerY, amplitude);
+    if (densityPath) {
+      group.appendChild(createSVG('path', {
+        d: densityPath,
+        fill: `url(#violin-gradient-${meta.key})`,
+        stroke: hexToRgba(meta.color, 0.85),
+        'stroke-width': '1.4',
+        opacity: '0.95'
+      }));
+    }
+
+    const medianX = scaleX(data.summary.median);
+    group.appendChild(createSVG('line', {
+      x1: medianX,
+      x2: medianX,
+      y1: centerY - amplitude - 8,
+      y2: centerY + amplitude + 8,
+      stroke: meta.color,
+      'stroke-width': '2.2'
+    }));
+
+    group.appendChild(createSVG('path', {
+      d: describeMedianDiamond(medianX, centerY, 8),
+      fill: colors.bg,
+      stroke: meta.color,
+      'stroke-width': '2'
+    }));
+
+    group.appendChild(createSVG('text', {
+      x: margin.left + chartWidth / 2,
+      y: height - 2,
+      fill: colors.subtext,
+      'font-size': '11',
+      'font-weight': '600',
+      'text-anchor': 'middle'
+    }, 'SYOP years'));
+
+    chartWrapper.appendChild(svg);
+
+    const swarmLayer = createEl('div', { class: 'syop-swarm-layer' });
+    swarmLayer.style.height = `${height}px`;
+    chartWrapper.appendChild(swarmLayer);
+
+    const swarmPoints = layoutSwarmPoints(data.players, scaleX, centerY, dotRadius);
+    swarmPoints.forEach((point) => {
+      const shareValue = point.player.share;
+      const shareText = shareValue >= 1 ? shareValue.toFixed(1) : shareValue.toFixed(2);
+      const dot = createEl('button', {
+        type: 'button',
+        class: 'syop-swarm-dot',
+        style: {
+          left: `${point.x - dotRadius}px`,
+          top: `${point.y - dotRadius}px`,
+          width: `${dotRadius * 2}px`,
+          height: `${dotRadius * 2}px`
+        },
+        'data-player-id': point.player.id,
+        'aria-label': `${point.player.name} — ${formatYearsLabel(point.player.bucketLabel)} (≈ ${shareText}% of ${meta.short})`
+      });
+      dot.style.setProperty('--dot-color', meta.color);
+      swarmLayer.appendChild(dot);
+
+      dot.addEventListener('mouseenter', () => showSwarmTooltip(tooltip, dot, meta, point.player));
+      dot.addEventListener('mouseleave', () => hideSwarmTooltip(tooltip));
+      dot.addEventListener('focus', () => showSwarmTooltip(tooltip, dot, meta, point.player));
+      dot.addEventListener('blur', () => hideSwarmTooltip(tooltip));
+    });
+  }
+
+  function describeDensityPath(points, scaleX, centerY, amplitude) {
+    if (!points || points.length === 0) return '';
+    const upper = points.map((point) => `${scaleX(point.x)} ${centerY - point.value * amplitude}`);
+    const lower = points
+      .slice()
+      .reverse()
+      .map((point) => `${scaleX(point.x)} ${centerY + point.value * amplitude}`);
+    if (upper.length === 0 || lower.length === 0) return '';
+    return `M ${upper[0]} L ${upper.slice(1).join(' L ')} L ${lower.join(' L ')} Z`;
+  }
+
+  function describeMedianDiamond(cx, cy, size) {
+    const half = size / 2;
+    return `M ${cx} ${cy - half} L ${cx + half} ${cy} L ${cx} ${cy + half} L ${cx - half} ${cy} Z`;
+  }
+
+  function layoutSwarmPoints(players, scaleX, centerY, radius) {
+    const placed = [];
+    const verticalStep = radius * 1.9;
+    const jitter = radius * 0.85;
+    const minX = scaleX(DISTRIBUTION_RANGE.min);
+    const maxX = scaleX(DISTRIBUTION_RANGE.max);
+    return players.map((player) => {
+      const hash = hashString(player.id);
+      const offset = ((hash % 1000) / 999 - 0.5) * jitter;
+      const baseX = scaleX(player.years);
+      const x = Math.min(maxX, Math.max(minX, baseX + offset));
+      let level = 0;
+      let direction = 1;
+      let y = centerY;
+      let attempts = 0;
+
+      while (placed.some((other) => Math.hypot(other.x - x, other.y - y) < radius * 2.05)) {
+        level += 1;
+        direction *= -1;
+        y = centerY + direction * level * verticalStep;
+        attempts += 1;
+        if (attempts > 80) {
+          break;
+        }
+      }
+
+      const point = { player, x, y };
+      placed.push(point);
+      return point;
+    });
+  }
+
+  function hashString(input) {
+    let hash = 0;
+    for (let i = 0; i < input.length; i++) {
+      hash = (hash << 5) - hash + input.charCodeAt(i);
+      hash |= 0;
+    }
+    return Math.abs(hash);
+  }
+
+  function showSwarmTooltip(tooltip, dot, meta, player) {
+    if (!tooltip || !tooltip.parentElement) return;
+    const host = tooltip.parentElement;
+    const parent = dot.parentElement;
+    if (parent) {
+      parent.querySelectorAll('.syop-swarm-dot.is-active').forEach((activeDot) => {
+        activeDot.classList.remove('is-active');
+      });
+    }
+    dot.classList.add('is-active');
+
+    tooltip.innerHTML = '';
+    const shareText = player.share >= 1 ? player.share.toFixed(1) : player.share.toFixed(2);
+    tooltip.appendChild(createEl('div', { class: 'syop-tooltip-name' }, player.name));
+    tooltip.appendChild(createEl('div', { class: 'syop-tooltip-years' }, formatYearsLabel(player.bucketLabel)));
+    tooltip.appendChild(createEl('div', { class: 'syop-tooltip-share' }, `≈ ${shareText}% of ${meta.short}`));
+
+    tooltip.classList.add('visible');
+    tooltip.setAttribute('aria-hidden', 'false');
+    tooltip.dataset.activeId = player.id;
+
+    const hostRect = host.getBoundingClientRect();
+    const dotRect = dot.getBoundingClientRect();
+    tooltip.style.left = '0px';
+    tooltip.style.top = '0px';
+
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const desiredLeft = dotRect.left - hostRect.left - tooltipRect.width / 2 + dotRect.width / 2;
+    const maxLeft = hostRect.width - tooltipRect.width - 8;
+    const left = Math.max(8, Math.min(desiredLeft, maxLeft));
+    let top = dotRect.top - hostRect.top - tooltipRect.height - 12;
+    if (top < 8) {
+      top = dotRect.top - hostRect.top + dotRect.height + 12;
+    }
+
+    tooltip.style.left = `${left}px`;
+    tooltip.style.top = `${top}px`;
+  }
+
+  function hideSwarmTooltip(tooltip) {
+    if (!tooltip || !tooltip.parentElement) return;
+    const host = tooltip.parentElement;
+    host.querySelectorAll('.syop-swarm-dot.is-active').forEach((activeDot) => {
+      activeDot.classList.remove('is-active');
+    });
+    tooltip.classList.remove('visible');
+    tooltip.setAttribute('aria-hidden', 'true');
+    tooltip.removeAttribute('data-active-id');
   }
 
   function renderGauges() {
@@ -938,7 +1502,7 @@
     }
     resizeTimer = window.setTimeout(() => {
       renderSunburst();
-      renderBarChart();
+      renderSyopDistribution();
       renderGauges();
       renderDraftOverall();
       renderDraftPositional();
@@ -988,7 +1552,7 @@
           renderDraftPositional();
         } else {
           renderSunburst();
-          renderBarChart();
+          renderSyopDistribution();
           renderGauges();
         }
       });
@@ -1027,7 +1591,7 @@
     applyUsernameFromQuery();
     setupTabs();
     renderSunburst();
-    renderBarChart();
+    renderSyopDistribution();
     renderGauges();
     renderDraftOverall();
     renderDraftPositional();

--- a/P30920/styles/styles.css
+++ b/P30920/styles/styles.css
@@ -4651,115 +4651,317 @@ body[data-page="research"] .app-header {
 }
 
 
-.syop-heatmap-scroll {
-  width: 100%;
-  overflow-x: hidden;
-  padding-bottom: 0.35rem;
-}
 
-.syop-heatmap-scroll::-webkit-scrollbar {
-  height: 6px;
-}
-
-.syop-heatmap-scroll::-webkit-scrollbar-thumb {
-  background: rgba(132, 146, 255, 0.35);
-  border-radius: 999px;
-}
-
-.syop-heatmap {
-  width: 100%;
-  display: grid;
-  gap: 0.3rem;
-  padding: 0.55rem;
-  background: rgba(12, 15, 28, 0.72);
-  border-radius: 14px;
-  border: 1px solid rgba(132, 146, 255, 0.14);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
-}
-
-.syop-heatmap-row {
-  display: grid;
-  grid-template-columns: minmax(48px, 0.8fr) repeat(4, minmax(0, 1fr));
-  gap: 0.3rem;
-  align-items: stretch;
-}
-
-.syop-heatmap-row.syop-heatmap-header {
-  font-size: 0.72rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: rgba(182, 185, 214, 0.72);
-}
-
-.syop-heatmap-row.syop-heatmap-header .syop-heatmap-cell {
-  background: transparent;
-  border: none;
-  padding: 0 0.4rem 0.35rem;
-  justify-content: center;
-}
-
-.syop-heatmap-row.syop-heatmap-header .position-header {
-  color: rgba(244, 246, 255, 0.82);
-}
-
-.syop-heatmap-row.syop-heatmap-header .position-header::after {
-  content: '';
-  display: block;
-  margin-top: 0.35rem;
-  width: 100%;
-  height: 2px;
-  border-radius: 999px;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.08), var(--header-accent));
-}
-
-.syop-heatmap-cell {
-  position: relative;
+.syop-distribution-header {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  justify-content: center;
-  padding: 0.5rem 0.55rem;
-  border-radius: 12px;
-  background: rgba(12, 15, 28, 0.72);
-  border: 1px solid rgba(132, 146, 255, 0.12);
-  min-height: 46px;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
 }
 
-.syop-heatmap-cell.bucket-cell {
-  justify-content: center;
+.syop-distribution-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.syop-legend-button {
+  position: relative;
+  padding: 0.45rem 0.85rem 0.45rem 1.9rem;
+  border-radius: 999px;
+  background: rgba(18, 21, 38, 0.78);
+  border: 1px solid rgba(132, 146, 255, 0.18);
+  color: #f5f7ff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.syop-legend-button::before {
+  content: '';
+  position: absolute;
+  left: 0.6rem;
+  top: 50%;
+  width: 0.7rem;
+  height: 0.7rem;
+  transform: translateY(-50%);
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.24), var(--legend-color));
+  box-shadow: 0 0 0 1px rgba(11, 14, 22, 0.4);
+}
+
+.syop-legend-button.active {
+  border-color: rgba(109, 132, 255, 0.65);
+  box-shadow: 0 0 0 1px rgba(109, 132, 255, 0.35), inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.syop-legend-button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(123, 149, 255, 0.58);
+}
+
+.syop-view-toggle {
+  padding: 0.5rem 0.95rem;
+  border-radius: 999px;
+  background: rgba(18, 21, 38, 0.82);
+  border: 1px solid rgba(132, 146, 255, 0.2);
+  color: rgba(245, 247, 255, 0.86);
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.syop-view-toggle:hover,
+.syop-view-toggle:focus-visible {
+  border-color: rgba(123, 149, 255, 0.68);
+  background: rgba(24, 27, 45, 0.88);
+  outline: none;
+}
+
+.syop-violin-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.2rem;
+}
+
+.syop-violin-panel {
+  padding: 0.9rem 1rem 1rem;
+  border-radius: 18px;
+  background: rgba(12, 15, 28, 0.68);
+  border: 1px solid rgba(132, 146, 255, 0.18);
+  backdrop-filter: blur(18px);
+  position: relative;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+}
+
+.syop-violin-panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.85rem;
+  margin-bottom: 0.35rem;
+}
+
+.syop-violin-panel-header h4 {
+  margin: 0;
+  font-size: 1.02rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #f5f7ff;
+}
+
+.syop-summary-chip {
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(24, 29, 52, 0.88);
+  border: 1px solid rgba(132, 146, 255, 0.25);
+  font-size: 0.75rem;
   font-weight: 700;
-  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(245, 247, 255, 0.9);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.syop-summary-chip::before {
+  content: '';
+  display: inline-block;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.35), var(--chip-accent));
+  margin-right: 0.35rem;
+}
+
+.syop-violin-meta {
+  margin: 0 0 0.65rem;
+  font-size: 0.82rem;
+  color: rgba(184, 191, 224, 0.82);
+  letter-spacing: 0.04em;
+}
+
+.syop-violin-chart {
+  position: relative;
+  width: 100%;
+}
+
+.syop-violin-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.syop-swarm-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.syop-swarm-dot {
+  position: absolute;
+  border-radius: 50%;
+  background: var(--dot-color);
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.35);
+  border: 2px solid rgba(6, 8, 16, 0.85);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  pointer-events: auto;
+}
+
+.syop-swarm-dot:hover,
+.syop-swarm-dot.is-active {
+  transform: scale(1.1);
+  box-shadow: 0 0 16px rgba(59, 228, 228, 0.2), 0 0 0 2px rgba(10, 14, 24, 0.9);
+}
+
+.syop-swarm-dot:focus-visible {
+  outline: none;
+  transform: scale(1.12);
+  box-shadow: 0 0 18px rgba(130, 146, 255, 0.32), 0 0 0 2px rgba(255, 255, 255, 0.18);
+}
+
+.syop-swarm-tooltip {
+  position: absolute;
+  z-index: 5;
+  top: 0;
+  left: 0;
+  padding: 0.65rem 0.85rem;
+  border-radius: 14px;
+  background: rgba(12, 16, 28, 0.92);
+  border: 1px solid rgba(132, 146, 255, 0.22);
+  box-shadow: 0 18px 32px rgba(2, 6, 16, 0.52);
+  min-width: 180px;
+  color: #f5f7ff;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  transform: translate3d(0, -12px, 0);
+}
+
+.syop-swarm-tooltip.visible {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+}
+
+.syop-tooltip-name {
+  font-size: 0.86rem;
+  font-weight: 700;
+  margin-bottom: 0.2rem;
+  letter-spacing: 0.04em;
+}
+
+.syop-tooltip-years {
+  font-size: 0.8rem;
+  color: rgba(184, 191, 224, 0.82);
+  margin-bottom: 0.15rem;
+}
+
+.syop-tooltip-share {
+  font-size: 0.78rem;
+  color: rgba(59, 228, 228, 0.88);
+  letter-spacing: 0.04em;
+}
+
+.syop-table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+  margin-top: 0.75rem;
+}
+
+.syop-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 420px;
+  background: rgba(12, 15, 28, 0.72);
+  border-radius: 16px;
+  border: 1px solid rgba(132, 146, 255, 0.16);
+  overflow: hidden;
+}
+
+.syop-table caption {
+  caption-side: top;
+  padding: 0.75rem 1rem;
+  font-size: 0.82rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(184, 191, 224, 0.84);
+}
+
+.syop-table th,
+.syop-table td {
+  padding: 0.65rem 0.75rem;
+  text-align: center;
+  border-bottom: 1px solid rgba(132, 146, 255, 0.12);
+  font-size: 0.83rem;
+  color: rgba(245, 247, 255, 0.86);
+}
+
+.syop-table th[scope='row'] {
+  text-align: left;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(184, 191, 224, 0.86);
+}
+
+.syop-table thead th {
+  font-size: 0.75rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(182, 185, 214, 0.85);
-  background: rgba(10, 13, 24, 0.82);
+  color: rgba(182, 188, 219, 0.8);
+  background: rgba(15, 18, 32, 0.78);
 }
 
-.syop-heatmap-cell.value-cell {
-  color: #f5f7ff;
-  font-weight: 600;
-  font-size: 0.84rem;
-  border: 1px solid rgba(132, 146, 255, 0.18);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+.syop-table-summary td {
+  font-weight: 700;
+  color: rgba(59, 228, 228, 0.9);
 }
 
-.syop-heatmap-bar {
-  position: absolute;
-  left: 6px;
-  top: 6px;
-  bottom: 6px;
-  border-radius: 8px;
-  opacity: 0.9;
+@media (min-width: 1040px) {
+  .syop-violin-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
 }
 
-.syop-heatmap-value {
-  position: relative;
-  z-index: 1;
-  text-shadow: 0 0 6px rgba(11, 14, 22, 0.6);
+@media (max-width: 820px) {
+  .syop-violin-panel {
+    padding: 0.85rem 0.85rem 0.95rem;
+  }
+}
+
+@media (max-width: 620px) {
+  .syop-distribution-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .syop-violin-grid {
+    gap: 1rem;
+  }
+}
+
+@media (max-width: 460px) {
+  .syop-violin-grid {
+    grid-template-columns: repeat(2, minmax(150px, 1fr));
+    overflow-x: auto;
+    padding-bottom: 0.6rem;
+  }
+  .syop-violin-grid::-webkit-scrollbar {
+    height: 6px;
+  }
+  .syop-violin-panel {
+    min-width: 164px;
+  }
 }
 
 .syop-chart {
   width: 100%;
   min-height: 240px;
+  position: relative;
 }
 
 .syop-chart svg {


### PR DESCRIPTION
## Summary
- replace the SYOP heatmap with responsive small-multiple violin + beeswarm panels that surface medians, IQR, outliers and ≥2 SYOP share chips
- add interactive legend filtering, keyboard-focusable swarm dots with tooltips, and a view-as-table toggle for accessibility
- refresh styling to preserve the neon glass aesthetic while adapting layout for desktop and mobile breakpoints

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d0d542357c832ea6ee155b7ba53c7b