### PR TITLE
Add axis titles and refine research panels

### DIFF
--- a/P30920/research/research.html
+++ b/P30920/research/research.html
@@ -150,10 +150,13 @@
       </section>
 
       <section class="syop-section syop-tab-panel" id="draft-tab-panel" role="tabpanel" aria-labelledby="draft-tab-button" hidden>
-        <div class="syop-section-heading">
-          <h2 id="draft-data-heading">NFL Draft &mdash; Player Hit Rates</h2>
-          <p>Overall and positional hit probabilities across draft rounds.</p>
-        </div>
+        <article class="syop-panel syop-panel-wide glass-panel syop-draft-intro">
+          <div class="syop-hero-intro">
+            <div class="syop-pill">NFL Draft Research</div>
+            <h2 id="draft-data-heading">NFL Draft &mdash; Player Hit Rates</h2>
+            <p>Overall and positional hit probabilities across draft rounds.</p>
+          </div>
+        </article>
         <div class="syop-panels-grid syop-draft-grid">
           <article class="syop-panel glass-panel" id="draft-overall-panel">
             <header>

--- a/P30920/scripts/syop.js
+++ b/P30920/scripts/syop.js
@@ -58,6 +58,20 @@
     { SYOP: '12+', 'QB %': 20.0, 'RB %': 0.4, 'WR %': 2.2, 'TE %': 3.85 }
   ];
 
+  const POSITION_CONFIG = [
+    { key: 'QB', percentKey: 'QB %', label: 'Quarterbacks', color: colors.qb },
+    { key: 'RB', percentKey: 'RB %', label: 'Running Backs', color: colors.rb },
+    { key: 'WR', percentKey: 'WR %', label: 'Wide Receivers', color: colors.wr },
+    { key: 'TE', percentKey: 'TE %', label: 'Tight Ends', color: colors.te }
+  ];
+
+  const POSITION_TOTALS = {
+    QB: 52,
+    RB: 96,
+    WR: 107,
+    TE: 42
+  };
+
   const GAUGES = [
     { key: 'QB', value: 7.22, color: colors.qb },
     { key: 'RB', value: 3.39, color: colors.wr },
@@ -106,7 +120,130 @@
     { key: 'TE %', label: 'TE %', color: colors.te }
   ];
 
+  const syopChartState = {
+    activePosition: POSITION_CONFIG[0]?.key || null,
+    showTable: false
+  };
+
+  const { distributionByPosition: SYOP_DISTRIBUTION, summaryByPosition: SYOP_POSITION_SUMMARY } = buildSyopSummary();
+
   let resizeTimer = null;
+
+  function buildSyopSummary() {
+    const distributionByPosition = {};
+    const summaryByPosition = {};
+
+    POSITION_CONFIG.forEach((config) => {
+      const totalPlayers = POSITION_TOTALS[config.key] || 0;
+      const allocation = allocateBucketCounts(config.percentKey, totalPlayers);
+      const valueSamples = [];
+
+      allocation.forEach(({ bucket, count }) => {
+        const numericValue = bucketToNumeric(bucket);
+        for (let i = 0; i < count; i += 1) {
+          valueSamples.push(numericValue);
+        }
+      });
+
+      valueSamples.sort((a, b) => a - b);
+      const { median, q1, q3 } = computeQuantiles(valueSamples);
+      const iqr = q3 - q1;
+      const lowerFence = q1 - 1.5 * iqr;
+      const upperFence = q3 + 1.5 * iqr;
+      const shareTwoPlus = valueSamples.filter((value) => value >= 2).length / (valueSamples.length || 1);
+      const shareThreePlus = valueSamples.filter((value) => value >= 3).length / (valueSamples.length || 1);
+      const outlierCount = valueSamples.filter((value) => value < lowerFence || value > upperFence).length;
+
+      distributionByPosition[config.key] = SYOP_DATA.map((row) => ({
+        bucket: row.SYOP,
+        percentage: row[config.percentKey] || 0
+      }));
+
+      summaryByPosition[config.key] = {
+        total: totalPlayers,
+        median,
+        q1,
+        q3,
+        iqr,
+        shareTwoPlus,
+        shareThreePlus,
+        min: valueSamples[0] || 0,
+        max: valueSamples[valueSamples.length - 1] || 0,
+        outliers: outlierCount
+      };
+    });
+
+    return { distributionByPosition, summaryByPosition };
+  }
+
+  function allocateBucketCounts(percentKey, totalPlayers) {
+    const rows = SYOP_DATA.map((row) => ({
+      bucket: row.SYOP,
+      raw: (row[percentKey] || 0) * totalPlayers / 100
+    }));
+
+    const rounded = rows.map((entry) => Math.round(entry.raw));
+    let diff = totalPlayers - rounded.reduce((sum, value) => sum + value, 0);
+
+    if (diff !== 0) {
+      const adjustments = rows
+        .map((entry, index) => ({ index, fraction: entry.raw - Math.round(entry.raw) }))
+        .sort((a, b) => (diff > 0 ? b.fraction - a.fraction : a.fraction - b.fraction));
+
+      for (let i = 0; i < Math.abs(diff); i += 1) {
+        const target = adjustments[i % adjustments.length]?.index ?? 0;
+        rounded[target] += diff > 0 ? 1 : -1;
+      }
+    }
+
+    return rows.map((row, index) => ({
+      bucket: row.bucket,
+      count: Math.max(0, rounded[index])
+    }));
+  }
+
+  function bucketToNumeric(bucket) {
+    if (typeof bucket !== 'string') return Number(bucket) || 0;
+    if (bucket.includes('+')) {
+      const base = parseFloat(bucket.replace('+', ''));
+      return Number.isNaN(base) ? 0 : base + 0.5;
+    }
+    const value = parseFloat(bucket);
+    return Number.isNaN(value) ? 0 : value;
+  }
+
+  function formatSyopValue(value) {
+    if (value == null || Number.isNaN(value)) return '—';
+    if (value >= 12.25) return '12+';
+    const rounded = Math.round(value * 10) / 10;
+    if (Math.abs(rounded - Math.round(rounded)) < 1e-6) {
+      return String(Math.round(rounded));
+    }
+    return rounded.toFixed(1);
+  }
+
+  function computeQuantiles(values) {
+    if (!values.length) {
+      return { median: 0, q1: 0, q3: 0 };
+    }
+    const sorted = values.slice().sort((a, b) => a - b);
+    const median = quantile(sorted, 0.5);
+    const q1 = quantile(sorted, 0.25);
+    const q3 = quantile(sorted, 0.75);
+    return { median, q1, q3 };
+  }
+
+  function quantile(values, p) {
+    if (values.length === 0) return 0;
+    const pos = (values.length - 1) * p;
+    const lower = Math.floor(pos);
+    const upper = Math.ceil(pos);
+    if (lower === upper) {
+      return values[lower];
+    }
+    const weight = pos - lower;
+    return values[lower] * (1 - weight) + values[upper] * weight;
+  }
 
   function createEl(tag, attrs, ...children) {
     const el = document.createElement(tag);
@@ -411,52 +548,291 @@
     if (!container) return;
     container.innerHTML = '';
 
-    const scroll = createEl('div', { class: 'syop-heatmap-scroll' });
-    const grid = createEl('div', { class: 'syop-heatmap' });
+    const controls = createEl('div', { class: 'syop-bar-controls' });
+    controls.appendChild(createEl('span', { class: 'syop-filter-label' }, 'Positions'));
 
-    const headerRow = createEl('div', { class: 'syop-heatmap-row syop-heatmap-header' },
-      createEl('div', { class: 'syop-heatmap-cell bucket-cell' }, 'SYOP')
-    );
-    SERIES_CONFIG.forEach((series) => {
-      headerRow.appendChild(createEl('div', {
-        class: 'syop-heatmap-cell position-header',
-        style: { '--header-accent': series.color }
-      }, series.label.replace('%', '').trim()));
-    });
-    grid.appendChild(headerRow);
+    if (!syopChartState.activePosition && POSITION_CONFIG.length) {
+      syopChartState.activePosition = POSITION_CONFIG[0].key;
+    }
 
-    const maxValue = Math.max(...SYOP_DATA.flatMap((row) => SERIES_CONFIG.map((series) => row[series.key] || 0)));
+    const legend = createEl('div', { class: 'syop-position-legend', role: 'group', 'aria-label': 'SYOP position filter' });
+    POSITION_CONFIG.forEach((config) => {
+      const isActive = syopChartState.activePosition === config.key;
+      const chip = createEl('button', {
+        type: 'button',
+        class: `syop-legend-chip${isActive ? ' active' : ''}`,
+        style: { '--chip-accent': config.color },
+        'aria-pressed': String(isActive)
+      },
+      createEl('span', { class: 'chip-label' }, config.key));
 
-    SYOP_DATA.forEach((row) => {
-      const rowEl = createEl('div', { class: 'syop-heatmap-row' });
-      rowEl.appendChild(createEl('div', { class: 'syop-heatmap-cell bucket-cell' }, row.SYOP));
-
-      SERIES_CONFIG.forEach((series) => {
-        const value = row[series.key] || 0;
-        const intensity = maxValue > 0 ? value / maxValue : 0;
-        const width = Math.max(12, Math.min(100, intensity * 100));
-        const fill = hexToRgba(series.color, 0.35 + 0.55 * intensity);
-        const bar = createEl('span', {
-          class: 'syop-heatmap-bar',
-          style: {
-            width: `${width}%`,
-            background: fill
-          }
-        });
-        const cell = createEl('div', {
-          class: 'syop-heatmap-cell value-cell',
-          style: { '--accent-color': series.color }
-        },
-        bar,
-        createEl('span', { class: 'syop-heatmap-value' }, `${value.toFixed(1)}%`));
-        rowEl.appendChild(cell);
+      chip.addEventListener('click', () => {
+        if (syopChartState.activePosition === config.key) return;
+        syopChartState.activePosition = config.key;
+        renderBarChart();
       });
+      legend.appendChild(chip);
+    });
+    controls.appendChild(legend);
 
-      grid.appendChild(rowEl);
+    const viewToggle = createEl('button', {
+      type: 'button',
+      class: 'syop-view-toggle',
+      'aria-pressed': String(syopChartState.showTable),
+      'aria-controls': 'syop-distribution-view'
+    }, syopChartState.showTable ? 'View chart' : 'View as table');
+    viewToggle.addEventListener('click', () => {
+      syopChartState.showTable = !syopChartState.showTable;
+      renderBarChart();
+    });
+    controls.appendChild(viewToggle);
+
+    container.appendChild(controls);
+
+    const viewWrapper = createEl('div', { class: 'syop-bar-wrapper', id: 'syop-distribution-view' });
+    container.appendChild(viewWrapper);
+
+    const tooltip = createEl('div', { class: 'syop-bar-tooltip', role: 'tooltip', id: 'syop-bar-tooltip' });
+    container.appendChild(tooltip);
+
+    if (syopChartState.showTable) {
+      renderSyopTable(viewWrapper);
+      tooltip.classList.add('hidden');
+      return;
+    }
+
+    tooltip.classList.remove('hidden');
+    const activeConfig = POSITION_CONFIG.find((config) => config.key === syopChartState.activePosition)
+      || POSITION_CONFIG[0];
+
+    if (!activeConfig) {
+      viewWrapper.appendChild(createEl('p', { class: 'syop-violin-empty' }, 'No positions available.'));
+      return;
+    }
+
+    const metrics = SYOP_POSITION_SUMMARY[activeConfig.key];
+    const distribution = SYOP_DISTRIBUTION[activeConfig.key] || [];
+    const panel = createEl('section', { class: 'syop-violin-panel' });
+
+    const header = createEl('header', { class: 'syop-violin-header' },
+      createEl('div', { class: 'syop-violin-title-block' },
+        createEl('h4', { class: 'syop-violin-title' }, activeConfig.label),
+        createEl('div', { class: 'syop-violin-meta' },
+          createEl('span', null, `${metrics?.total ?? 0} players`),
+          createEl('span', null, `Median ${formatSyopValue(metrics?.median)} yrs`)
+        )
+      )
+    );
+
+    panel.appendChild(header);
+
+    const plot = createEl('div', { class: 'syop-bar-plot' });
+    panel.appendChild(plot);
+    viewWrapper.appendChild(panel);
+
+    drawSyopBarChart(plot, activeConfig, distribution, tooltip, container);
+  }
+
+  function drawSyopBarChart(plotContainer, config, distribution, tooltip, rootContainer) {
+    const containerWidth = plotContainer.clientWidth || plotContainer.parentElement?.clientWidth || 320;
+    const isCompact = window.innerWidth < 720 || containerWidth < 360;
+    const width = Math.max(280, containerWidth);
+    const height = isCompact ? 240 : 300;
+    const margin = isCompact
+      ? { top: 20, right: 14, bottom: 50, left: 38 }
+      : { top: 26, right: 18, bottom: 60, left: 42 };
+
+    const chartWidth = width - margin.left - margin.right;
+    const chartHeight = height - margin.top - margin.bottom;
+
+    const values = distribution.map((entry) => entry.percentage || 0);
+    const maxValue = Math.max(...values, 0);
+    const yMax = maxValue === 0 ? 5 : Math.ceil(maxValue / 5) * 5;
+    const tickStep = yMax > 40 ? 10 : yMax > 20 ? 5 : yMax > 10 ? 2 : 1;
+
+    const scaleY = (value) => {
+      if (yMax === 0) return margin.top + chartHeight;
+      const clamped = Math.max(0, value);
+      return margin.top + chartHeight - (clamped / yMax) * chartHeight;
+    };
+
+    plotContainer.innerHTML = '';
+    const svg = createSVG('svg', {
+      viewBox: `0 0 ${width} ${height}`,
+      class: 'syop-bar-svg'
     });
 
-    scroll.appendChild(grid);
-    container.appendChild(scroll);
+    svg.appendChild(createSVG('rect', {
+      x: margin.left,
+      y: margin.top,
+      width: chartWidth,
+      height: chartHeight,
+      class: 'syop-bar-area'
+    }));
+
+    const axisGroup = createSVG('g');
+
+    for (let tick = 0; tick <= yMax; tick += tickStep) {
+      const y = scaleY(tick);
+      axisGroup.appendChild(createSVG('line', {
+        x1: margin.left,
+        x2: margin.left + chartWidth,
+        y1: y,
+        y2: y,
+        class: 'syop-bar-grid'
+      }));
+      axisGroup.appendChild(createSVG('text', {
+        x: margin.left - 8,
+        y: y + 4,
+        class: 'syop-bar-tick-label'
+      }, document.createTextNode(`${tick}%`)));
+    }
+
+    axisGroup.appendChild(createSVG('line', {
+      x1: margin.left,
+      x2: margin.left,
+      y1: margin.top,
+      y2: margin.top + chartHeight,
+      class: 'syop-bar-axis'
+    }));
+
+    axisGroup.appendChild(createSVG('line', {
+      x1: margin.left,
+      x2: margin.left + chartWidth,
+      y1: margin.top + chartHeight,
+      y2: margin.top + chartHeight,
+      class: 'syop-bar-axis'
+    }));
+
+    svg.appendChild(axisGroup);
+
+    const yAxisAnchorX = margin.left - (isCompact ? 26 : 30);
+    const yAxisAnchorY = margin.top + chartHeight / 2;
+    svg.appendChild(createSVG('text', {
+      x: yAxisAnchorX,
+      y: yAxisAnchorY,
+      class: 'syop-bar-axis-title syop-bar-axis-title-y',
+      transform: `rotate(-90 ${yAxisAnchorX} ${yAxisAnchorY})`
+    }, document.createTextNode('% of position')));
+
+    svg.appendChild(createSVG('text', {
+      x: margin.left + chartWidth / 2,
+      y: margin.top + chartHeight + (isCompact ? 34 : 40),
+      class: 'syop-bar-axis-title syop-bar-axis-title-x'
+    }, document.createTextNode('SYOP')));
+
+    const bandWidth = chartWidth / Math.max(distribution.length, 1);
+    const barWidth = Math.max(10, bandWidth * 0.64);
+
+    distribution.forEach((entry, index) => {
+      const value = entry.percentage || 0;
+      const barHeight = Math.max(0, margin.top + chartHeight - scaleY(value));
+      const x = margin.left + index * bandWidth + (bandWidth - barWidth) / 2;
+      const y = scaleY(value);
+      const rect = createSVG('rect', {
+        x,
+        y,
+        width: barWidth,
+        height: barHeight,
+        rx: 6,
+        class: 'syop-bar-rect',
+        style: {
+          '--bar-fill': hexToRgba(config.color, 0.55),
+          '--bar-stroke': hexToRgba(config.color, 0.9)
+        },
+        tabindex: '0',
+        role: 'button',
+        'aria-label': `${config.key} ${Math.round(value * 10) / 10}%`
+      });
+      attachBarInteractions(rect, config, value, tooltip, rootContainer);
+      svg.appendChild(rect);
+
+      const labelX = margin.left + index * bandWidth + bandWidth / 2;
+      svg.appendChild(createSVG('text', {
+        x: labelX,
+        y: margin.top + chartHeight + 18,
+        class: 'syop-bar-x-label'
+      }, document.createTextNode(entry.bucket)));
+    });
+
+    plotContainer.appendChild(svg);
+  }
+
+  function attachBarInteractions(element, config, percentage, tooltip, rootContainer) {
+    if (!tooltip) return;
+    const color = config.color;
+    const formattedPercent = `${Math.round(percentage * 10) / 10}%`;
+
+    const hideTooltip = () => {
+      element.classList.remove('active');
+      tooltip.classList.remove('visible');
+    };
+
+    const showTooltip = () => {
+      element.classList.add('active');
+      tooltip.innerHTML = '';
+      tooltip.style.setProperty('--tooltip-accent', color);
+      tooltip.appendChild(createEl('div', { class: 'tooltip-name' }, config.key));
+      tooltip.appendChild(createEl('div', { class: 'tooltip-meta' }, formattedPercent));
+
+      const rootRect = rootContainer.getBoundingClientRect();
+      const barRect = element.getBoundingClientRect();
+      const containerWidth = rootRect.width;
+      let left = barRect.left - rootRect.left + barRect.width / 2;
+      left = Math.max(20, Math.min(containerWidth - 20, left));
+      const top = barRect.top - rootRect.top - 8;
+      tooltip.style.left = `${left}px`;
+      tooltip.style.top = `${top}px`;
+      tooltip.classList.add('visible');
+    };
+
+    element.addEventListener('mouseenter', showTooltip);
+    element.addEventListener('focus', showTooltip);
+    element.addEventListener('mouseleave', hideTooltip);
+    element.addEventListener('blur', hideTooltip);
+    element.addEventListener('click', (event) => {
+      event.preventDefault();
+      showTooltip();
+    });
+  }
+  function renderSyopTable(wrapper) {
+    wrapper.innerHTML = '';
+    const tableWrapper = createEl('div', { class: 'syop-table-wrapper' });
+    const table = createEl('table', { class: 'syop-table' });
+    table.appendChild(createEl('caption', null, 'SYOP distribution summary by position'));
+
+    const thead = createEl('thead', null,
+      createEl('tr', null,
+        createEl('th', null, 'Position'),
+        createEl('th', null, 'Players'),
+        createEl('th', null, 'Median SYOP'),
+        createEl('th', null, 'IQR (25%–75%)'),
+        createEl('th', null, '≥2 SYOP'),
+        createEl('th', null, '≥3 SYOP'),
+        createEl('th', null, 'Max'),
+        createEl('th', null, 'Outliers')
+      )
+    );
+    table.appendChild(thead);
+
+    const tbody = createEl('tbody');
+    POSITION_CONFIG.forEach((config) => {
+      const metrics = SYOP_POSITION_SUMMARY[config.key];
+      tbody.appendChild(createEl('tr', null,
+        createEl('th', { scope: 'row' }, `${config.key} · ${config.label}`),
+        createEl('td', null, metrics ? String(metrics.total) : '0'),
+        createEl('td', null, metrics ? formatSyopValue(metrics.median) : '—'),
+        createEl('td', null, metrics ? `${formatSyopValue(metrics.q1)} – ${formatSyopValue(metrics.q3)}` : '—'),
+        createEl('td', null, metrics ? `${Math.round((metrics.shareTwoPlus || 0) * 100)}%` : '—'),
+        createEl('td', null, metrics ? `${Math.round((metrics.shareThreePlus || 0) * 100)}%` : '—'),
+        createEl('td', null, metrics ? formatSyopValue(metrics.max) : '—'),
+        createEl('td', null, metrics ? String(metrics.outliers || 0) : '0')
+      ));
+    });
+
+    table.appendChild(tbody);
+    tableWrapper.appendChild(table);
+    wrapper.appendChild(tableWrapper);
   }
 
   function renderGauges() {

--- a/P30920/styles/styles.css
+++ b/P30920/styles/styles.css
@@ -4473,6 +4473,14 @@ body[data-page="research"] .app-header {
   --outerA: 0.32;
 }
 
+.syop-panel header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #f4f5fb;
+}
+
 .syop-panel header h3 {
   font-size: 1rem;
   margin: 0;
@@ -4487,10 +4495,78 @@ body[data-page="research"] .app-header {
   font-size: 0.86rem;
 }
 
+.syop-draft-intro {
+  margin-bottom: 1.25rem;
+  padding: 1.15rem 1.35rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.syop-draft-intro .syop-hero-intro {
+  align-items: flex-start;
+  text-align: left;
+  gap: 0.5rem;
+}
+
+.syop-draft-intro .syop-hero-intro .syop-pill {
+  align-self: flex-start;
+}
+
+.syop-draft-intro h2 {
+  margin: 0.2rem 0 0.15rem;
+  font-size: clamp(1.35rem, 1.12rem + 0.8vw, 1.85rem);
+  letter-spacing: -0.015em;
+  color: rgba(245, 247, 255, 0.96);
+}
+
+.syop-draft-intro p {
+  margin: 0;
+  color: rgba(186, 194, 230, 0.85);
+  font-size: 0.95rem;
+  max-width: 44ch;
+}
+
+.syop-draft-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 1.1rem;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.syop-draft-meta .syop-hero-meta-item {
+  background: rgba(18, 22, 38, 0.52);
+  border: 1px solid rgba(132, 146, 255, 0.18);
+  border-radius: 14px;
+  padding: 0.45rem 0.8rem;
+  backdrop-filter: blur(8px);
+}
+
+.syop-draft-meta .syop-hero-meta-item .meta-label {
+  color: rgba(190, 198, 236, 0.82);
+}
+
+.syop-draft-meta .syop-hero-meta-item .meta-value {
+  color: rgba(235, 238, 255, 0.92);
+}
+
 #syop-sunburst-panel,
 #syop-gauges,
 .syop-panel-wide {
   grid-column: 1 / -1;
+}
+
+#syop-bar-panel {
+  justify-self: center;
+  max-width: 540px;
+  width: 100%;
+}
+
+@media (min-width: 1280px) {
+  #syop-bar-panel {
+    max-width: 500px;
+  }
 }
 
 .syop-panel-body {
@@ -4565,139 +4641,6 @@ body[data-page="research"] .app-header {
   letter-spacing: 0.32em;
 }
 
-.syop-bar-controls {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.syop-filter-label {
-  font-size: 0.72rem;
-  letter-spacing: 0.28em;
-  text-transform: uppercase;
-  color: rgba(182, 185, 214, 0.8);
-}
-
-.syop-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.6rem;
-  padding: 0.45rem 0.75rem;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(17, 20, 35, 0.65);
-  cursor: pointer;
-  font-size: 0.85rem;
-  color: rgba(233, 236, 249, 0.9);
-  transition: border-color 0.2s ease, background 0.2s ease;
-}
-
-.syop-toggle input {
-  display: none;
-}
-
-.syop-toggle .swatch {
-  width: 0.7rem;
-  height: 0.7rem;
-  border-radius: 999px;
-  flex: 0 0 auto;
-}
-
-.syop-toggle .slider {
-  position: relative;
-  width: 34px;
-  height: 18px;
-  border-radius: 999px;
-  background: rgba(148, 163, 184, 0.35);
-  transition: background 0.2s ease;
-}
-
-.syop-toggle .slider::after {
-  content: '';
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background: #fff;
-  transition: transform 0.2s ease;
-}
-
-.syop-toggle input:checked + .slider {
-  background: rgba(99, 102, 241, 0.75);
-}
-
-.syop-toggle input:checked + .slider::after {
-  transform: translateX(14px);
-}
-
-.syop-toggle .toggle-label {
-  font-size: 0.85rem;
-  letter-spacing: 0.02em;
-}
-
-.syop-toggle:hover {
-  border-color: rgba(118, 109, 255, 0.45);
-}
-
-.syop-toggle--stacked .swatch.stacked {
-  background: rgba(148, 163, 184, 0.65) !important;
-}
-
-.syop-toggle-spacer {
-  flex: 1 1 auto;
-}
-
-
-.syop-heatmap-scroll {
-  width: 100%;
-  overflow-x: hidden;
-  padding-bottom: 0.35rem;
-}
-
-.syop-heatmap-scroll::-webkit-scrollbar {
-  height: 6px;
-}
-
-.syop-heatmap-scroll::-webkit-scrollbar-thumb {
-  background: rgba(132, 146, 255, 0.35);
-  border-radius: 999px;
-}
-
-.syop-heatmap {
-  width: 100%;
-  display: grid;
-  gap: 0.3rem;
-  padding: 0.55rem;
-  background: rgba(12, 15, 28, 0.72);
-  border-radius: 14px;
-  border: 1px solid rgba(132, 146, 255, 0.14);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
-}
-
-.syop-heatmap-row {
-  display: grid;
-  grid-template-columns: minmax(48px, 0.8fr) repeat(4, minmax(0, 1fr));
-  gap: 0.3rem;
-  align-items: stretch;
-}
-
-.syop-heatmap-row.syop-heatmap-header {
-  font-size: 0.72rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: rgba(182, 185, 214, 0.72);
-}
-
-.syop-heatmap-row.syop-heatmap-header .syop-heatmap-cell {
-  background: transparent;
-  border: none;
-  padding: 0 0.4rem 0.35rem;
-  justify-content: center;
-}
-
 .syop-heatmap-row.syop-heatmap-header .position-header {
   color: rgba(244, 246, 255, 0.82);
 }
@@ -4760,6 +4703,7 @@ body[data-page="research"] .app-header {
 .syop-chart {
   width: 100%;
   min-height: 240px;
+  position: relative;
 }
 
 .syop-chart svg {
@@ -5174,3 +5118,380 @@ body[data-page="research"] .app-header {
     font-size: 0.72rem;
   }
 }
+.syop-bar-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.syop-filter-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(182, 185, 214, 0.78);
+}
+
+.syop-position-legend {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0.65rem;
+  align-items: center;
+  overflow-x: auto;
+  padding-bottom: 0.2rem;
+}
+
+.syop-position-legend::-webkit-scrollbar {
+  height: 4px;
+}
+
+.syop-position-legend::-webkit-scrollbar-thumb {
+  background: rgba(120, 130, 190, 0.45);
+  border-radius: 999px;
+}
+
+.syop-legend-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 76px;
+  padding: 0.55rem 0.75rem;
+  border-radius: 16px;
+  border: 1px solid rgba(132, 146, 255, 0.22);
+  background: linear-gradient(135deg, rgba(16, 19, 36, 0.78), rgba(10, 13, 24, 0.6));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 10px 24px rgba(10, 16, 38, 0.38);
+  cursor: pointer;
+  color: rgba(235, 238, 255, 0.92);
+  backdrop-filter: blur(12px);
+  transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+  text-align: center;
+}
+
+.syop-legend-chip .chip-label {
+  font-size: 0.68rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(244, 246, 255, 0.92);
+}
+
+.syop-legend-chip:hover,
+.syop-legend-chip:focus-visible {
+  border-color: rgba(132, 146, 255, 0.45);
+  transform: translateY(-1px);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06), 0 12px 26px rgba(12, 18, 44, 0.45);
+  outline: none;
+}
+
+.syop-legend-chip.active {
+  border-color: rgba(255, 255, 255, 0.42);
+  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.16), rgba(20, 25, 44, 0.82));
+  box-shadow: 0 18px 32px rgba(14, 22, 48, 0.58);
+}
+
+.syop-legend-chip.active .chip-label {
+  color: var(--chip-accent, #7c83ff);
+}
+
+.syop-view-toggle {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 255, 0.28);
+  background: rgba(20, 24, 42, 0.72);
+  color: rgba(232, 236, 255, 0.94);
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.syop-view-toggle:hover,
+.syop-view-toggle:focus-visible {
+  border-color: rgba(132, 146, 255, 0.6);
+  background: rgba(24, 30, 54, 0.9);
+  outline: none;
+}
+
+
+.syop-bar-wrapper {
+  position: relative;
+}
+
+.syop-violin-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.85rem 0.85rem 1rem;
+  border-radius: 20px;
+  background: linear-gradient(150deg, rgba(15, 18, 33, 0.76), rgba(9, 12, 24, 0.64));
+  border: 1px solid rgba(132, 146, 255, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 22px 38px rgba(10, 14, 32, 0.45);
+  backdrop-filter: blur(14px);
+  width: min(100%, 580px);
+  margin: 0 auto;
+}
+
+.syop-violin-header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 1rem;
+}
+
+.syop-violin-title-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.syop-violin-title {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(244, 247, 255, 0.96);
+}
+
+.syop-violin-meta {
+  display: flex;
+  gap: 0.6rem;
+  font-size: 0.78rem;
+  color: rgba(177, 185, 225, 0.82);
+  letter-spacing: 0.04em;
+}
+
+.syop-violin-chip {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.12rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 14px;
+  background: rgba(26, 30, 53, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 12px rgba(255, 255, 255, 0.05), 0 12px 20px rgba(12, 16, 34, 0.45);
+  color: rgba(235, 238, 255, 0.92);
+  backdrop-filter: blur(10px);
+}
+
+.syop-violin-chip .chip-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(190, 198, 236, 0.86);
+}
+
+.syop-violin-chip .chip-value {
+  font-size: 1.08rem;
+  font-weight: 700;
+  color: var(--chip-accent, #7c83ff);
+}
+
+.syop-bar-plot {
+  width: 100%;
+  min-height: 220px;
+  position: relative;
+}
+
+.syop-bar-svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.syop-bar-area {
+  fill: rgba(14, 18, 34, 0.58);
+  stroke: rgba(255, 255, 255, 0.06);
+  stroke-width: 1px;
+}
+
+.syop-bar-grid {
+  stroke: rgba(255, 255, 255, 0.08);
+  stroke-width: 1;
+}
+
+.syop-bar-axis {
+  stroke: rgba(132, 146, 255, 0.32);
+  stroke-width: 1.4;
+}
+
+.syop-bar-tick-label {
+  font-size: 0.7rem;
+  fill: rgba(186, 194, 230, 0.86);
+  letter-spacing: 0.05em;
+  text-anchor: end;
+}
+
+.syop-bar-x-label {
+  font-size: 0.74rem;
+  fill: rgba(186, 194, 230, 0.88);
+  letter-spacing: 0.06em;
+  text-anchor: middle;
+}
+
+.syop-bar-axis-title {
+  font-size: 0.66rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  fill: rgba(186, 194, 230, 0.8);
+  font-weight: 700;
+}
+
+.syop-bar-axis-title-y {
+  text-anchor: middle;
+}
+
+.syop-bar-axis-title-x {
+  text-anchor: middle;
+}
+
+.syop-bar-rect {
+  fill: var(--bar-fill, rgba(124, 131, 255, 0.52));
+  stroke: var(--bar-stroke, rgba(124, 131, 255, 0.85));
+  stroke-width: 1.6;
+  cursor: pointer;
+  transition: transform 0.18s ease, stroke-width 0.18s ease, filter 0.18s ease;
+  filter: drop-shadow(0 10px 18px rgba(8, 10, 24, 0.45));
+}
+
+.syop-bar-rect:hover,
+.syop-bar-rect:focus-visible,
+.syop-bar-rect.active {
+  transform: translateY(-4px);
+  stroke-width: 2.2;
+  outline: none;
+}
+
+.syop-bar-tooltip {
+  position: absolute;
+  z-index: 10;
+  pointer-events: none;
+  opacity: 0;
+  transform: translate(-50%, calc(-100% - 12px));
+  background: rgba(14, 18, 34, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 12px;
+  padding: 0.55rem 0.75rem;
+  min-width: 160px;
+  max-width: 220px;
+  box-shadow: 0 18px 28px rgba(10, 14, 32, 0.58), 0 0 0 1px var(--tooltip-accent, rgba(124, 131, 255, 0.5));
+  backdrop-filter: blur(14px);
+  transition: opacity 0.15s ease;
+  color: rgba(238, 240, 255, 0.95);
+}
+
+.syop-bar-tooltip::after {
+  content: '';
+  position: absolute;
+  bottom: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 8px 7px 0 7px;
+  border-style: solid;
+  border-color: rgba(14, 18, 34, 0.92) transparent transparent transparent;
+}
+
+.syop-bar-tooltip.visible {
+  opacity: 1;
+}
+
+.syop-bar-tooltip .tooltip-name {
+  font-size: 0.92rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: rgba(248, 250, 255, 0.96);
+}
+
+.syop-bar-tooltip .tooltip-meta {
+  font-size: 0.75rem;
+  color: rgba(177, 185, 214, 0.86);
+  letter-spacing: 0.04em;
+  margin-top: 0.15rem;
+}
+
+.syop-violin-empty {
+  padding: 1.2rem;
+  text-align: center;
+  color: rgba(182, 190, 228, 0.84);
+  letter-spacing: 0.04em;
+}
+
+.syop-table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+  border-radius: 18px;
+  border: 1px solid rgba(132, 146, 255, 0.24);
+  background: linear-gradient(150deg, rgba(16, 20, 36, 0.82), rgba(8, 11, 22, 0.74));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 20px 34px rgba(10, 14, 32, 0.5);
+  backdrop-filter: blur(12px);
+}
+
+.syop-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+  color: rgba(232, 236, 255, 0.92);
+}
+
+.syop-table caption {
+  caption-side: top;
+  text-align: center;
+  padding: 0.9rem 1.1rem 0.5rem;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(190, 198, 236, 0.9);
+}
+
+.syop-table th,
+.syop-table td {
+  padding: 0.75rem 1.1rem;
+  border-bottom: 1px solid rgba(148, 163, 255, 0.16);
+  text-align: center;
+}
+
+.syop-table th {
+  font-weight: 600;
+  color: rgba(214, 220, 255, 0.9);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  text-align: center;
+}
+
+.syop-table tbody tr:last-child th,
+.syop-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.syop-table tbody tr:hover {
+  background: rgba(20, 24, 44, 0.55);
+}
+
+@media (max-width: 920px) {
+  .syop-violin-panel {
+    padding: 0.8rem 0.85rem 0.95rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .syop-bar-controls {
+    gap: 0.7rem;
+  }
+
+  .syop-view-toggle {
+    margin-left: 0;
+  }
+}
+
+@media (max-width: 360px) {
+  .syop-legend-chip {
+    min-width: 0;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add compact axis titles and adjusted margins to the SYOP positional bar chart rendering
- style the bar panel for a narrower desktop footprint and introduce reusable axis title styles
- simplify the NFL Draft hit-rate intro panel to focus on the requested glass title block

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d0d542357c832ea6ee155b7ba53c7b