### PR TITLE
Switch research and analyzer navigation and enhance SYOP visuals

### DIFF
--- a/P30920/analyzer/analyzer.html
+++ b/P30920/analyzer/analyzer.html
@@ -161,14 +161,14 @@
                                 <i class="fa-solid fa-percent" aria-hidden="true"></i>
                                 <span>Ownership</span>
                             </a>
-            <a href="#" id="menu-analyzer">
-                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-                <span>League Analyzer</span>
-            </a>
-            <a href="#" id="menu-research">
-                <i class="fa-solid fa-flask" aria-hidden="true"></i>
-                <span>Research</span>
-            </a>
+                            <a href="#" id="menu-research">
+                                <i class="fa-solid fa-flask" aria-hidden="true"></i>
+                                <span>Research</span>
+                            </a>
+                            <a href="#" id="menu-analyzer">
+                                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+                                <span>League Analyzer</span>
+                            </a>
                         </div>
                     </div>
                     <div class="username-area">

--- a/P30920/index.html
+++ b/P30920/index.html
@@ -52,13 +52,13 @@
             <i class="fa-solid fa-percent" aria-hidden="true"></i>
             <span>Ownership</span>
         </a>
-        <a href="#" id="menu-analyzer">
-            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-            <span>League Analyzer</span>
-        </a>
         <a href="#" id="menu-research">
             <i class="fa-solid fa-flask" aria-hidden="true"></i>
             <span>Research</span>
+        </a>
+        <a href="#" id="menu-analyzer">
+            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+            <span>League Analyzer</span>
         </a>
     </div>
 </div>

--- a/P30920/ownership/ownership.html
+++ b/P30920/ownership/ownership.html
@@ -50,14 +50,14 @@
             <i class="fa-solid fa-percent" aria-hidden="true"></i>
             <span>Ownership</span>
         </a>
-            <a href="#" id="menu-analyzer">
-                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-                <span>League Analyzer</span>
-            </a>
-            <a href="#" id="menu-research">
-                <i class="fa-solid fa-flask" aria-hidden="true"></i>
-                <span>Research</span>
-            </a>
+        <a href="#" id="menu-research">
+            <i class="fa-solid fa-flask" aria-hidden="true"></i>
+            <span>Research</span>
+        </a>
+        <a href="#" id="menu-analyzer">
+            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+            <span>League Analyzer</span>
+        </a>
     </div>
 </div>
 <div class="username-area">

--- a/P30920/research/research.html
+++ b/P30920/research/research.html
@@ -52,13 +52,13 @@
               <i class="fa-solid fa-percent" aria-hidden="true"></i>
               <span>Ownership</span>
             </a>
-            <a href="#" id="menu-analyzer">
-              <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-              <span>League Analyzer</span>
-            </a>
             <a href="#" id="menu-research" class="active">
               <i class="fa-solid fa-flask" aria-hidden="true"></i>
               <span>Research</span>
+            </a>
+            <a href="#" id="menu-analyzer">
+              <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+              <span>League Analyzer</span>
             </a>
           </div>
         </div>

--- a/P30920/rosters/rosters.html
+++ b/P30920/rosters/rosters.html
@@ -50,14 +50,14 @@
             <i class="fa-solid fa-percent" aria-hidden="true"></i>
             <span>Ownership</span>
         </a>
-            <a href="#" id="menu-analyzer">
-                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-                <span>League Analyzer</span>
-            </a>
-            <a href="#" id="menu-research">
-                <i class="fa-solid fa-flask" aria-hidden="true"></i>
-                <span>Research</span>
-            </a>
+        <a href="#" id="menu-research">
+            <i class="fa-solid fa-flask" aria-hidden="true"></i>
+            <span>Research</span>
+        </a>
+        <a href="#" id="menu-analyzer">
+            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+            <span>League Analyzer</span>
+        </a>
     </div>
 </div>
 <div class="header-quick-links" id="header-quick-links" aria-label="Research shortcuts"></div>

--- a/P30920/scripts/app.js
+++ b/P30920/scripts/app.js
@@ -163,11 +163,11 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             const quickLinksQuery = window.matchMedia('(min-width: 1024px)');
             const placeQuickLinks = (isDesktop) => {
                 if (isDesktop) {
-                    if (!headerQuickLinks.contains(analyzerButtonContainer)) {
-                        headerQuickLinks.appendChild(analyzerButtonContainer);
-                    }
                     if (!headerQuickLinks.contains(researchButtonContainer)) {
                         headerQuickLinks.appendChild(researchButtonContainer);
+                    }
+                    if (!headerQuickLinks.contains(analyzerButtonContainer)) {
+                        headerQuickLinks.appendChild(analyzerButtonContainer);
                     }
                 } else {
                     if (!analyzerButtonSlot.contains(analyzerButtonContainer)) {

--- a/P30920/scripts/syop.js
+++ b/P30920/scripts/syop.js
@@ -65,6 +65,33 @@
     { key: 'TE', percentKey: 'TE %', label: 'Tight Ends', color: colors.te }
   ];
 
+  const BAR_GRADIENTS = {
+    QB: [
+      { offset: '0%', color: 'rgba(59, 228, 228, 0.92)' },
+      { offset: '54%', color: 'rgba(122, 114, 255, 0.88)' },
+      { offset: '100%', color: '#4723FF' }
+    ],
+    RB: [
+      { offset: '0%', color: 'rgba(255, 117, 209, 0.92)' },
+      { offset: '58%', color: 'rgba(255, 157, 112, 0.88)' },
+      { offset: '100%', color: '#FF3B8F' }
+    ],
+    WR: [
+      { offset: '0%', color: 'rgba(124, 131, 255, 0.92)' },
+      { offset: '56%', color: 'rgba(255, 142, 208, 0.9)' },
+      { offset: '100%', color: '#7A2DFF' }
+    ],
+    TE: [
+      { offset: '0%', color: 'rgba(70, 231, 255, 0.92)' },
+      { offset: '60%', color: 'rgba(134, 255, 205, 0.88)' },
+      { offset: '100%', color: '#2BC4A5' }
+    ],
+    DEFAULT: [
+      { offset: '0%', color: 'rgba(124, 131, 255, 0.82)' },
+      { offset: '100%', color: '#5C4BFF' }
+    ]
+  };
+
   const POSITION_TOTALS = {
     QB: 52,
     RB: 96,
@@ -662,6 +689,33 @@
       class: 'syop-bar-svg'
     });
 
+    const gradientStops = BAR_GRADIENTS[config.key] || BAR_GRADIENTS.DEFAULT;
+    const gradientId = `syop-bar-gradient-${config.key.toLowerCase()}`;
+    const defs = createSVG('defs');
+    const gradient = createSVG('linearGradient', {
+      id: gradientId,
+      gradientUnits: 'userSpaceOnUse',
+      x1: margin.left,
+      y1: margin.top + chartHeight,
+      x2: margin.left,
+      y2: margin.top
+    });
+
+    gradientStops.forEach((stop) => {
+      if (!stop) return;
+      const attrs = {
+        offset: stop.offset ?? '0%',
+        'stop-color': stop.color || '#7C83FF'
+      };
+      if (typeof stop.opacity === 'number') {
+        attrs['stop-opacity'] = String(stop.opacity);
+      }
+      gradient.appendChild(createSVG('stop', attrs));
+    });
+
+    defs.appendChild(gradient);
+    svg.appendChild(defs);
+
     svg.appendChild(createSVG('rect', {
       x: margin.left,
       y: margin.top,
@@ -705,17 +759,17 @@
     }));
 
     const axisTitleY = createSVG('text', {
-      x: margin.left - 32,
+      x: margin.left - 33,
       y: margin.top + chartHeight / 2,
       class: 'syop-bar-axis-title syop-bar-axis-title-y',
-      transform: `rotate(-90 ${margin.left - 32} ${margin.top + chartHeight / 2})`
+      transform: `rotate(-90 ${margin.left - 33} ${margin.top + chartHeight / 2})`
     }, document.createTextNode('% of position'));
 
     axisGroup.appendChild(axisTitleY);
 
     const axisTitleX = createSVG('text', {
       x: margin.left + chartWidth / 2,
-      y: margin.top + chartHeight + 46,
+      y: margin.top + chartHeight + 40,
       class: 'syop-bar-axis-title syop-bar-axis-title-x'
     }, document.createTextNode('SYOP'));
 
@@ -725,6 +779,8 @@
 
     const bandWidth = chartWidth / Math.max(distribution.length, 1);
     const barWidth = Math.max(10, bandWidth * 0.64);
+
+    const gradientStroke = (gradientStops[gradientStops.length - 1] || {}).color || config.color;
 
     distribution.forEach((entry, index) => {
       const value = entry.percentage || 0;
@@ -738,15 +794,12 @@
         height: barHeight,
         rx: 6,
         class: 'syop-bar-rect',
-        style: {
-          '--bar-fill': hexToRgba(config.color, 0.38),
-          '--bar-stroke': hexToRgba(config.color, 0.82)
-        },
+        style: `--bar-stroke: ${gradientStroke}; fill: url(#${gradientId});`,
         tabindex: '0',
         role: 'button',
         'aria-label': `${config.key} ${Math.round(value * 10) / 10}%`
       });
-      attachBarInteractions(rect, config, value, tooltip, rootContainer);
+      attachBarInteractions(rect, config, value, tooltip, rootContainer, gradientStroke);
       svg.appendChild(rect);
 
       const labelX = margin.left + index * bandWidth + bandWidth / 2;
@@ -760,9 +813,9 @@
     plotContainer.appendChild(svg);
   }
 
-  function attachBarInteractions(element, config, percentage, tooltip, rootContainer) {
+  function attachBarInteractions(element, config, percentage, tooltip, rootContainer, accentColor) {
     if (!tooltip) return;
-    const color = config.color;
+    const color = accentColor || config.color;
     const formattedPercent = `${Math.round(percentage * 10) / 10}%`;
 
     const hideTooltip = () => {

--- a/P30920/styles/styles.css
+++ b/P30920/styles/styles.css
@@ -4312,23 +4312,23 @@ body[data-page="research"] .app-header {
   gap: 0.26rem;
   padding: 0.62rem 0.8rem;
   border-radius: 12px;
-  background: rgba(12, 15, 28, 0.78);
-  border: 1px solid rgba(132, 146, 255, 0.14);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  background: rgba(16, 20, 34, 0.32);
+  border: 1px solid rgba(132, 146, 255, 0.24);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03), 0 14px 28px rgba(5, 8, 22, 0.28);
 }
 
 .syop-hero-card .label {
   font-size: 0.64rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(182, 185, 214, 0.74);
+  color: rgba(182, 185, 214, 0.8);
 }
 
 .syop-hero-card .value {
   font-size: 0.88rem;
   font-weight: 600;
   line-height: 1.28;
-  color: #f4f6ff;
+  color: rgba(232, 235, 255, 0.94);
 }
 
 
@@ -4810,10 +4810,10 @@ body[data-page="research"] .app-header {
   gap: 0.5rem;
   margin-top: 0.35rem;
   padding: 0.75rem 0.9rem;
-  background: rgba(14, 17, 30, 0.78);
-  border: 1px solid rgba(132, 146, 255, 0.14);
+  background: rgba(16, 20, 34, 0.32);
+  border: 1px solid rgba(132, 146, 255, 0.24);
   border-radius: 16px;
-  box-shadow: 0 12px 24px rgba(4, 7, 16, 0.35);
+  box-shadow: 0 18px 32px rgba(4, 7, 16, 0.32);
   backdrop-filter: blur(12px);
 }
 
@@ -4822,7 +4822,9 @@ body[data-page="research"] .app-header {
 }
 
 .syop-key-legend .syop-hero-card {
-  background: rgba(10, 13, 24, 0.78);
+  background: rgba(18, 22, 36, 0.42);
+  border-color: rgba(168, 178, 255, 0.3);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 12px 24px rgba(4, 7, 16, 0.28);
 }
 
 .syop-line-legend {
@@ -5319,8 +5321,8 @@ body[data-page="research"] .app-header {
 }
 
 .syop-bar-area {
-  fill: rgba(14, 18, 34, 0.58);
-  stroke: rgba(255, 255, 255, 0.06);
+  fill: rgba(14, 18, 34, 0.22);
+  stroke: rgba(128, 142, 204, 0.18);
   stroke-width: 1px;
 }
 


### PR DESCRIPTION
## Summary
- Reorder Research ahead of League Analyzer across navigation, including desktop quick links.
- Restyle SYOP legend chips to match the hero metadata styling.
- Update SYOP positional bar chart with gradient fills, lighter canvas, and refined axis spacing.

## Testing
- No automated tests were run (not provided).


------
https://chatgpt.com/codex/tasks/task_e_68d107544e54832eb9b2efad6f76c2ce