### PR TITLE
Reorder Research nav and refresh SYOP visuals

### DIFF
--- a/P30920/analyzer/analyzer.html
+++ b/P30920/analyzer/analyzer.html
@@ -161,13 +161,13 @@
                                 <i class="fa-solid fa-percent" aria-hidden="true"></i>
                                 <span>Ownership</span>
                             </a>
-            <a href="#" id="menu-analyzer">
-                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-                <span>League Analyzer</span>
-            </a>
             <a href="#" id="menu-research">
                 <i class="fa-solid fa-flask" aria-hidden="true"></i>
                 <span>Research</span>
+            </a>
+            <a href="#" id="menu-analyzer">
+                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+                <span>League Analyzer</span>
             </a>
                         </div>
                     </div>

--- a/P30920/index.html
+++ b/P30920/index.html
@@ -52,13 +52,13 @@
             <i class="fa-solid fa-percent" aria-hidden="true"></i>
             <span>Ownership</span>
         </a>
-        <a href="#" id="menu-analyzer">
-            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-            <span>League Analyzer</span>
-        </a>
         <a href="#" id="menu-research">
             <i class="fa-solid fa-flask" aria-hidden="true"></i>
             <span>Research</span>
+        </a>
+        <a href="#" id="menu-analyzer">
+            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+            <span>League Analyzer</span>
         </a>
     </div>
 </div>

--- a/P30920/ownership/ownership.html
+++ b/P30920/ownership/ownership.html
@@ -50,14 +50,14 @@
             <i class="fa-solid fa-percent" aria-hidden="true"></i>
             <span>Ownership</span>
         </a>
-            <a href="#" id="menu-analyzer">
-                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-                <span>League Analyzer</span>
-            </a>
-            <a href="#" id="menu-research">
-                <i class="fa-solid fa-flask" aria-hidden="true"></i>
-                <span>Research</span>
-            </a>
+        <a href="#" id="menu-research">
+            <i class="fa-solid fa-flask" aria-hidden="true"></i>
+            <span>Research</span>
+        </a>
+        <a href="#" id="menu-analyzer">
+            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+            <span>League Analyzer</span>
+        </a>
     </div>
 </div>
 <div class="username-area">

--- a/P30920/research/research.html
+++ b/P30920/research/research.html
@@ -52,13 +52,13 @@
               <i class="fa-solid fa-percent" aria-hidden="true"></i>
               <span>Ownership</span>
             </a>
-            <a href="#" id="menu-analyzer">
-              <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-              <span>League Analyzer</span>
-            </a>
             <a href="#" id="menu-research" class="active">
               <i class="fa-solid fa-flask" aria-hidden="true"></i>
               <span>Research</span>
+            </a>
+            <a href="#" id="menu-analyzer">
+              <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+              <span>League Analyzer</span>
             </a>
           </div>
         </div>

--- a/P30920/rosters/rosters.html
+++ b/P30920/rosters/rosters.html
@@ -50,14 +50,14 @@
             <i class="fa-solid fa-percent" aria-hidden="true"></i>
             <span>Ownership</span>
         </a>
-            <a href="#" id="menu-analyzer">
-                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-                <span>League Analyzer</span>
-            </a>
             <a href="#" id="menu-research">
                 <i class="fa-solid fa-flask" aria-hidden="true"></i>
                 <span>Research</span>
             </a>
+        <a href="#" id="menu-analyzer">
+            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+            <span>League Analyzer</span>
+        </a>
     </div>
 </div>
 <div class="header-quick-links" id="header-quick-links" aria-label="Research shortcuts"></div>
@@ -71,13 +71,13 @@
 </div>
 <div class="hidden" id="contextual-controls">
 <div class="header-row" id="secondary-header-row">
-<div class="analyzer-button-slot" id="analyzer-button-slot">
-<div class="analyzer-button-container">
-    <button aria-label="Open League Analyzer" class="menu-button analyzer-button" id="analyzeLeagueButton" type="button">
-        <i class="fa-solid fa-square-poll-vertical analyzer-icon" aria-hidden="true"></i>
-        <span class="analyzer-label">Analyzer</span>
-    </button>
-</div>
+<div class="research-button-slot" id="research-button-slot">
+    <div class="research-button-container">
+        <button class="menu-button analyzer-button research-button" id="researchButton" type="button" aria-label="Open Research insights">
+            <i class="fa-solid fa-flask-vial analyzer-icon" aria-hidden="true"></i>
+            <span class="analyzer-label">Research</span>
+        </button>
+    </div>
 </div>
 <div class="custom-select-wrapper">
 <select disabled="" id="leagueSelect">
@@ -90,11 +90,11 @@
 </div>
 </div>
 <div class="header-row" id="filters-row">
-    <div class="research-button-slot" id="research-button-slot">
-    <div class="research-button-container">
-        <button class="menu-button analyzer-button research-button" id="researchButton" type="button" aria-label="Open Research insights">
-            <i class="fa-solid fa-flask-vial analyzer-icon" aria-hidden="true"></i>
-            <span class="analyzer-label">Research</span>
+    <div class="analyzer-button-slot" id="analyzer-button-slot">
+    <div class="analyzer-button-container">
+        <button aria-label="Open League Analyzer" class="menu-button analyzer-button" id="analyzeLeagueButton" type="button">
+            <i class="fa-solid fa-square-poll-vertical analyzer-icon" aria-hidden="true"></i>
+            <span class="analyzer-label">Analyzer</span>
         </button>
     </div>
     </div>

--- a/P30920/scripts/app.js
+++ b/P30920/scripts/app.js
@@ -163,18 +163,21 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             const quickLinksQuery = window.matchMedia('(min-width: 1024px)');
             const placeQuickLinks = (isDesktop) => {
                 if (isDesktop) {
-                    if (!headerQuickLinks.contains(analyzerButtonContainer)) {
-                        headerQuickLinks.appendChild(analyzerButtonContainer);
-                    }
                     if (!headerQuickLinks.contains(researchButtonContainer)) {
                         headerQuickLinks.appendChild(researchButtonContainer);
                     }
-                } else {
-                    if (!analyzerButtonSlot.contains(analyzerButtonContainer)) {
-                        analyzerButtonSlot.appendChild(analyzerButtonContainer);
+                    if (!headerQuickLinks.contains(analyzerButtonContainer)) {
+                        headerQuickLinks.appendChild(analyzerButtonContainer);
                     }
+                    if (headerQuickLinks.contains(researchButtonContainer) && headerQuickLinks.contains(analyzerButtonContainer)) {
+                        headerQuickLinks.insertBefore(researchButtonContainer, analyzerButtonContainer);
+                    }
+                } else {
                     if (!researchButtonSlot.contains(researchButtonContainer)) {
                         researchButtonSlot.appendChild(researchButtonContainer);
+                    }
+                    if (!analyzerButtonSlot.contains(analyzerButtonContainer)) {
+                        analyzerButtonSlot.appendChild(analyzerButtonContainer);
                     }
                 }
             };

--- a/P30920/scripts/syop.js
+++ b/P30920/scripts/syop.js
@@ -332,12 +332,56 @@
   }
 
   function hexToRgba(hex, alpha) {
-    const normalized = hex.replace('#', '');
-    const value = parseInt(normalized, 16);
-    const r = (value >> 16) & 255;
-    const g = (value >> 8) & 255;
-    const b = value & 255;
+    const { r, g, b } = parseHexColor(hex);
     return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
+  function parseHexColor(hex) {
+    if (!hex) {
+      return { r: 0, g: 0, b: 0 };
+    }
+    let normalized = hex.trim().replace('#', '');
+    if (normalized.length === 3) {
+      normalized = normalized.split('').map((char) => char + char).join('');
+    }
+    const value = parseInt(normalized, 16);
+    if (Number.isNaN(value)) {
+      return { r: 0, g: 0, b: 0 };
+    }
+    return {
+      r: (value >> 16) & 255,
+      g: (value >> 8) & 255,
+      b: value & 255
+    };
+  }
+
+  function channelToHex(channel) {
+    const clamped = Math.max(0, Math.min(255, Math.round(channel)));
+    return clamped.toString(16).padStart(2, '0');
+  }
+
+  function rgbToHex({ r, g, b }) {
+    return `#${channelToHex(r)}${channelToHex(g)}${channelToHex(b)}`;
+  }
+
+  function lightenHex(hex, amount = 0.2) {
+    const { r, g, b } = parseHexColor(hex);
+    const lighten = (channel) => channel + (255 - channel) * amount;
+    return rgbToHex({
+      r: lighten(r),
+      g: lighten(g),
+      b: lighten(b)
+    });
+  }
+
+  function darkenHex(hex, amount = 0.2) {
+    const { r, g, b } = parseHexColor(hex);
+    const darken = (channel) => channel * (1 - amount);
+    return rgbToHex({
+      r: darken(r),
+      g: darken(g),
+      b: darken(b)
+    });
   }
 
   function stripYearSuffix(text) {
@@ -662,6 +706,32 @@
       class: 'syop-bar-svg'
     });
 
+    const defs = createSVG('defs');
+    svg.appendChild(defs);
+
+    const gradientId = `syop-bar-gradient-${config.key}`;
+    const gradient = createSVG('linearGradient', {
+      id: gradientId,
+      x1: '0%',
+      y1: '0%',
+      x2: '0%',
+      y2: '100%'
+    });
+
+    [
+      { offset: '0%', color: lightenHex(config.color, 0.32), opacity: '0.9' },
+      { offset: '55%', color: config.color, opacity: '0.85' },
+      { offset: '100%', color: darkenHex(config.color, 0.3), opacity: '0.95' }
+    ].forEach((stop) => {
+      gradient.appendChild(createSVG('stop', {
+        offset: stop.offset,
+        'stop-color': stop.color,
+        'stop-opacity': stop.opacity
+      }));
+    });
+
+    defs.appendChild(gradient);
+
     svg.appendChild(createSVG('rect', {
       x: margin.left,
       y: margin.top,
@@ -704,18 +774,19 @@
       class: 'syop-bar-axis'
     }));
 
+    const yAxisTitleX = margin.left - 33;
     const axisTitleY = createSVG('text', {
-      x: margin.left - 32,
+      x: yAxisTitleX,
       y: margin.top + chartHeight / 2,
       class: 'syop-bar-axis-title syop-bar-axis-title-y',
-      transform: `rotate(-90 ${margin.left - 32} ${margin.top + chartHeight / 2})`
+      transform: `rotate(-90 ${yAxisTitleX} ${margin.top + chartHeight / 2})`
     }, document.createTextNode('% of position'));
 
     axisGroup.appendChild(axisTitleY);
 
     const axisTitleX = createSVG('text', {
       x: margin.left + chartWidth / 2,
-      y: margin.top + chartHeight + 46,
+      y: margin.top + chartHeight + (isCompact ? 40 : 42),
       class: 'syop-bar-axis-title syop-bar-axis-title-x'
     }, document.createTextNode('SYOP'));
 
@@ -738,10 +809,8 @@
         height: barHeight,
         rx: 6,
         class: 'syop-bar-rect',
-        style: {
-          '--bar-fill': hexToRgba(config.color, 0.38),
-          '--bar-stroke': hexToRgba(config.color, 0.82)
-        },
+        fill: `url(#${gradientId})`,
+        stroke: hexToRgba(darkenHex(config.color, 0.28), 0.88),
         tabindex: '0',
         role: 'button',
         'aria-label': `${config.key} ${Math.round(value * 10) / 10}%`

--- a/P30920/styles/styles.css
+++ b/P30920/styles/styles.css
@@ -267,6 +267,7 @@
 
         #primary-header-row .menu-container,
         #secondary-header-row .analyzer-button-container,
+        #secondary-header-row .research-button-container,
         .analyzer-button-slot,
         .research-button-slot {
             width: max(var(--header-icon-size), 2.6rem);
@@ -294,7 +295,8 @@
         }
 
         #primary-header-row .menu-button,
-        #secondary-header-row .analyzer-button {
+        #secondary-header-row .analyzer-button,
+        #secondary-header-row .research-button {
             width: 100%;
             height: 100%;
             border-radius: 8px;
@@ -321,6 +323,7 @@
         }
 
         #secondary-header-row .analyzer-button .analyzer-icon,
+        #secondary-header-row .research-button .analyzer-icon,
         .header-quick-links .analyzer-button .analyzer-icon,
         .header-quick-links .research-button .analyzer-icon {
             display: block;
@@ -330,6 +333,7 @@
         }
 
         #secondary-header-row .analyzer-button .analyzer-label,
+        #secondary-header-row .research-button .analyzer-label,
         .header-quick-links .analyzer-button .analyzer-label,
         .header-quick-links .research-button .analyzer-label {
             display: block;
@@ -343,6 +347,8 @@
         }
         #secondary-header-row .analyzer-button:hover .analyzer-icon,
         #secondary-header-row .analyzer-button:focus-visible .analyzer-icon,
+        #secondary-header-row .research-button:hover .analyzer-icon,
+        #secondary-header-row .research-button:focus-visible .analyzer-icon,
         .header-quick-links .analyzer-button:hover .analyzer-icon,
         .header-quick-links .analyzer-button:focus-visible .analyzer-icon,
         .header-quick-links .research-button:hover .analyzer-icon,
@@ -4810,10 +4816,10 @@ body[data-page="research"] .app-header {
   gap: 0.5rem;
   margin-top: 0.35rem;
   padding: 0.75rem 0.9rem;
-  background: rgba(14, 17, 30, 0.78);
-  border: 1px solid rgba(132, 146, 255, 0.14);
-  border-radius: 16px;
-  box-shadow: 0 12px 24px rgba(4, 7, 16, 0.35);
+  background: rgba(16, 20, 34, 0.28);
+  border: 1px solid rgba(132, 146, 255, 0.2);
+  border-radius: 22px;
+  box-shadow: 0 10px 22px rgba(6, 8, 18, 0.32);
   backdrop-filter: blur(12px);
 }
 
@@ -4822,7 +4828,32 @@ body[data-page="research"] .app-header {
 }
 
 .syop-key-legend .syop-hero-card {
-  background: rgba(10, 13, 24, 0.78);
+  background: rgba(16, 20, 34, 0.32);
+  border: 1px solid rgba(132, 146, 255, 0.22);
+  border-radius: 999px;
+  padding: 0.36rem 0.85rem;
+  min-height: 48px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.28rem;
+  color: rgba(226, 232, 240, 0.9);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.syop-key-legend .syop-hero-card .label {
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.61rem;
+  color: rgba(182, 185, 214, 0.8);
+  font-weight: 500;
+}
+
+.syop-key-legend .syop-hero-card .value {
+  font-weight: 500;
+  font-size: 0.72rem;
+  line-height: 1.24;
+  color: rgba(244, 246, 255, 0.94);
 }
 
 .syop-line-legend {
@@ -5319,8 +5350,8 @@ body[data-page="research"] .app-header {
 }
 
 .syop-bar-area {
-  fill: rgba(14, 18, 34, 0.58);
-  stroke: rgba(255, 255, 255, 0.06);
+  fill: rgba(14, 18, 34, 0.18);
+  stroke: rgba(255, 255, 255, 0.04);
   stroke-width: 1px;
 }
 


### PR DESCRIPTION
## Summary
- place the Research link ahead of League Analyzer across the hamburger menu and roster quick links while keeping icons paired to their labels
- swap the roster page Research and Analyzer quick action slots for consistent ordering between mobile and desktop layouts
- restyle the SYOP distribution chart with per-position gradients, refined axis spacing, and refreshed legend chip styling to match the hero summary cards

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d107544e54832eb9b2efad6f76c2ce