### PR TITLE
Swap Research navigation order and refresh SYOP visuals

### DIFF
--- a/P30920/analyzer/analyzer.html
+++ b/P30920/analyzer/analyzer.html
@@ -161,14 +161,14 @@
                                 <i class="fa-solid fa-percent" aria-hidden="true"></i>
                                 <span>Ownership</span>
                             </a>
-            <a href="#" id="menu-analyzer">
-                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-                <span>League Analyzer</span>
-            </a>
-            <a href="#" id="menu-research">
-                <i class="fa-solid fa-flask" aria-hidden="true"></i>
-                <span>Research</span>
-            </a>
+                            <a href="#" id="menu-research">
+                                <i class="fa-solid fa-flask" aria-hidden="true"></i>
+                                <span>Research</span>
+                            </a>
+                            <a href="#" id="menu-analyzer">
+                                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+                                <span>League Analyzer</span>
+                            </a>
                         </div>
                     </div>
                     <div class="username-area">

--- a/P30920/index.html
+++ b/P30920/index.html
@@ -52,13 +52,13 @@
             <i class="fa-solid fa-percent" aria-hidden="true"></i>
             <span>Ownership</span>
         </a>
-        <a href="#" id="menu-analyzer">
-            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-            <span>League Analyzer</span>
-        </a>
         <a href="#" id="menu-research">
             <i class="fa-solid fa-flask" aria-hidden="true"></i>
             <span>Research</span>
+        </a>
+        <a href="#" id="menu-analyzer">
+            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+            <span>League Analyzer</span>
         </a>
     </div>
 </div>

--- a/P30920/ownership/ownership.html
+++ b/P30920/ownership/ownership.html
@@ -50,14 +50,14 @@
             <i class="fa-solid fa-percent" aria-hidden="true"></i>
             <span>Ownership</span>
         </a>
-            <a href="#" id="menu-analyzer">
-                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-                <span>League Analyzer</span>
-            </a>
-            <a href="#" id="menu-research">
-                <i class="fa-solid fa-flask" aria-hidden="true"></i>
-                <span>Research</span>
-            </a>
+        <a href="#" id="menu-research">
+            <i class="fa-solid fa-flask" aria-hidden="true"></i>
+            <span>Research</span>
+        </a>
+        <a href="#" id="menu-analyzer">
+            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+            <span>League Analyzer</span>
+        </a>
     </div>
 </div>
 <div class="username-area">

--- a/P30920/research/research.html
+++ b/P30920/research/research.html
@@ -52,13 +52,13 @@
               <i class="fa-solid fa-percent" aria-hidden="true"></i>
               <span>Ownership</span>
             </a>
-            <a href="#" id="menu-analyzer">
-              <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-              <span>League Analyzer</span>
-            </a>
             <a href="#" id="menu-research" class="active">
               <i class="fa-solid fa-flask" aria-hidden="true"></i>
               <span>Research</span>
+            </a>
+            <a href="#" id="menu-analyzer">
+              <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+              <span>League Analyzer</span>
             </a>
           </div>
         </div>

--- a/P30920/rosters/rosters.html
+++ b/P30920/rosters/rosters.html
@@ -50,14 +50,14 @@
             <i class="fa-solid fa-percent" aria-hidden="true"></i>
             <span>Ownership</span>
         </a>
-            <a href="#" id="menu-analyzer">
-                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-                <span>League Analyzer</span>
-            </a>
-            <a href="#" id="menu-research">
-                <i class="fa-solid fa-flask" aria-hidden="true"></i>
-                <span>Research</span>
-            </a>
+        <a href="#" id="menu-research">
+            <i class="fa-solid fa-flask" aria-hidden="true"></i>
+            <span>Research</span>
+        </a>
+        <a href="#" id="menu-analyzer">
+            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+            <span>League Analyzer</span>
+        </a>
     </div>
 </div>
 <div class="header-quick-links" id="header-quick-links" aria-label="Research shortcuts"></div>
@@ -71,32 +71,32 @@
 </div>
 <div class="hidden" id="contextual-controls">
 <div class="header-row" id="secondary-header-row">
-<div class="analyzer-button-slot" id="analyzer-button-slot">
-<div class="analyzer-button-container">
-    <button aria-label="Open League Analyzer" class="menu-button analyzer-button" id="analyzeLeagueButton" type="button">
-        <i class="fa-solid fa-square-poll-vertical analyzer-icon" aria-hidden="true"></i>
-        <span class="analyzer-label">Analyzer</span>
-    </button>
-</div>
-</div>
-<div class="custom-select-wrapper">
-<select disabled="" id="leagueSelect">
-<option>Select a league...</option>
-</select>
-</div>
-<div class="view-switcher secondary-switcher">
-<button id="positionalViewBtn">Positional </button>
-<button id="depthChartViewBtn">Lineup</button>
-</div>
+    <div class="analyzer-button-slot" id="analyzer-button-slot">
+        <div class="analyzer-button-container">
+            <button class="menu-button analyzer-button research-button" id="researchButton" type="button" aria-label="Open Research insights">
+                <i class="fa-solid fa-flask-vial analyzer-icon" aria-hidden="true"></i>
+                <span class="analyzer-label">Research</span>
+            </button>
+        </div>
+    </div>
+    <div class="custom-select-wrapper">
+        <select disabled="" id="leagueSelect">
+            <option>Select a league...</option>
+        </select>
+    </div>
+    <div class="view-switcher secondary-switcher">
+        <button id="positionalViewBtn">Positional </button>
+        <button id="depthChartViewBtn">Lineup</button>
+    </div>
 </div>
 <div class="header-row" id="filters-row">
     <div class="research-button-slot" id="research-button-slot">
-    <div class="research-button-container">
-        <button class="menu-button analyzer-button research-button" id="researchButton" type="button" aria-label="Open Research insights">
-            <i class="fa-solid fa-flask-vial analyzer-icon" aria-hidden="true"></i>
-            <span class="analyzer-label">Research</span>
-        </button>
-    </div>
+        <div class="research-button-container">
+            <button aria-label="Open League Analyzer" class="menu-button analyzer-button" id="analyzeLeagueButton" type="button">
+                <i class="fa-solid fa-square-poll-vertical analyzer-icon" aria-hidden="true"></i>
+                <span class="analyzer-label">Analyzer</span>
+            </button>
+        </div>
     </div>
     <div class="filters-container">
         <div id="positional-filters">

--- a/P30920/scripts/syop.js
+++ b/P30920/scripts/syop.js
@@ -340,6 +340,90 @@
     return `rgba(${r}, ${g}, ${b}, ${alpha})`;
   }
 
+  function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+  }
+
+  function parseHexColor(hex) {
+    if (typeof hex !== 'string') {
+      return { r: 0, g: 0, b: 0 };
+    }
+    let normalized = hex.trim().replace('#', '');
+    if (normalized.length === 3) {
+      normalized = normalized.split('').map((ch) => ch + ch).join('');
+    }
+    const value = Number.parseInt(normalized, 16);
+    if (Number.isNaN(value)) {
+      return { r: 0, g: 0, b: 0 };
+    }
+    return {
+      r: (value >> 16) & 255,
+      g: (value >> 8) & 255,
+      b: value & 255
+    };
+  }
+
+  function componentToHex(component) {
+    const value = clamp(Math.round(component), 0, 255).toString(16).padStart(2, '0');
+    return value;
+  }
+
+  function tintColor(hex, amount) {
+    const { r, g, b } = parseHexColor(hex);
+    const clamped = clamp(amount, -1, 1);
+    const target = clamped < 0 ? 0 : 255;
+    const ratio = Math.abs(clamped);
+    const mix = (channel) => channel + (target - channel) * ratio;
+    return `#${componentToHex(mix(r))}${componentToHex(mix(g))}${componentToHex(mix(b))}`;
+  }
+
+  function ensureBarGradient(svg, key, baseColor) {
+    let defs = svg.querySelector('defs');
+    if (!defs) {
+      defs = createSVG('defs');
+      svg.appendChild(defs);
+    }
+
+    const gradientId = `syop-bar-gradient-${String(key).toLowerCase()}`;
+    let gradient = defs.querySelector(`#${gradientId}`);
+    if (!gradient) {
+      gradient = createSVG('linearGradient', {
+        id: gradientId,
+        x1: '0',
+        x2: '0',
+        y1: '0',
+        y2: '1'
+      });
+
+      const topColor = tintColor(baseColor, 0.55);
+      const midColor = tintColor(baseColor, 0.1);
+      const bottomColor = tintColor(baseColor, -0.2);
+
+      gradient.appendChild(createSVG('stop', {
+        offset: '0%',
+        'stop-color': topColor,
+        'stop-opacity': '0.98'
+      }));
+      gradient.appendChild(createSVG('stop', {
+        offset: '60%',
+        'stop-color': midColor,
+        'stop-opacity': '0.94'
+      }));
+      gradient.appendChild(createSVG('stop', {
+        offset: '100%',
+        'stop-color': bottomColor,
+        'stop-opacity': '0.98'
+      }));
+
+      defs.appendChild(gradient);
+    }
+
+    return {
+      gradientId,
+      strokeColor: tintColor(baseColor, -0.25)
+    };
+  }
+
   function stripYearSuffix(text) {
     if (typeof text !== 'string') return text;
     return text.replace(/\s*yrs?\.?/gi, '').trim();
@@ -705,17 +789,17 @@
     }));
 
     const axisTitleY = createSVG('text', {
-      x: margin.left - 32,
+      x: margin.left - 33,
       y: margin.top + chartHeight / 2,
       class: 'syop-bar-axis-title syop-bar-axis-title-y',
-      transform: `rotate(-90 ${margin.left - 32} ${margin.top + chartHeight / 2})`
+      transform: `rotate(-90 ${margin.left - 33} ${margin.top + chartHeight / 2})`
     }, document.createTextNode('% of position'));
 
     axisGroup.appendChild(axisTitleY);
 
     const axisTitleX = createSVG('text', {
       x: margin.left + chartWidth / 2,
-      y: margin.top + chartHeight + 46,
+      y: margin.top + chartHeight + 36,
       class: 'syop-bar-axis-title syop-bar-axis-title-x'
     }, document.createTextNode('SYOP'));
 
@@ -725,6 +809,8 @@
 
     const bandWidth = chartWidth / Math.max(distribution.length, 1);
     const barWidth = Math.max(10, bandWidth * 0.64);
+
+    const { gradientId, strokeColor } = ensureBarGradient(svg, config.key, config.color);
 
     distribution.forEach((entry, index) => {
       const value = entry.percentage || 0;
@@ -738,10 +824,8 @@
         height: barHeight,
         rx: 6,
         class: 'syop-bar-rect',
-        style: {
-          '--bar-fill': hexToRgba(config.color, 0.38),
-          '--bar-stroke': hexToRgba(config.color, 0.82)
-        },
+        style: `fill:url(#${gradientId});stroke:${strokeColor};`,
+        'data-accent': strokeColor,
         tabindex: '0',
         role: 'button',
         'aria-label': `${config.key} ${Math.round(value * 10) / 10}%`
@@ -762,7 +846,7 @@
 
   function attachBarInteractions(element, config, percentage, tooltip, rootContainer) {
     if (!tooltip) return;
-    const color = config.color;
+    const accentColor = element?.dataset?.accent || config.color;
     const formattedPercent = `${Math.round(percentage * 10) / 10}%`;
 
     const hideTooltip = () => {
@@ -773,7 +857,7 @@
     const showTooltip = () => {
       element.classList.add('active');
       tooltip.innerHTML = '';
-      tooltip.style.setProperty('--tooltip-accent', color);
+      tooltip.style.setProperty('--tooltip-accent', accentColor);
       tooltip.appendChild(createEl('div', { class: 'tooltip-name' }, config.key));
       tooltip.appendChild(createEl('div', { class: 'tooltip-meta' }, formattedPercent));
 

--- a/P30920/styles/styles.css
+++ b/P30920/styles/styles.css
@@ -4810,11 +4810,11 @@ body[data-page="research"] .app-header {
   gap: 0.5rem;
   margin-top: 0.35rem;
   padding: 0.75rem 0.9rem;
-  background: rgba(14, 17, 30, 0.78);
-  border: 1px solid rgba(132, 146, 255, 0.14);
+  background: rgba(16, 20, 34, 0.32);
+  border: 1px solid rgba(132, 146, 255, 0.22);
   border-radius: 16px;
-  box-shadow: 0 12px 24px rgba(4, 7, 16, 0.35);
-  backdrop-filter: blur(12px);
+  box-shadow: 0 14px 26px rgba(7, 10, 20, 0.45);
+  backdrop-filter: blur(14px);
 }
 
 .syop-key-legend .syop-key-grid {
@@ -4822,7 +4822,27 @@ body[data-page="research"] .app-header {
 }
 
 .syop-key-legend .syop-hero-card {
-  background: rgba(10, 13, 24, 0.78);
+  align-items: center;
+  text-align: center;
+  background: rgba(16, 20, 34, 0.32);
+  border: 1px solid rgba(132, 146, 255, 0.22);
+  border-radius: 999px;
+  box-shadow: none;
+  padding: 0.36rem 0.9rem;
+  gap: 0.28rem;
+}
+
+.syop-key-legend .syop-hero-card .label {
+  color: rgba(182, 185, 214, 0.8);
+  font-size: 0.61rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.syop-key-legend .syop-hero-card .value {
+  color: rgba(226, 232, 240, 0.9);
+  font-size: 0.72rem;
+  line-height: 1.24;
 }
 
 .syop-line-legend {
@@ -5319,8 +5339,8 @@ body[data-page="research"] .app-header {
 }
 
 .syop-bar-area {
-  fill: rgba(14, 18, 34, 0.58);
-  stroke: rgba(255, 255, 255, 0.06);
+  fill: rgba(14, 18, 34, 0.24);
+  stroke: rgba(255, 255, 255, 0.05);
   stroke-width: 1px;
 }
 


### PR DESCRIPTION
## Summary
- swap the Research and League Analyzer links throughout the navigation menus and rosters quick actions so their order and icons stay consistent on desktop and mobile
- refresh the SYOP positional column chart with per-position gradients, a lighter plot backdrop, and refined axis spacing for the labels
- restyle the SYOP legend chips to mirror the hero panel pill treatment for consistent presentation

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d107544e54832eb9b2efad6f76c2ce