### PR TITLE
Dial in SYOP bar gradients and lighten plot glass

### DIFF
--- a/P30920/analyzer/analyzer.html
+++ b/P30920/analyzer/analyzer.html
@@ -161,14 +161,14 @@
                                 <i class="fa-solid fa-percent" aria-hidden="true"></i>
                                 <span>Ownership</span>
                             </a>
-            <a href="#" id="menu-analyzer">
-                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-                <span>League Analyzer</span>
-            </a>
-            <a href="#" id="menu-research">
-                <i class="fa-solid fa-flask" aria-hidden="true"></i>
-                <span>Research</span>
-            </a>
+                            <a href="#" id="menu-research">
+                                <i class="fa-solid fa-flask" aria-hidden="true"></i>
+                                <span>Research</span>
+                            </a>
+                            <a href="#" id="menu-analyzer">
+                                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+                                <span>League Analyzer</span>
+                            </a>
                         </div>
                     </div>
                     <div class="username-area">

--- a/P30920/index.html
+++ b/P30920/index.html
@@ -52,13 +52,13 @@
             <i class="fa-solid fa-percent" aria-hidden="true"></i>
             <span>Ownership</span>
         </a>
-        <a href="#" id="menu-analyzer">
-            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-            <span>League Analyzer</span>
-        </a>
         <a href="#" id="menu-research">
             <i class="fa-solid fa-flask" aria-hidden="true"></i>
             <span>Research</span>
+        </a>
+        <a href="#" id="menu-analyzer">
+            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+            <span>League Analyzer</span>
         </a>
     </div>
 </div>

--- a/P30920/ownership/ownership.html
+++ b/P30920/ownership/ownership.html
@@ -50,14 +50,14 @@
             <i class="fa-solid fa-percent" aria-hidden="true"></i>
             <span>Ownership</span>
         </a>
-            <a href="#" id="menu-analyzer">
-                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-                <span>League Analyzer</span>
-            </a>
-            <a href="#" id="menu-research">
-                <i class="fa-solid fa-flask" aria-hidden="true"></i>
-                <span>Research</span>
-            </a>
+        <a href="#" id="menu-research">
+            <i class="fa-solid fa-flask" aria-hidden="true"></i>
+            <span>Research</span>
+        </a>
+        <a href="#" id="menu-analyzer">
+            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+            <span>League Analyzer</span>
+        </a>
     </div>
 </div>
 <div class="username-area">

--- a/P30920/research/research.html
+++ b/P30920/research/research.html
@@ -52,13 +52,13 @@
               <i class="fa-solid fa-percent" aria-hidden="true"></i>
               <span>Ownership</span>
             </a>
-            <a href="#" id="menu-analyzer">
-              <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-              <span>League Analyzer</span>
-            </a>
             <a href="#" id="menu-research" class="active">
               <i class="fa-solid fa-flask" aria-hidden="true"></i>
               <span>Research</span>
+            </a>
+            <a href="#" id="menu-analyzer">
+              <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+              <span>League Analyzer</span>
             </a>
           </div>
         </div>

--- a/P30920/rosters/rosters.html
+++ b/P30920/rosters/rosters.html
@@ -50,14 +50,14 @@
             <i class="fa-solid fa-percent" aria-hidden="true"></i>
             <span>Ownership</span>
         </a>
-            <a href="#" id="menu-analyzer">
-                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-                <span>League Analyzer</span>
-            </a>
-            <a href="#" id="menu-research">
-                <i class="fa-solid fa-flask" aria-hidden="true"></i>
-                <span>Research</span>
-            </a>
+        <a href="#" id="menu-research">
+            <i class="fa-solid fa-flask" aria-hidden="true"></i>
+            <span>Research</span>
+        </a>
+        <a href="#" id="menu-analyzer">
+            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+            <span>League Analyzer</span>
+        </a>
     </div>
 </div>
 <div class="header-quick-links" id="header-quick-links" aria-label="Research shortcuts"></div>

--- a/P30920/scripts/app.js
+++ b/P30920/scripts/app.js
@@ -163,11 +163,11 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             const quickLinksQuery = window.matchMedia('(min-width: 1024px)');
             const placeQuickLinks = (isDesktop) => {
                 if (isDesktop) {
-                    if (!headerQuickLinks.contains(analyzerButtonContainer)) {
-                        headerQuickLinks.appendChild(analyzerButtonContainer);
-                    }
                     if (!headerQuickLinks.contains(researchButtonContainer)) {
                         headerQuickLinks.appendChild(researchButtonContainer);
+                    }
+                    if (!headerQuickLinks.contains(analyzerButtonContainer)) {
+                        headerQuickLinks.appendChild(analyzerButtonContainer);
                     }
                 } else {
                     if (!analyzerButtonSlot.contains(analyzerButtonContainer)) {

--- a/P30920/scripts/syop.js
+++ b/P30920/scripts/syop.js
@@ -65,6 +65,33 @@
     { key: 'TE', percentKey: 'TE %', label: 'Tight Ends', color: colors.te }
   ];
 
+  const BAR_GRADIENTS = {
+    QB: [
+      { offset: '0%', color: '#FF7CB0', opacity: 0.28 },
+      { offset: '54%', color: '#FF3A75', opacity: 0.63 },
+      { offset: '100%', color: '#C21F59', opacity: 0.82 }
+    ],
+    RB: [
+      { offset: '0%', color: '#5CFFE3', opacity: 0.22 },
+      { offset: '56%', color: '#00EBC7', opacity: 0.63 },
+      { offset: '100%', color: '#00B68F', opacity: 0.8 }
+    ],
+    WR: [
+      { offset: '0%', color: '#8CC3FF', opacity: 0.26 },
+      { offset: '55%', color: '#58A7FF', opacity: 0.73 },
+      { offset: '100%', color: '#2B6FE0', opacity: 0.84 }
+    ],
+    TE: [
+      { offset: '0%', color: '#D1A1FF', opacity: 0.28 },
+      { offset: '56%', color: '#B469FF', opacity: 0.73 },
+      { offset: '100%', color: '#7A2AD6', opacity: 0.85 }
+    ],
+    DEFAULT: [
+      { offset: '0%', color: '#8F97FF', opacity: 0.32 },
+      { offset: '100%', color: '#5C4BFF', opacity: 0.66 }
+    ]
+  };
+
   const POSITION_TOTALS = {
     QB: 52,
     RB: 96,
@@ -662,6 +689,33 @@
       class: 'syop-bar-svg'
     });
 
+    const gradientStops = BAR_GRADIENTS[config.key] || BAR_GRADIENTS.DEFAULT;
+    const gradientId = `syop-bar-gradient-${config.key.toLowerCase()}`;
+    const defs = createSVG('defs');
+    const gradient = createSVG('linearGradient', {
+      id: gradientId,
+      gradientUnits: 'userSpaceOnUse',
+      x1: margin.left,
+      y1: margin.top + chartHeight,
+      x2: margin.left,
+      y2: margin.top
+    });
+
+    gradientStops.forEach((stop) => {
+      if (!stop) return;
+      const attrs = {
+        offset: stop.offset ?? '0%',
+        'stop-color': stop.color || '#7C83FF'
+      };
+      if (typeof stop.opacity === 'number') {
+        attrs['stop-opacity'] = String(stop.opacity);
+      }
+      gradient.appendChild(createSVG('stop', attrs));
+    });
+
+    defs.appendChild(gradient);
+    svg.appendChild(defs);
+
     svg.appendChild(createSVG('rect', {
       x: margin.left,
       y: margin.top,
@@ -705,17 +759,17 @@
     }));
 
     const axisTitleY = createSVG('text', {
-      x: margin.left - 32,
+      x: margin.left - 35,
       y: margin.top + chartHeight / 2,
       class: 'syop-bar-axis-title syop-bar-axis-title-y',
-      transform: `rotate(-90 ${margin.left - 32} ${margin.top + chartHeight / 2})`
+      transform: `rotate(-90 ${margin.left - 35} ${margin.top + chartHeight / 2})`
     }, document.createTextNode('% of position'));
 
     axisGroup.appendChild(axisTitleY);
 
     const axisTitleX = createSVG('text', {
       x: margin.left + chartWidth / 2,
-      y: margin.top + chartHeight + 46,
+      y: margin.top + chartHeight + 30,
       class: 'syop-bar-axis-title syop-bar-axis-title-x'
     }, document.createTextNode('SYOP'));
 
@@ -725,6 +779,8 @@
 
     const bandWidth = chartWidth / Math.max(distribution.length, 1);
     const barWidth = Math.max(10, bandWidth * 0.64);
+
+    const gradientStroke = (gradientStops[gradientStops.length - 1] || {}).color || config.color;
 
     distribution.forEach((entry, index) => {
       const value = entry.percentage || 0;
@@ -738,15 +794,12 @@
         height: barHeight,
         rx: 6,
         class: 'syop-bar-rect',
-        style: {
-          '--bar-fill': hexToRgba(config.color, 0.38),
-          '--bar-stroke': hexToRgba(config.color, 0.82)
-        },
+        style: `--bar-stroke: ${gradientStroke}; fill: url(#${gradientId});`,
         tabindex: '0',
         role: 'button',
         'aria-label': `${config.key} ${Math.round(value * 10) / 10}%`
       });
-      attachBarInteractions(rect, config, value, tooltip, rootContainer);
+      attachBarInteractions(rect, config, value, tooltip, rootContainer, gradientStroke);
       svg.appendChild(rect);
 
       const labelX = margin.left + index * bandWidth + bandWidth / 2;
@@ -760,9 +813,9 @@
     plotContainer.appendChild(svg);
   }
 
-  function attachBarInteractions(element, config, percentage, tooltip, rootContainer) {
+  function attachBarInteractions(element, config, percentage, tooltip, rootContainer, accentColor) {
     if (!tooltip) return;
-    const color = config.color;
+    const color = accentColor || config.color;
     const formattedPercent = `${Math.round(percentage * 10) / 10}%`;
 
     const hideTooltip = () => {

--- a/P30920/styles/styles.css
+++ b/P30920/styles/styles.css
@@ -4312,23 +4312,23 @@ body[data-page="research"] .app-header {
   gap: 0.26rem;
   padding: 0.62rem 0.8rem;
   border-radius: 12px;
-  background: rgba(12, 15, 28, 0.78);
-  border: 1px solid rgba(132, 146, 255, 0.14);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  background: rgba(16, 20, 34, 0.32);
+  border: 1px solid rgba(132, 146, 255, 0.24);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03), 0 14px 28px rgba(5, 8, 22, 0.28);
 }
 
 .syop-hero-card .label {
   font-size: 0.64rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(182, 185, 214, 0.74);
+  color: rgba(182, 185, 214, 0.8);
 }
 
 .syop-hero-card .value {
   font-size: 0.88rem;
   font-weight: 600;
   line-height: 1.28;
-  color: #f4f6ff;
+  color: rgba(232, 235, 255, 0.94);
 }
 
 
@@ -4810,11 +4810,13 @@ body[data-page="research"] .app-header {
   gap: 0.5rem;
   margin-top: 0.35rem;
   padding: 0.75rem 0.9rem;
-  background: rgba(14, 17, 30, 0.78);
-  border: 1px solid rgba(132, 146, 255, 0.14);
+  background: radial-gradient(circle at 18% 18%, rgba(96, 165, 250, 0.18), transparent 60%),
+              radial-gradient(circle at 82% 62%, rgba(192, 132, 252, 0.22), transparent 70%),
+              rgba(13, 16, 32, 0.46);
+  border: 1px solid rgba(138, 152, 255, 0.28);
   border-radius: 16px;
-  box-shadow: 0 12px 24px rgba(4, 7, 16, 0.35);
-  backdrop-filter: blur(12px);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 22px 36px rgba(6, 9, 24, 0.52);
+  backdrop-filter: blur(16px) saturate(130%);
 }
 
 .syop-key-legend .syop-key-grid {
@@ -4822,7 +4824,19 @@ body[data-page="research"] .app-header {
 }
 
 .syop-key-legend .syop-hero-card {
-  background: rgba(10, 13, 24, 0.78);
+  background: rgba(16, 20, 36, 0.42);
+  border-color: rgba(148, 162, 255, 0.32);
+  border-radius: 999px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 14px 22px rgba(6, 9, 24, 0.42);
+  backdrop-filter: blur(12px) saturate(130%);
+}
+
+.syop-key-legend .syop-hero-card .label {
+  color: rgba(188, 194, 236, 0.84);
+}
+
+.syop-key-legend .syop-hero-card .value {
+  color: rgba(232, 235, 255, 0.95);
 }
 
 .syop-line-legend {
@@ -5319,18 +5333,18 @@ body[data-page="research"] .app-header {
 }
 
 .syop-bar-area {
-  fill: rgba(14, 18, 34, 0.58);
-  stroke: rgba(255, 255, 255, 0.06);
+  fill: rgba(8, 12, 24, 0.02);
+  stroke: rgba(140, 154, 255, 0.08);
   stroke-width: 1px;
 }
 
 .syop-bar-grid {
-  stroke: rgba(255, 255, 255, 0.08);
+  stroke: rgba(255, 255, 255, 0.05);
   stroke-width: 1;
 }
 
 .syop-bar-axis {
-  stroke: rgba(132, 146, 255, 0.32);
+  stroke: rgba(140, 154, 255, 0.26);
   stroke-width: 1.4;
 }
 
@@ -5365,12 +5379,13 @@ body[data-page="research"] .app-header {
 }
 
 .syop-bar-rect {
-  fill: var(--bar-fill, rgba(124, 131, 255, 0.34));
-  stroke: var(--bar-stroke, rgba(124, 131, 255, 0.8));
+  fill: var(--bar-fill, rgba(124, 131, 255, 0.32));
+  stroke: var(--bar-stroke, rgba(124, 131, 255, 0.72));
   stroke-width: 1.6;
   cursor: pointer;
-  transition: transform 0.18s ease, stroke-width 0.18s ease, filter 0.18s ease;
-  filter: drop-shadow(0 10px 18px rgba(8, 10, 24, 0.45));
+  opacity: 0.92;
+  transition: transform 0.18s ease, stroke-width 0.18s ease, filter 0.18s ease, opacity 0.18s ease;
+  filter: drop-shadow(0 12px 20px rgba(6, 9, 24, 0.35));
 }
 
 .syop-bar-rect:hover,
@@ -5379,6 +5394,7 @@ body[data-page="research"] .app-header {
   transform: translateY(-4px);
   stroke-width: 2.2;
   outline: none;
+  opacity: 1;
 }
 
 .syop-bar-tooltip {

--- a/P30920/styles/styles.css
+++ b/P30920/styles/styles.css
@@ -5256,10 +5256,10 @@ body[data-page="research"] .app-header {
   gap: 0.75rem;
   padding: 0.85rem 0.85rem 1rem;
   border-radius: 20px;
-  background: linear-gradient(150deg, rgba(15, 18, 33, 0.76), rgba(9, 12, 24, 0.64));
-  border: 1px solid rgba(132, 146, 255, 0.25);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 22px 38px rgba(10, 14, 32, 0.45);
-  backdrop-filter: blur(14px);
+  background: transparent;
+  border: 1px solid rgba(132, 146, 255, 0.16);
+  box-shadow: none;
+  backdrop-filter: none;
   width: min(100%, 580px);
   margin: 0 auto;
 }


### PR DESCRIPTION
## Summary
- Tune each SYOP bar gradient to center on the position palette colors with translucent depth
- Pull the chart canvas styling closer to fully transparent glass while tightening axis title spacing

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d107544e54832eb9b2efad6f76c2ce