### PR TITLE
Implement mobile liquid header for rosters

### DIFF
--- a/DH_P3-5.3/rosters/rosters.html
+++ b/DH_P3-5.3/rosters/rosters.html
@@ -31,7 +31,7 @@
 <div class="liquid-roster-shell" id="mobileRosterShell">
     <div class="liquid-row liquid-row-nav" id="primary-header-row">
         <button id="menu-button" class="liquid-logo-button" type="button" aria-label="Return to Home">
-            <span class="liquid-logo-mark">DH</span>
+            <img src="../assets/welcome/welcome-logo-256.png" alt="Dynasty Hub Home" loading="lazy"/>
         </button>
         <nav class="liquid-nav-cluster" aria-label="Primary navigation">
             <button class="liquid-nav-item" data-nav="home" type="button">
@@ -74,14 +74,6 @@
         </div>
     </div>
     <div class="liquid-row liquid-row-filters" id="filters-row">
-        <div class="liquid-support-chip" id="research-button-slot">
-            <div class="research-button-container">
-                <button class="menu-button analyzer-button research-button" id="researchButton" type="button" aria-label="Open Research insights">
-                    <i class="fa-solid fa-flask-vial analyzer-icon" aria-hidden="true"></i>
-                    <span class="analyzer-label">Research</span>
-                </button>
-            </div>
-        </div>
         <div class="filters-container">
             <div id="positional-filters">
                 <button class="filter-btn" data-position="QB">QB</button>
@@ -127,6 +119,14 @@
             <button aria-label="Open League Analyzer" class="menu-button analyzer-button" id="analyzeLeagueButton" type="button">
                 <i class="fa-solid fa-square-poll-vertical analyzer-icon" aria-hidden="true"></i>
                 <span class="analyzer-label">Analyzer</span>
+            </button>
+        </div>
+    </div>
+    <div class="research-button-slot" id="research-button-slot">
+        <div class="research-button-container">
+            <button class="menu-button analyzer-button research-button" id="researchButton" type="button" aria-label="Open Research insights">
+                <i class="fa-solid fa-flask-vial analyzer-icon" aria-hidden="true"></i>
+                <span class="analyzer-label">Research</span>
             </button>
         </div>
     </div>

--- a/DH_P3-5.3/rosters/rosters.html
+++ b/DH_P3-5.3/rosters/rosters.html
@@ -28,106 +28,118 @@
 <div class="relative z-10 content-wrapper">
 <div id="header-container">
 <header class="app-header glass-panel">
-<div class="header-row" id="primary-header-row">
-<div class="menu-container">
-    <button id="menu-button" class="menu-button">
-        <svg viewBox="0 0 100 80" width="20" height="20">
-            <rect width="100" height="15"></rect>
-            <rect y="30" width="100" height="15"></rect>
-            <rect y="60" width="100" height="15"></rect>
-        </svg>
-    </button>
-    <div id="dropdown-menu" class="dropdown-menu hidden">
-        <a href="../">
-            <i class="fa-solid fa-house-user" aria-hidden="true"></i>
-            <span>Home</span>
-        </a>
-        <a href="#" id="menu-rosters">
-            <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
-            <span>Rosters</span>
-        </a>
-        <a href="#" id="menu-ownership">
-            <i class="fa-solid fa-percent" aria-hidden="true"></i>
-            <span>Ownership</span>
-        </a>
-        <a href="#" id="menu-research">
-            <i class="fa-solid fa-flask" aria-hidden="true"></i>
-            <span>Research</span>
-        </a>
-        <a href="#" id="menu-analyzer">
-            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-            <span>League Analyzer</span>
-        </a>
-    </div>
-</div>
-<div class="header-quick-links" id="header-quick-links" aria-label="Research shortcuts"></div>
-<div class="username-area">
-<input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
-</div>
-<div class="app-view-switcher primary-switcher">
-<button id="fetchRostersButton">Rosters</button>
-<button id="fetchOwnershipButton">Ownership%</button>
-</div>
-</div>
-<div class="hidden" id="contextual-controls">
-<div class="header-row" id="secondary-header-row">
-<div class="analyzer-button-slot" id="analyzer-button-slot">
-<div class="analyzer-button-container">
-    <button aria-label="Open League Analyzer" class="menu-button analyzer-button" id="analyzeLeagueButton" type="button">
-        <i class="fa-solid fa-square-poll-vertical analyzer-icon" aria-hidden="true"></i>
-        <span class="analyzer-label">Analyzer</span>
-    </button>
-</div>
-</div>
-<div class="custom-select-wrapper">
-<select disabled="" id="leagueSelect">
-<option>Select a league...</option>
-</select>
-</div>
-<div class="view-switcher secondary-switcher">
-<button id="positionalViewBtn">Positional </button>
-<button id="depthChartViewBtn">Lineup</button>
-</div>
-</div>
-<div class="header-row" id="filters-row">
-    <div class="research-button-slot" id="research-button-slot">
-    <div class="research-button-container">
-        <button class="menu-button analyzer-button research-button" id="researchButton" type="button" aria-label="Open Research insights">
-            <i class="fa-solid fa-flask-vial analyzer-icon" aria-hidden="true"></i>
-            <span class="analyzer-label">Research</span>
+<div class="liquid-roster-shell" id="mobileRosterShell">
+    <div class="liquid-row liquid-row-nav" id="primary-header-row">
+        <button id="menu-button" class="liquid-logo-button" type="button" aria-label="Return to Home">
+            <span class="liquid-logo-mark">DH</span>
         </button>
+        <nav class="liquid-nav-cluster" aria-label="Primary navigation">
+            <button class="liquid-nav-item" data-nav="home" type="button">
+                <i class="fa-solid fa-house-user" aria-hidden="true"></i>
+                <span>Home</span>
+            </button>
+            <button class="liquid-nav-item is-active" data-nav="rosters" type="button" aria-current="page">
+                <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
+                <span>Rosters</span>
+            </button>
+            <button class="liquid-nav-item" data-nav="ownership" type="button">
+                <i class="fa-solid fa-percent" aria-hidden="true"></i>
+                <span>Ownership</span>
+            </button>
+            <button class="liquid-nav-item" data-nav="research" type="button">
+                <i class="fa-solid fa-flask" aria-hidden="true"></i>
+                <span>Research</span>
+            </button>
+            <button class="liquid-nav-item" data-nav="analyzer" type="button">
+                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+                <span>Lg.Analyze</span>
+            </button>
+        </nav>
     </div>
-    </div>
-    <div class="filters-container">
-        <div id="positional-filters">
-            <button class="filter-btn" data-position="QB">QB</button>
-            <button class="filter-btn" data-position="RB">RB</button>
-            <button class="filter-btn" data-position="WR">WR</button>
-            <button class="filter-btn" data-position="TE">TE</button>
-            <button class="filter-btn" data-position="FLX">FLX</button>
+    <div class="liquid-row liquid-row-controls" id="secondary-header-row">
+        <div class="liquid-league-chip select-chip" id="leagueChipWrapper">
+            <select disabled="" id="leagueSelect">
+                <option>Select a league...</option>
+            </select>
         </div>
-        <button class="control-button-subtle" id="clearFiltersButton">
-            <span class="clear-filters-stack">
-                <i class="fa-solid fa-filter-circle-xmark" aria-hidden="true"></i>
-                <span class="sr-only">Clear filters</span>
-            </span>
-        </button>
-
-        <div class="compare-controls">
-            <!-- Hidden compare button kept only to satisfy JS state machine (do not show) -->
-            <button class="control-button hidden" id="compareButton" aria-hidden="true" tabindex="-1" style="display:none;"></button>
-            <!-- Clear selections button -->
-            <button class="control-button-subtle hidden" id="clearCompareButton" aria-label="Clear selections">
-                <span class="clear-filters-stack">
-                    <i class="fa-regular fa-rectangle-xmark" aria-hidden="true"></i>
-                    <span class="sr-only">Clear compare selections</span>
-                </span>
+        <div class="liquid-view-toggle" id="view-controls">
+            <button class="liquid-toggle-option active" id="positionalViewBtn" type="button" data-view="positional">
+                <i class="fa-solid fa-id-card" aria-hidden="true"></i>
+                <span>Positional</span>
+            </button>
+            <button class="liquid-toggle-option" id="depthChartViewBtn" type="button" data-view="depthChart">
+                <i class="fa-solid fa-elevator" aria-hidden="true"></i>
+                <span>Lineup</span>
             </button>
         </div>
+    </div>
+    <div class="liquid-row liquid-row-filters" id="filters-row">
+        <div class="liquid-support-chip" id="research-button-slot">
+            <div class="research-button-container">
+                <button class="menu-button analyzer-button research-button" id="researchButton" type="button" aria-label="Open Research insights">
+                    <i class="fa-solid fa-flask-vial analyzer-icon" aria-hidden="true"></i>
+                    <span class="analyzer-label">Research</span>
+                </button>
+            </div>
+        </div>
+        <div class="filters-container">
+            <div id="positional-filters">
+                <button class="filter-btn" data-position="QB">QB</button>
+                <button class="filter-btn" data-position="RB">RB</button>
+                <button class="filter-btn" data-position="WR">WR</button>
+                <button class="filter-btn" data-position="TE">TE</button>
+                <button class="filter-btn" data-position="FLX">FLX</button>
+            </div>
+            <button class="control-button-subtle" id="clearFiltersButton">
+                <span class="clear-filters-stack">
+                    <i class="fa-solid fa-filter-circle-xmark" aria-hidden="true"></i>
+                    <span class="sr-only">Clear filters</span>
+                </span>
+            </button>
 
+            <div class="compare-controls">
+                <!-- Hidden compare button kept only to satisfy JS state machine (do not show) -->
+                <button class="control-button hidden" id="compareButton" aria-hidden="true" tabindex="-1" style="display:none;"></button>
+                <!-- Clear selections button -->
+                <button class="control-button-subtle hidden" id="clearCompareButton" aria-label="Clear selections">
+                    <span class="clear-filters-stack">
+                        <i class="fa-regular fa-rectangle-xmark" aria-hidden="true"></i>
+                        <span class="sr-only">Clear compare selections</span>
+                    </span>
+                </button>
+            </div>
+
+        </div>
+        <div class="liquid-search-chip" id="rosterSearch">
+            <button class="search-trigger" type="button" aria-expanded="false" aria-controls="rosterSearchInput">
+                <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+                <span class="sr-only">Search players</span>
+            </button>
+            <div class="search-field">
+                <input type="search" id="rosterSearchInput" name="rosterSearchInput" placeholder="Search players" autocomplete="off" spellcheck="false"/>
+            </div>
+        </div>
     </div>
 </div>
+<div class="legacy-header-support">
+    <div class="analyzer-button-slot" id="analyzer-button-slot">
+        <div class="analyzer-button-container">
+            <button aria-label="Open League Analyzer" class="menu-button analyzer-button" id="analyzeLeagueButton" type="button">
+                <i class="fa-solid fa-square-poll-vertical analyzer-icon" aria-hidden="true"></i>
+                <span class="analyzer-label">Analyzer</span>
+            </button>
+        </div>
+    </div>
+    <div class="header-quick-links" id="header-quick-links" aria-label="Research shortcuts"></div>
+    <div class="username-area">
+        <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
+    </div>
+    <div class="app-view-switcher primary-switcher">
+        <button id="fetchRostersButton">Rosters</button>
+        <button id="fetchOwnershipButton">Ownership%</button>
+    </div>
 </div>
+<div class="hidden" id="contextual-controls"></div>
 </header>
 </div>
 <main class="container mx-auto" id="content">

--- a/DH_P3-5.3/scripts/app.js
+++ b/DH_P3-5.3/scripts/app.js
@@ -50,17 +50,22 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             compareButton.innerHTML = COMPARE_BUTTON_PREVIEW_HTML;
         }
 
-        // --- Menu Button ---
+        // --- Navigation & Search Controls ---
         const menuButton = document.getElementById('menu-button');
-        const dropdownMenu = document.getElementById('dropdown-menu');
-        const menuRosters = document.getElementById('menu-rosters');
-        const menuOwnership = document.getElementById('menu-ownership');
-        const menuAnalyzer = document.getElementById('menu-analyzer');
-        const menuResearch = document.getElementById('menu-research');
+        const navButtons = document.querySelectorAll('.liquid-nav-item');
         const analyzeLeagueButton = document.getElementById('analyzeLeagueButton');
+        const searchChip = document.getElementById('rosterSearch');
+        const searchTrigger = searchChip?.querySelector('.search-trigger');
+        const rosterSearchInput = document.getElementById('rosterSearchInput');
+        let searchDebounceId = null;
+
         const resolveResearchUrl = () => {
+            const params = new URLSearchParams();
             const username = usernameInput.value.trim();
-            const suffix = username ? `?username=${encodeURIComponent(username)}` : '';
+            if (username) {
+                params.set('username', username);
+            }
+            const suffix = params.toString() ? `?${params.toString()}` : '';
             if (pageType === 'welcome') {
                 return `research/research.html${suffix}`;
             }
@@ -70,85 +75,121 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             return `../research/research.html${suffix}`;
         };
 
-        menuButton?.addEventListener('click', (e) => {
-            e.stopPropagation();
-            dropdownMenu.classList.toggle('hidden');
-        });
-
-        document.addEventListener('click', (e) => {
-            if (dropdownMenu && !dropdownMenu.classList.contains('hidden') && !menuButton.contains(e.target)) {
-                dropdownMenu.classList.add('hidden');
-            }
-        });
-
-        menuRosters?.addEventListener('click', () => {
-            const username = usernameInput.value.trim();
-            if (!username) return;
-            if (pageType === 'rosters') {
-                handleFetchRosters();
-            } else {
-                let url = pageType === 'welcome'
-                    ? `rosters/rosters.html?username=${encodeURIComponent(username)}`
-                    : `../rosters/rosters.html?username=${encodeURIComponent(username)}`;
-                const selected = leagueSelect?.value;
-                if (selected && selected !== 'Select a league...') {
-                    url += `&leagueId=${selected}`;
-                } else if (state.currentLeagueId) {
-                    url += `&leagueId=${state.currentLeagueId}`;
-                }
-                window.location.href = url;
-            }
-            dropdownMenu.classList.add('hidden');
-        });
-
-        menuAnalyzer?.addEventListener('click', () => {
-            const username = usernameInput.value.trim();
-            if (!username) return;
-            let url = pageType === 'welcome'
-                ? `analyzer/analyzer.html?username=${encodeURIComponent(username)}`
-                : `../analyzer/analyzer.html?username=${encodeURIComponent(username)}`;
-            const selected = leagueSelect?.value || state.currentLeagueId;
+        const getActiveLeagueId = () => {
+            const selected = leagueSelect?.value;
             if (selected && selected !== 'Select a league...') {
-                url += `&leagueId=${selected}`;
+                return selected;
             }
-            window.location.href = url;
-            dropdownMenu.classList.add('hidden');
+            if (state.currentLeagueId) {
+                return state.currentLeagueId;
+            }
+            return null;
+        };
+
+        const buildNavUrl = (target) => {
+            if (target === 'research') {
+                return resolveResearchUrl();
+            }
+
+            const params = new URLSearchParams();
+            const username = usernameInput.value.trim();
+            if (username) {
+                params.set('username', username);
+            }
+            if (['rosters', 'ownership', 'analyzer'].includes(target)) {
+                const activeLeague = getActiveLeagueId();
+                if (activeLeague) {
+                    params.set('leagueId', activeLeague);
+                }
+            }
+
+            const query = params.toString();
+            const appendQuery = (base) => (query ? `${base}?${query}` : base);
+
+            switch (target) {
+                case 'home':
+                    return appendQuery(pageType === 'welcome' ? 'index.html' : '../index.html');
+                case 'rosters':
+                    return appendQuery(pageType === 'welcome' ? 'rosters/rosters.html' : '../rosters/rosters.html');
+                case 'ownership':
+                    return appendQuery(pageType === 'welcome' ? 'ownership/ownership.html' : '../ownership/ownership.html');
+                case 'analyzer':
+                    return appendQuery(pageType === 'welcome' ? 'analyzer/analyzer.html' : '../analyzer/analyzer.html');
+                default:
+                    return null;
+            }
+        };
+
+        const handleNavSelection = (target) => {
+            if (!target) return;
+
+            if (target === 'home') {
+                const url = buildNavUrl('home');
+                if (url) {
+                    window.location.href = url;
+                }
+                return;
+            }
+
+            const username = usernameInput.value.trim();
+            if (!username) {
+                return;
+            }
+
+            if (target === 'rosters') {
+                if (pageType === 'rosters') {
+                    handleFetchRosters();
+                } else {
+                    const url = buildNavUrl('rosters');
+                    if (url) {
+                        window.location.href = url;
+                    }
+                }
+                return;
+            }
+
+            if (target === 'ownership') {
+                if (pageType === 'ownership') {
+                    handleFetchOwnership();
+                } else {
+                    const url = buildNavUrl('ownership');
+                    if (url) {
+                        window.location.href = url;
+                    }
+                }
+                return;
+            }
+
+            if (target === 'analyzer') {
+                const url = buildNavUrl('analyzer');
+                if (url) {
+                    window.location.href = url;
+                }
+                return;
+            }
+
+            if (target === 'research') {
+                if (pageType === 'research') {
+                    return;
+                }
+                const url = buildNavUrl('research');
+                if (url) {
+                    window.location.href = url;
+                }
+            }
+        };
+
+        menuButton?.addEventListener('click', () => handleNavSelection('home'));
+
+        navButtons.forEach((btn) => {
+            btn.addEventListener('click', () => handleNavSelection(btn.dataset.nav));
         });
 
         analyzeLeagueButton?.addEventListener('click', () => {
             const username = usernameInput.value.trim();
             if (!username || !state.currentLeagueId) return;
-            window.location.href = `../analyzer/analyzer.html?username=${encodeURIComponent(username)}&leagueId=${state.currentLeagueId}`;
-        });
-
-        menuOwnership?.addEventListener('click', () => {
-            const username = usernameInput.value.trim();
-            if (!username) return;
-            if (pageType === 'ownership') {
-                handleFetchOwnership();
-            } else {
-                let url = pageType === 'welcome'
-                    ? `ownership/ownership.html?username=${encodeURIComponent(username)}`
-                    : `../ownership/ownership.html?username=${encodeURIComponent(username)}`;
-                const selected = leagueSelect?.value;
-                if (selected && selected !== 'Select a league...') {
-                    url += `&leagueId=${selected}`;
-                } else if (state.currentLeagueId) {
-                    url += `&leagueId=${state.currentLeagueId}`;
-                }
-                window.location.href = url;
-            }
-            dropdownMenu.classList.add('hidden');
-        });
-
-        menuResearch?.addEventListener('click', () => {
-            if (pageType === 'research') {
-                dropdownMenu.classList.add('hidden');
-                return;
-            }
-            const url = resolveResearchUrl();
-            window.location.href = url;
-            dropdownMenu.classList.add('hidden');
+            const params = new URLSearchParams({ username, leagueId: state.currentLeagueId });
+            window.location.href = `../analyzer/analyzer.html?${params.toString()}`;
         });
 
         researchButton?.addEventListener('click', () => {
@@ -156,8 +197,70 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 return;
             }
             const url = resolveResearchUrl();
-            window.location.href = url;
+            if (url) {
+                window.location.href = url;
+            }
         });
+
+        if (searchTrigger && rosterSearchInput && searchChip) {
+            const closeSearchIfEmpty = () => {
+                if (!rosterSearchInput.value.trim()) {
+                    searchChip.classList.remove('is-open');
+                    searchTrigger.setAttribute('aria-expanded', 'false');
+                }
+            };
+
+            searchTrigger.addEventListener('click', () => {
+                const isOpen = searchChip.classList.toggle('is-open');
+                searchTrigger.setAttribute('aria-expanded', String(isOpen));
+                if (isOpen) {
+                    requestAnimationFrame(() => rosterSearchInput.focus({ preventScroll: true }));
+                }
+            });
+
+            rosterSearchInput.addEventListener('input', (event) => {
+                const value = event.target.value.trim().toLowerCase();
+                if (searchDebounceId) {
+                    clearTimeout(searchDebounceId);
+                }
+                searchDebounceId = setTimeout(() => {
+                    state.playerSearchTerm = value;
+                    if (value) {
+                        searchChip.classList.add('is-open');
+                        searchTrigger.setAttribute('aria-expanded', 'true');
+                    }
+                    if (state.currentTeams) {
+                        renderAllTeamData(state.currentTeams);
+                    }
+                }, 250);
+            });
+
+            rosterSearchInput.addEventListener('blur', () => {
+                setTimeout(closeSearchIfEmpty, 120);
+            });
+
+            rosterSearchInput.addEventListener('keydown', (event) => {
+                if (event.key === 'Escape') {
+                    event.preventDefault();
+                    rosterSearchInput.value = '';
+                    state.playerSearchTerm = '';
+                    closeSearchIfEmpty();
+                    if (state.currentTeams) {
+                        renderAllTeamData(state.currentTeams);
+                    }
+                }
+            });
+        }
+
+        if (!searchTrigger && rosterSearchInput) {
+            rosterSearchInput.addEventListener('input', (event) => {
+                const value = event.target.value.trim().toLowerCase();
+                state.playerSearchTerm = value;
+                if (state.currentTeams) {
+                    renderAllTeamData(state.currentTeams);
+                }
+            });
+        }
 
         if (headerQuickLinks && analyzerButtonSlot && researchButtonSlot && analyzerButtonContainer && researchButtonContainer) {
             const quickLinksQuery = window.matchMedia('(min-width: 1024px)');
@@ -189,7 +292,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         }
 
         // --- State ---
-        let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), tradeBlock: {}, isTradeCollapsed: false, weeklyStats: {}, playerSeasonStats: {}, playerSeasonRanks: {}, playerWeeklyStats: {}, statsSheetsLoaded: false, seasonRankCache: null, isGameLogModalOpenFromComparison: false };
+        let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), playerSearchTerm: '', tradeBlock: {}, isTradeCollapsed: false, weeklyStats: {}, playerSeasonStats: {}, playerSeasonRanks: {}, playerWeeklyStats: {}, statsSheetsLoaded: false, seasonRankCache: null, isGameLogModalOpenFromComparison: false };
         const assignedLeagueColors = new Map();
         let nextColorIndex = 0;
         const assignedRyColors = new Map();
@@ -282,7 +385,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             compareButton?.addEventListener('click', handleCompareClick);
             clearCompareButton?.addEventListener('click', () => handleClearCompare(true));
             positionalViewBtn?.addEventListener('click', () => setRosterView('positional'));
-            depthChartViewBtn?.addEventListener('click', () => setRosterView('depth'));
+            depthChartViewBtn?.addEventListener('click', () => setRosterView('depthChart'));
             positionalFiltersContainer?.addEventListener('click', handlePositionFilter);
             clearFiltersButton?.addEventListener('click', handleClearFilters);
 
@@ -342,8 +445,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
         // --- View Toggling and Main Handlers ---
         function setRosterView(view) {
-    closeComparisonModal();
-    hideLegend();
+            closeComparisonModal();
+            hideLegend();
             state.currentRosterView = view;
             const isPositional = view === 'positional';
             positionalViewBtn.classList.toggle('active', isPositional);
@@ -702,6 +805,64 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 const pos = btn.dataset.position;
                 btn.classList.toggle('active', state.activePositions.has(pos));
             });
+        }
+
+
+        function matchesPositionFilters(player) {
+            if (!player || player.isPlaceholder) {
+                return true;
+            }
+            if (state.activePositions.size === 0) {
+                return true;
+            }
+            const basePos = (player.pos || player.position || player.basePosition || '').toUpperCase();
+            if (!basePos) {
+                return true;
+            }
+            if (state.activePositions.has(basePos)) {
+                return true;
+            }
+            if (state.activePositions.has('FLX') && ['RB', 'WR', 'TE'].includes(basePos)) {
+                return true;
+            }
+            return false;
+        }
+
+        function computePlayerSearchKey(player) {
+            if (!player) return '';
+            if (player._searchCache) return player._searchCache;
+            const fields = [
+                player.name,
+                player.full_name,
+                player.fullName,
+                player.display_name,
+                player.playerName,
+                player.first_name,
+                player.last_name,
+                player.nickname,
+                player.searchName,
+                player.search,
+                player.player?.full_name,
+                player.player?.display_name,
+            ];
+            const key = fields
+                .filter(Boolean)
+                .map(value => String(value).toLowerCase())
+                .join(' ');
+            player._searchCache = key;
+            return key;
+        }
+
+        function playerMatchesSearch(player) {
+            const term = state.playerSearchTerm;
+            if (!term) {
+                return true;
+            }
+            if (!player || player.isPlaceholder) {
+                return false;
+            }
+            const cacheKey = player._searchCache || computePlayerSearchKey(player);
+            return cacheKey.includes(term);
         }
 
 
@@ -2618,14 +2779,19 @@ const SEASON_META_HEADERS = {
             const card = document.createElement('div');
             card.className = 'team-card';
             card.innerHTML = `<div class="roster-section starters-section"><h3>Starters</h3></div><div class="roster-section bench-section"><h3>Bench</h3></div><div class="roster-section taxi-section"><h3>Taxi</h3></div><div class="roster-section picks-section"><h3>Draft Picks</h3></div>`;
-            
-            const filterActive = state.activePositions.size > 0;
-            const filterFunc = player => !filterActive || state.activePositions.has(player.pos) || (state.activePositions.has('FLX') && ['RB', 'WR', 'TE'].includes(player.pos));
 
             const populate = (sel, data, creator) => {
                 const el = card.querySelector(sel);
-                const filteredData = data.filter(item => item.isPlaceholder || filterFunc(item));
-                
+                const filteredData = data.filter(item => {
+                    if (!matchesPositionFilters(item)) {
+                        return false;
+                    }
+                    if (item.isPlaceholder) {
+                        return state.playerSearchTerm === '';
+                    }
+                    return playerMatchesSearch(item);
+                });
+
                 const h3 = el.querySelector('h3');
                 el.innerHTML = '';
                 el.appendChild(h3);
@@ -2664,9 +2830,6 @@ const SEASON_META_HEADERS = {
                 <div class="roster-section picks-section"><h3>Draft Picks</h3></div>
             `;
 
-            const filterActive = state.activePositions.size > 0;
-            const isFlexActive = state.activePositions.has('FLX');
-
             const positions = {
                 QB: team.allPlayers.filter(p => p.pos === 'QB').sort((a, b) => (b.ktc || 0) - (a.ktc || 0)),
                 RB: team.allPlayers.filter(p => p.pos === 'RB').sort((a, b) => (b.ktc || 0) - (a.ktc || 0)),
@@ -2677,18 +2840,24 @@ const SEASON_META_HEADERS = {
             const populate = (sel, data, creator) => {
                 const el = card.querySelector(sel);
                 const pos = sel.split('-')[0].toUpperCase().replace('.', '');
-                
-                el.style.display = 'none';
-                if (!filterActive || state.activePositions.has(pos) || (isFlexActive && ['RB', 'WR', 'TE'].includes(pos))) {
-                    el.style.display = 'block';
-                    const h3 = el.querySelector('h3');
-                    el.innerHTML = '';
-                    el.appendChild(h3);
-                    if (data && data.length > 0) {
-                        data.forEach(item => el.appendChild(creator(item, team.teamName)));
-                    } else {
-                        el.innerHTML += `<div class="text-xs text-slate-500 p-1 italic">None</div>`;
-                    }
+                const sectionAllowed = matchesPositionFilters({ pos });
+
+                if (!sectionAllowed) {
+                    el.style.display = 'none';
+                    return;
+                }
+
+                el.style.display = 'block';
+                const h3 = el.querySelector('h3');
+                el.innerHTML = '';
+                el.appendChild(h3);
+
+                const filteredPlayers = (data || []).filter(player => matchesPositionFilters(player) && playerMatchesSearch(player));
+
+                if (filteredPlayers.length > 0) {
+                    filteredPlayers.forEach(item => el.appendChild(creator(item, team.teamName)));
+                } else {
+                    el.innerHTML += `<div class="text-xs text-slate-500 p-1 italic">None</div>`;
                 }
             };
 
@@ -2727,7 +2896,7 @@ const SEASON_META_HEADERS = {
             const row = document.createElement('div');
             row.className = 'player-row';
             const slotAbbr = { 'SUPER_FLEX': 'SFLX', 'FLEX': 'FLX' };
-            const displaySlot = state.currentRosterView === 'depth' ? (slotAbbr[player.slot] || player.slot) : player.pos;
+            const displaySlot = state.currentRosterView === 'depthChart' ? (slotAbbr[player.slot] || player.slot) : player.pos;
             row.dataset.assetId = player.id;
             row.dataset.assetLabel = player.name;
             row.dataset.assetKtc = player.ktc || 0;

--- a/DH_P3-5.3/styles/styles.css
+++ b/DH_P3-5.3/styles/styles.css
@@ -5618,7 +5618,7 @@ body[data-page="rosters"] .liquid-nav-item {
 @media (min-width: 768px) {
   body[data-page="rosters"] .legacy-header-support {
     display: grid;
-    grid-template-columns: repeat(3, auto);
+    grid-template-columns: repeat(2, auto) minmax(0, 1fr) auto auto;
     gap: 0.75rem;
     align-items: center;
     margin-top: 0.75rem;
@@ -5715,122 +5715,144 @@ body[data-page="rosters"] .liquid-nav-item {
   }
 
   body[data-page="rosters"] .liquid-row-nav {
-    grid-template-columns: 3.1rem 1fr;
+    grid-template-columns: 2.625rem repeat(5, minmax(0, 1fr));
     column-gap: 0.45rem;
+    align-items: stretch;
   }
 
   body[data-page="rosters"] .liquid-logo-button {
-    height: 3rem;
-    width: 3rem;
-    border-radius: 24px;
+    height: 2.625rem;
+    width: 2.625rem;
+    border-radius: 50%;
     border: 1px solid rgba(118, 109, 255, 0.5);
-    background: linear-gradient(135deg, rgba(118, 109, 255, 0.4), rgba(66, 194, 255, 0.25));
-    color: #fff;
-    font-weight: 700;
-    font-size: 1.05rem;
-    letter-spacing: 0.08em;
+    background: linear-gradient(135deg, rgba(118, 109, 255, 0.45), rgba(66, 194, 255, 0.28));
+    padding: 0.2rem;
     display: grid;
     place-items: center;
-    box-shadow: 0 4px 16px rgba(18, 22, 44, 0.45);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.24);
+    transition: transform 180ms ease-out, box-shadow 180ms ease-out;
+  }
+
+  body[data-page="rosters"] .liquid-logo-button img {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    object-fit: contain;
+    filter: drop-shadow(0 2px 4px rgba(16, 19, 37, 0.35));
   }
 
   body[data-page="rosters"] .liquid-logo-button:active {
-    transform: scale(0.97);
+    transform: scale(0.94);
   }
 
   body[data-page="rosters"] .liquid-nav-cluster {
     display: grid;
     grid-template-columns: repeat(5, minmax(0, 1fr));
     gap: 0.4rem;
+    grid-column: 2 / -1;
   }
 
   body[data-page="rosters"] .liquid-nav-item {
-    display: grid;
-    gap: 0.1rem;
-    place-items: center;
-    padding: 0.35rem 0.25rem 0.45rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.2rem;
+    min-height: 3.25rem;
+    padding: 0.35rem 0.25rem;
     border-radius: 18px;
-    background: linear-gradient(145deg, rgba(15, 18, 36, 0.65), rgba(18, 22, 44, 0.4));
-    border: 1px solid rgba(128, 138, 189, 0.28);
-    color: rgba(234, 235, 240, 0.7);
-    font-size: 0.65rem;
-    text-transform: none;
-    transition: background 180ms ease-out, color 180ms ease-out, border 180ms ease-out, box-shadow 180ms ease-out;
+    background: linear-gradient(145deg, rgba(15, 18, 36, 0.62), rgba(18, 22, 44, 0.52));
+    border: 1px solid rgba(128, 138, 189, 0.34);
+    color: var(--color-text-secondary);
+    font-size: 0.7rem;
+    letter-spacing: 0.01em;
+    line-height: 1;
+    white-space: nowrap;
+    transition: background 180ms ease-out, color 180ms ease-out, box-shadow 180ms ease-out, transform 180ms ease-out;
   }
 
   body[data-page="rosters"] .liquid-nav-item i {
-    font-size: 1rem;
+    font-size: 1.1rem;
     opacity: 0.85;
   }
 
+  body[data-page="rosters"] .liquid-nav-item:active {
+    transform: translateY(1px);
+  }
+
   body[data-page="rosters"] .liquid-nav-item.is-active {
-    background: linear-gradient(135deg, rgba(118, 109, 255, 0.9), rgba(66, 194, 255, 0.85));
-    color: #0e1124;
-    border-color: rgba(118, 109, 255, 0.9);
-    box-shadow: 0 8px 16px rgba(18, 22, 44, 0.45);
+    background: linear-gradient(135deg, rgba(118, 109, 255, 0.88), rgba(66, 194, 255, 0.68));
+    color: #0f1325;
+    box-shadow: 0 8px 18px rgba(16, 19, 37, 0.32);
   }
 
   body[data-page="rosters"] .liquid-nav-item.is-active i {
     opacity: 1;
-    color: #0e1124;
+    color: #0f1325;
   }
 
   body[data-page="rosters"] .liquid-row-controls {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1.35fr);
-    gap: 0.45rem;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    column-gap: 0.45rem;
+    align-items: stretch;
   }
 
   body[data-page="rosters"] .liquid-league-chip {
     display: flex;
     align-items: center;
-    justify-content: flex-start;
-    padding: 0.15rem 0.5rem;
-    border-radius: 24px;
-    background: linear-gradient(145deg, rgba(15, 18, 36, 0.55), rgba(27, 30, 49, 0.45));
-    border: 1px solid rgba(128, 138, 189, 0.35);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+    background: linear-gradient(145deg, rgba(15, 18, 36, 0.55), rgba(18, 22, 44, 0.45));
+    border: 1px solid rgba(128, 138, 189, 0.3);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+    height: 2.75rem;
   }
 
   body[data-page="rosters"] .liquid-league-chip select {
     width: 100%;
+    height: 100%;
     background: transparent;
     border: none;
     color: var(--color-text-primary);
-    font-weight: 600;
-    font-size: 0.82rem;
+    font-size: 0.85rem;
+    padding: 0 0.35rem;
   }
 
   body[data-page="rosters"] .liquid-league-chip select:disabled {
-    opacity: 0.6;
+    opacity: 0.7;
   }
 
   body[data-page="rosters"] .liquid-view-toggle {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     background: linear-gradient(145deg, rgba(16, 19, 37, 0.7), rgba(18, 22, 44, 0.5));
-    border-radius: 24px;
+    border-radius: 999px;
     border: 1px solid rgba(128, 138, 189, 0.3);
     padding: 0.2rem;
     gap: 0.25rem;
+    height: 2.75rem;
   }
 
   body[data-page="rosters"] .liquid-toggle-option {
     border: none;
     background: transparent;
-    color: rgba(234, 235, 240, 0.75);
+    color: var(--color-text-secondary);
     font-size: 0.72rem;
     font-weight: 600;
     border-radius: 18px;
-    display: grid;
-    place-items: center;
-    gap: 0.25rem;
-    padding: 0.35rem 0.25rem;
-    transition: background 180ms ease-out, color 180ms ease-out, transform 180ms ease-out;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.18rem;
+    line-height: 1;
+    white-space: nowrap;
+    transition: background 180ms ease-out, color 180ms ease-out, transform 180ms ease-out, box-shadow 180ms ease-out;
   }
 
   body[data-page="rosters"] .liquid-toggle-option i {
     font-size: 0.95rem;
-    opacity: 0.8;
+    opacity: 0.85;
   }
 
   body[data-page="rosters"] .liquid-toggle-option.active {
@@ -5846,20 +5868,9 @@ body[data-page="rosters"] .liquid-nav-item {
   }
 
   body[data-page="rosters"] .liquid-row-filters {
-    grid-template-columns: auto minmax(0, 1fr) auto;
-    align-items: start;
-    gap: 0.45rem;
-  }
-
-  body[data-page="rosters"] .liquid-support-chip {
-    display: flex;
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
-    justify-content: center;
-    padding: 0.25rem 0.4rem;
-    border-radius: 20px;
-    background: linear-gradient(145deg, rgba(15, 18, 36, 0.55), rgba(18, 22, 44, 0.45));
-    border: 1px solid rgba(128, 138, 189, 0.3);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    gap: 0.5rem;
   }
 
   body[data-page="rosters"] .filters-container {
@@ -5877,7 +5888,7 @@ body[data-page="rosters"] .liquid-nav-item {
 
   body[data-page="rosters"] #positional-filters .filter-btn {
     border-radius: 16px;
-    padding: 0.3rem 0;
+    padding: 0.32rem 0;
     font-size: 0.7rem;
   }
 
@@ -5890,15 +5901,15 @@ body[data-page="rosters"] .liquid-nav-item {
     border-radius: 999px;
     background: linear-gradient(145deg, rgba(15, 18, 36, 0.6), rgba(18, 22, 44, 0.5));
     border: 1px solid rgba(128, 138, 189, 0.32);
-    padding: 0.2rem;
-    min-width: 2.75rem;
+    padding: 0.18rem;
+    min-width: 2.625rem;
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.09);
     overflow: hidden;
   }
 
   body[data-page="rosters"] .liquid-search-chip .search-trigger {
-    width: 2.35rem;
-    height: 2.35rem;
+    width: 2.625rem;
+    height: 2.625rem;
     border-radius: 50%;
     border: none;
     background: linear-gradient(135deg, rgba(118, 109, 255, 0.9), rgba(66, 194, 255, 0.8));
@@ -5932,7 +5943,7 @@ body[data-page="rosters"] .liquid-nav-item {
 
   body[data-page="rosters"] .liquid-search-chip.is-open {
     grid-template-columns: auto minmax(0, 1fr);
-    min-width: min(100%, 220px);
+    min-width: min(100%, 10rem);
   }
 
   body[data-page="rosters"] .liquid-search-chip.is-open .search-field {

--- a/DH_P3-5.3/styles/styles.css
+++ b/DH_P3-5.3/styles/styles.css
@@ -5602,3 +5602,347 @@ body[data-page="research"] .app-header {
   }
 }
 
+/* --- Mobile Liquid Header (Variant A) --- */
+body[data-page="rosters"] #usernameInput {
+  display: none;
+}
+
+body[data-page="rosters"] .liquid-nav-item {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  padding: 0;
+}
+
+@media (min-width: 768px) {
+  body[data-page="rosters"] .legacy-header-support {
+    display: grid;
+    grid-template-columns: repeat(3, auto);
+    gap: 0.75rem;
+    align-items: center;
+    margin-top: 0.75rem;
+  }
+
+  body[data-page="rosters"] #mobileRosterShell {
+    border-radius: var(--panel-border-radius);
+    background: var(--color-panel-bg);
+    padding: 0.5rem;
+  }
+
+  body[data-page="rosters"] .liquid-row-nav {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+  }
+
+  body[data-page="rosters"] .liquid-nav-cluster {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  body[data-page="rosters"] .liquid-nav-item {
+    padding: 0.35rem 0.65rem;
+    border-radius: 999px;
+    background: rgba(22, 24, 43, 0.6);
+    border: 1px solid rgba(128, 138, 189, 0.25);
+    font-size: 0.85rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  body[data-page="rosters"] .liquid-nav-item i {
+    font-size: 0.9rem;
+  }
+
+  body[data-page="rosters"] .liquid-nav-item.is-active {
+    background: rgba(118, 109, 255, 0.24);
+    border-color: var(--color-accent-primary);
+    color: var(--color-text-primary);
+  }
+}
+
+@media (max-width: 767px) {
+  body[data-page="rosters"] .app-header {
+    padding: 0.5rem 0.35rem 0.4rem;
+  }
+
+  body[data-page="rosters"] .legacy-header-support {
+    display: none;
+  }
+
+  body[data-page="rosters"] #mobileRosterShell {
+    position: relative;
+    border-radius: 32px;
+    background: linear-gradient(145deg, rgba(22, 24, 43, 0.62), rgba(22, 24, 43, 0.42));
+    border: 1px solid rgba(128, 138, 189, 0.3);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12), 0 12px 24px rgba(8, 10, 24, 0.45);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
+    padding: 0.45rem 0.55rem;
+    display: grid;
+    gap: 0.55rem;
+    overflow: hidden;
+  }
+
+  body[data-page="rosters"] #mobileRosterShell::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    border-radius: inherit;
+    background: radial-gradient(circle at 20% 15%, rgba(255, 255, 255, 0.15), transparent 55%);
+    mix-blend-mode: screen;
+  }
+
+  body[data-page="rosters"] .liquid-row {
+    position: relative;
+    display: grid;
+    align-items: center;
+    width: 100%;
+  }
+
+  body[data-page="rosters"] .liquid-row:not(:last-child)::after {
+    content: '';
+    position: absolute;
+    left: 0.55rem;
+    right: 0.55rem;
+    bottom: -0.3rem;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(128, 138, 189, 0.35), transparent);
+    opacity: 0.75;
+  }
+
+  body[data-page="rosters"] .liquid-row-nav {
+    grid-template-columns: 3.1rem 1fr;
+    column-gap: 0.45rem;
+  }
+
+  body[data-page="rosters"] .liquid-logo-button {
+    height: 3rem;
+    width: 3rem;
+    border-radius: 24px;
+    border: 1px solid rgba(118, 109, 255, 0.5);
+    background: linear-gradient(135deg, rgba(118, 109, 255, 0.4), rgba(66, 194, 255, 0.25));
+    color: #fff;
+    font-weight: 700;
+    font-size: 1.05rem;
+    letter-spacing: 0.08em;
+    display: grid;
+    place-items: center;
+    box-shadow: 0 4px 16px rgba(18, 22, 44, 0.45);
+  }
+
+  body[data-page="rosters"] .liquid-logo-button:active {
+    transform: scale(0.97);
+  }
+
+  body[data-page="rosters"] .liquid-nav-cluster {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 0.4rem;
+  }
+
+  body[data-page="rosters"] .liquid-nav-item {
+    display: grid;
+    gap: 0.1rem;
+    place-items: center;
+    padding: 0.35rem 0.25rem 0.45rem;
+    border-radius: 18px;
+    background: linear-gradient(145deg, rgba(15, 18, 36, 0.65), rgba(18, 22, 44, 0.4));
+    border: 1px solid rgba(128, 138, 189, 0.28);
+    color: rgba(234, 235, 240, 0.7);
+    font-size: 0.65rem;
+    text-transform: none;
+    transition: background 180ms ease-out, color 180ms ease-out, border 180ms ease-out, box-shadow 180ms ease-out;
+  }
+
+  body[data-page="rosters"] .liquid-nav-item i {
+    font-size: 1rem;
+    opacity: 0.85;
+  }
+
+  body[data-page="rosters"] .liquid-nav-item.is-active {
+    background: linear-gradient(135deg, rgba(118, 109, 255, 0.9), rgba(66, 194, 255, 0.85));
+    color: #0e1124;
+    border-color: rgba(118, 109, 255, 0.9);
+    box-shadow: 0 8px 16px rgba(18, 22, 44, 0.45);
+  }
+
+  body[data-page="rosters"] .liquid-nav-item.is-active i {
+    opacity: 1;
+    color: #0e1124;
+  }
+
+  body[data-page="rosters"] .liquid-row-controls {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.35fr);
+    gap: 0.45rem;
+  }
+
+  body[data-page="rosters"] .liquid-league-chip {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    padding: 0.15rem 0.5rem;
+    border-radius: 24px;
+    background: linear-gradient(145deg, rgba(15, 18, 36, 0.55), rgba(27, 30, 49, 0.45));
+    border: 1px solid rgba(128, 138, 189, 0.35);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  }
+
+  body[data-page="rosters"] .liquid-league-chip select {
+    width: 100%;
+    background: transparent;
+    border: none;
+    color: var(--color-text-primary);
+    font-weight: 600;
+    font-size: 0.82rem;
+  }
+
+  body[data-page="rosters"] .liquid-league-chip select:disabled {
+    opacity: 0.6;
+  }
+
+  body[data-page="rosters"] .liquid-view-toggle {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    background: linear-gradient(145deg, rgba(16, 19, 37, 0.7), rgba(18, 22, 44, 0.5));
+    border-radius: 24px;
+    border: 1px solid rgba(128, 138, 189, 0.3);
+    padding: 0.2rem;
+    gap: 0.25rem;
+  }
+
+  body[data-page="rosters"] .liquid-toggle-option {
+    border: none;
+    background: transparent;
+    color: rgba(234, 235, 240, 0.75);
+    font-size: 0.72rem;
+    font-weight: 600;
+    border-radius: 18px;
+    display: grid;
+    place-items: center;
+    gap: 0.25rem;
+    padding: 0.35rem 0.25rem;
+    transition: background 180ms ease-out, color 180ms ease-out, transform 180ms ease-out;
+  }
+
+  body[data-page="rosters"] .liquid-toggle-option i {
+    font-size: 0.95rem;
+    opacity: 0.8;
+  }
+
+  body[data-page="rosters"] .liquid-toggle-option.active {
+    background: linear-gradient(135deg, rgba(118, 109, 255, 0.85), rgba(66, 194, 255, 0.7));
+    color: #101326;
+    box-shadow: 0 6px 12px rgba(16, 19, 37, 0.35);
+    transform: translateY(-1px);
+  }
+
+  body[data-page="rosters"] .liquid-toggle-option.active i {
+    opacity: 1;
+    color: #101326;
+  }
+
+  body[data-page="rosters"] .liquid-row-filters {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.45rem;
+  }
+
+  body[data-page="rosters"] .liquid-support-chip {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.4rem;
+    border-radius: 20px;
+    background: linear-gradient(145deg, rgba(15, 18, 36, 0.55), rgba(18, 22, 44, 0.45));
+    border: 1px solid rgba(128, 138, 189, 0.3);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  }
+
+  body[data-page="rosters"] .filters-container {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  body[data-page="rosters"] #positional-filters {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 0.25rem;
+  }
+
+  body[data-page="rosters"] #positional-filters .filter-btn {
+    border-radius: 16px;
+    padding: 0.3rem 0;
+    font-size: 0.7rem;
+  }
+
+  body[data-page="rosters"] .liquid-search-chip {
+    position: relative;
+    display: grid;
+    grid-template-columns: auto;
+    justify-content: end;
+    align-items: center;
+    border-radius: 999px;
+    background: linear-gradient(145deg, rgba(15, 18, 36, 0.6), rgba(18, 22, 44, 0.5));
+    border: 1px solid rgba(128, 138, 189, 0.32);
+    padding: 0.2rem;
+    min-width: 2.75rem;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.09);
+    overflow: hidden;
+  }
+
+  body[data-page="rosters"] .liquid-search-chip .search-trigger {
+    width: 2.35rem;
+    height: 2.35rem;
+    border-radius: 50%;
+    border: none;
+    background: linear-gradient(135deg, rgba(118, 109, 255, 0.9), rgba(66, 194, 255, 0.8));
+    color: #0f1325;
+    display: grid;
+    place-items: center;
+    box-shadow: 0 6px 14px rgba(16, 19, 37, 0.45);
+    transition: transform 180ms ease-out;
+  }
+
+  body[data-page="rosters"] .liquid-search-chip .search-trigger:active {
+    transform: scale(0.95);
+  }
+
+  body[data-page="rosters"] .liquid-search-chip .search-field {
+    width: 0;
+    opacity: 0;
+    transform: scale(0.75);
+    transform-origin: right center;
+    transition: width 220ms ease-out, opacity 220ms ease-out, transform 220ms ease-out;
+  }
+
+  body[data-page="rosters"] .liquid-search-chip .search-field input {
+    width: 100%;
+    background: transparent;
+    border: none;
+    color: var(--color-text-primary);
+    font-size: 0.78rem;
+    padding: 0 0.5rem 0 0.45rem;
+  }
+
+  body[data-page="rosters"] .liquid-search-chip.is-open {
+    grid-template-columns: auto minmax(0, 1fr);
+    min-width: min(100%, 220px);
+  }
+
+  body[data-page="rosters"] .liquid-search-chip.is-open .search-field {
+    width: 100%;
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  body[data-page="rosters"] .liquid-search-chip.is-open .search-trigger {
+    box-shadow: 0 8px 16px rgba(16, 19, 37, 0.35);
+  }
+}
+


### PR DESCRIPTION
## Summary
- redesign the mobile rosters header with a liquid glass navigation shell, segmented view control, and inline player search chip
- add responsive styling for the new mobile-only layout while keeping desktop header elements accessible via the legacy support wrapper
- update navigation, query preservation, and filtering logic to include the debounced name search and new depthChart view identifier

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d1897c2424832e956ac5f455838215