### PR TITLE
Implement mobile liquid glass header on Rosters

### DIFF
--- a/DH_P3-5.3/rosters/rosters.html
+++ b/DH_P3-5.3/rosters/rosters.html
@@ -28,106 +28,124 @@
 <div class="relative z-10 content-wrapper">
 <div id="header-container">
 <header class="app-header glass-panel">
-<div class="header-row" id="primary-header-row">
-<div class="menu-container">
-    <button id="menu-button" class="menu-button">
-        <svg viewBox="0 0 100 80" width="20" height="20">
-            <rect width="100" height="15"></rect>
-            <rect y="30" width="100" height="15"></rect>
-            <rect y="60" width="100" height="15"></rect>
-        </svg>
-    </button>
-    <div id="dropdown-menu" class="dropdown-menu hidden">
-        <a href="../">
-            <i class="fa-solid fa-house-user" aria-hidden="true"></i>
-            <span>Home</span>
-        </a>
-        <a href="#" id="menu-rosters">
-            <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
-            <span>Rosters</span>
-        </a>
-        <a href="#" id="menu-ownership">
-            <i class="fa-solid fa-percent" aria-hidden="true"></i>
-            <span>Ownership</span>
-        </a>
-        <a href="#" id="menu-research">
-            <i class="fa-solid fa-flask" aria-hidden="true"></i>
-            <span>Research</span>
-        </a>
-        <a href="#" id="menu-analyzer">
-            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-            <span>League Analyzer</span>
-        </a>
-    </div>
-</div>
-<div class="header-quick-links" id="header-quick-links" aria-label="Research shortcuts"></div>
-<div class="username-area">
-<input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
-</div>
-<div class="app-view-switcher primary-switcher">
-<button id="fetchRostersButton">Rosters</button>
-<button id="fetchOwnershipButton">Ownership%</button>
-</div>
-</div>
-<div class="hidden" id="contextual-controls">
-<div class="header-row" id="secondary-header-row">
-<div class="analyzer-button-slot" id="analyzer-button-slot">
-<div class="analyzer-button-container">
-    <button aria-label="Open League Analyzer" class="menu-button analyzer-button" id="analyzeLeagueButton" type="button">
-        <i class="fa-solid fa-square-poll-vertical analyzer-icon" aria-hidden="true"></i>
-        <span class="analyzer-label">Analyzer</span>
-    </button>
-</div>
-</div>
-<div class="custom-select-wrapper">
-<select disabled="" id="leagueSelect">
-<option>Select a league...</option>
-</select>
-</div>
-<div class="view-switcher secondary-switcher">
-<button id="positionalViewBtn">Positional </button>
-<button id="depthChartViewBtn">Lineup</button>
-</div>
-</div>
-<div class="header-row" id="filters-row">
-    <div class="research-button-slot" id="research-button-slot">
-    <div class="research-button-container">
-        <button class="menu-button analyzer-button research-button" id="researchButton" type="button" aria-label="Open Research insights">
-            <i class="fa-solid fa-flask-vial analyzer-icon" aria-hidden="true"></i>
-            <span class="analyzer-label">Research</span>
-        </button>
-    </div>
-    </div>
-    <div class="filters-container">
-        <div id="positional-filters">
-            <button class="filter-btn" data-position="QB">QB</button>
-            <button class="filter-btn" data-position="RB">RB</button>
-            <button class="filter-btn" data-position="WR">WR</button>
-            <button class="filter-btn" data-position="TE">TE</button>
-            <button class="filter-btn" data-position="FLX">FLX</button>
-        </div>
-        <button class="control-button-subtle" id="clearFiltersButton">
-            <span class="clear-filters-stack">
-                <i class="fa-solid fa-filter-circle-xmark" aria-hidden="true"></i>
-                <span class="sr-only">Clear filters</span>
-            </span>
-        </button>
-
-        <div class="compare-controls">
-            <!-- Hidden compare button kept only to satisfy JS state machine (do not show) -->
-            <button class="control-button hidden" id="compareButton" aria-hidden="true" tabindex="-1" style="display:none;"></button>
-            <!-- Clear selections button -->
-            <button class="control-button-subtle hidden" id="clearCompareButton" aria-label="Clear selections">
-                <span class="clear-filters-stack">
-                    <i class="fa-regular fa-rectangle-xmark" aria-hidden="true"></i>
-                    <span class="sr-only">Clear compare selections</span>
-                </span>
+    <div class="liquid-header-shell" data-variant="liquid-a">
+        <div class="liquid-row liquid-nav-row" role="navigation" aria-label="Primary navigation">
+            <button id="menu-button" class="dh-home-button" type="button" aria-label="Dynasty Hub Home">
+                <span class="dh-home-logo">DH</span>
             </button>
+            <nav class="liquid-nav-menu">
+                <button class="liquid-nav-item" data-nav-target="home" type="button">
+                    <i class="fa-solid fa-house-user" aria-hidden="true"></i>
+                    <span>Home</span>
+                </button>
+                <button class="liquid-nav-item active" data-nav-target="rosters" type="button">
+                    <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
+                    <span>Rosters</span>
+                </button>
+                <button class="liquid-nav-item" data-nav-target="ownership" type="button">
+                    <i class="fa-solid fa-percent" aria-hidden="true"></i>
+                    <span>Ownership</span>
+                </button>
+                <button class="liquid-nav-item" data-nav-target="research" type="button">
+                    <i class="fa-solid fa-flask" aria-hidden="true"></i>
+                    <span>Research</span>
+                </button>
+                <button class="liquid-nav-item" data-nav-target="analyzer" type="button">
+                    <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+                    <span>Lg.Analyze</span>
+                </button>
+            </nav>
         </div>
+        <div class="liquid-context hidden" id="contextual-controls">
+            <div class="liquid-row liquid-controls-row" id="secondary-header-row">
+                <div class="league-chip">
+                    <label class="sr-only" for="leagueSelect">Select league</label>
+                    <div class="custom-select-wrapper">
+                        <select disabled="" id="leagueSelect">
+                            <option>Select a league...</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="view-switcher secondary-switcher" role="group" aria-label="Roster view">
+                    <button id="positionalViewBtn" type="button">
+                        <i class="fa-solid fa-id-card" aria-hidden="true"></i>
+                        <span>Positional</span>
+                    </button>
+                    <button id="depthChartViewBtn" type="button">
+                        <i class="fa-solid fa-elevator" aria-hidden="true"></i>
+                        <span>Lineup</span>
+                    </button>
+                </div>
+            </div>
+            <div class="liquid-row liquid-filters-row" id="filters-row">
+                <div class="filters-container">
+                    <div id="positional-filters">
+                        <button class="filter-btn" data-position="QB">QB</button>
+                        <button class="filter-btn" data-position="RB">RB</button>
+                        <button class="filter-btn" data-position="WR">WR</button>
+                        <button class="filter-btn" data-position="TE">TE</button>
+                        <button class="filter-btn" data-position="FLX">FLX</button>
+                    </div>
+                    <button class="control-button-subtle" id="clearFiltersButton" type="button">
+                        <span class="clear-filters-stack">
+                            <i class="fa-solid fa-filter-circle-xmark" aria-hidden="true"></i>
+                            <span class="sr-only">Clear filters</span>
+                        </span>
+                    </button>
 
+                    <div class="compare-controls">
+                        <!-- Hidden compare button kept only to satisfy JS state machine (do not show) -->
+                        <button class="control-button hidden" id="compareButton" aria-hidden="true" tabindex="-1" style="display:none;"></button>
+                        <!-- Clear selections button -->
+                        <button class="control-button-subtle hidden" id="clearCompareButton" aria-label="Clear selections" type="button">
+                            <span class="clear-filters-stack">
+                                <i class="fa-regular fa-rectangle-xmark" aria-hidden="true"></i>
+                                <span class="sr-only">Clear compare selections</span>
+                            </span>
+                        </button>
+                    </div>
+                </div>
+                <div class="search-chip" id="roster-search-chip">
+                    <button class="search-chip-toggle" type="button" aria-expanded="false" aria-controls="rosterSearchInput">
+                        <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+                        <span class="sr-only">Search players</span>
+                    </button>
+                    <div class="search-chip-field">
+                        <input type="search" id="rosterSearchInput" autocomplete="off" placeholder="Search players" aria-label="Search players" />
+                        <button type="button" class="search-chip-clear" aria-label="Clear search">
+                            <i class="fa-solid fa-circle-xmark" aria-hidden="true"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
-</div>
-</div>
+    <div class="legacy-action-slots" aria-hidden="true">
+        <div class="analyzer-button-slot" id="analyzer-button-slot">
+            <div class="analyzer-button-container">
+                <button aria-label="Open League Analyzer" class="menu-button analyzer-button" id="analyzeLeagueButton" type="button">
+                    <i class="fa-solid fa-square-poll-vertical analyzer-icon" aria-hidden="true"></i>
+                    <span class="analyzer-label">Analyzer</span>
+                </button>
+            </div>
+        </div>
+        <div class="research-button-slot" id="research-button-slot">
+            <div class="research-button-container">
+                <button class="menu-button analyzer-button research-button" id="researchButton" type="button" aria-label="Open Research insights">
+                    <i class="fa-solid fa-flask-vial analyzer-icon" aria-hidden="true"></i>
+                    <span class="analyzer-label">Research</span>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="header-quick-links" id="header-quick-links" aria-label="Research shortcuts"></div>
+    <div class="username-area">
+        <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle" />
+    </div>
+    <div class="app-view-switcher primary-switcher">
+        <button id="fetchRostersButton">Rosters</button>
+        <button id="fetchOwnershipButton">Ownership%</button>
+    </div>
 </header>
 </div>
 <main class="container mx-auto" id="content">

--- a/DH_P3-5.3/scripts/app.js
+++ b/DH_P3-5.3/scripts/app.js
@@ -50,13 +50,10 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             compareButton.innerHTML = COMPARE_BUTTON_PREVIEW_HTML;
         }
 
-        // --- Menu Button ---
+        // --- Navigation & Search ---
         const menuButton = document.getElementById('menu-button');
-        const dropdownMenu = document.getElementById('dropdown-menu');
-        const menuRosters = document.getElementById('menu-rosters');
-        const menuOwnership = document.getElementById('menu-ownership');
-        const menuAnalyzer = document.getElementById('menu-analyzer');
-        const menuResearch = document.getElementById('menu-research');
+        const navMenu = document.querySelector('.liquid-nav-menu');
+        const navItems = navMenu ? Array.from(navMenu.querySelectorAll('.liquid-nav-item')) : [];
         const analyzeLeagueButton = document.getElementById('analyzeLeagueButton');
         const resolveResearchUrl = () => {
             const username = usernameInput.value.trim();
@@ -69,87 +66,12 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             }
             return `../research/research.html${suffix}`;
         };
-
-        menuButton?.addEventListener('click', (e) => {
-            e.stopPropagation();
-            dropdownMenu.classList.toggle('hidden');
-        });
-
-        document.addEventListener('click', (e) => {
-            if (dropdownMenu && !dropdownMenu.classList.contains('hidden') && !menuButton.contains(e.target)) {
-                dropdownMenu.classList.add('hidden');
-            }
-        });
-
-        menuRosters?.addEventListener('click', () => {
-            const username = usernameInput.value.trim();
-            if (!username) return;
-            if (pageType === 'rosters') {
-                handleFetchRosters();
-            } else {
-                let url = pageType === 'welcome'
-                    ? `rosters/rosters.html?username=${encodeURIComponent(username)}`
-                    : `../rosters/rosters.html?username=${encodeURIComponent(username)}`;
-                const selected = leagueSelect?.value;
-                if (selected && selected !== 'Select a league...') {
-                    url += `&leagueId=${selected}`;
-                } else if (state.currentLeagueId) {
-                    url += `&leagueId=${state.currentLeagueId}`;
-                }
-                window.location.href = url;
-            }
-            dropdownMenu.classList.add('hidden');
-        });
-
-        menuAnalyzer?.addEventListener('click', () => {
-            const username = usernameInput.value.trim();
-            if (!username) return;
-            let url = pageType === 'welcome'
-                ? `analyzer/analyzer.html?username=${encodeURIComponent(username)}`
-                : `../analyzer/analyzer.html?username=${encodeURIComponent(username)}`;
-            const selected = leagueSelect?.value || state.currentLeagueId;
-            if (selected && selected !== 'Select a league...') {
-                url += `&leagueId=${selected}`;
-            }
-            window.location.href = url;
-            dropdownMenu.classList.add('hidden');
-        });
-
-        analyzeLeagueButton?.addEventListener('click', () => {
-            const username = usernameInput.value.trim();
-            if (!username || !state.currentLeagueId) return;
-            window.location.href = `../analyzer/analyzer.html?username=${encodeURIComponent(username)}&leagueId=${state.currentLeagueId}`;
-        });
-
-        menuOwnership?.addEventListener('click', () => {
-            const username = usernameInput.value.trim();
-            if (!username) return;
-            if (pageType === 'ownership') {
-                handleFetchOwnership();
-            } else {
-                let url = pageType === 'welcome'
-                    ? `ownership/ownership.html?username=${encodeURIComponent(username)}`
-                    : `../ownership/ownership.html?username=${encodeURIComponent(username)}`;
-                const selected = leagueSelect?.value;
-                if (selected && selected !== 'Select a league...') {
-                    url += `&leagueId=${selected}`;
-                } else if (state.currentLeagueId) {
-                    url += `&leagueId=${state.currentLeagueId}`;
-                }
-                window.location.href = url;
-            }
-            dropdownMenu.classList.add('hidden');
-        });
-
-        menuResearch?.addEventListener('click', () => {
-            if (pageType === 'research') {
-                dropdownMenu.classList.add('hidden');
-                return;
-            }
-            const url = resolveResearchUrl();
-            window.location.href = url;
-            dropdownMenu.classList.add('hidden');
-        });
+        const searchChip = document.getElementById('roster-search-chip');
+        const searchToggle = searchChip?.querySelector('.search-chip-toggle');
+        const searchInput = document.getElementById('rosterSearchInput');
+        const searchClearButton = searchChip?.querySelector('.search-chip-clear');
+        let searchDebounceTimer = null;
+        let searchCloseTimer = null;
 
         researchButton?.addEventListener('click', () => {
             if (pageType === 'research') {
@@ -189,7 +111,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         }
 
         // --- State ---
-        let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), tradeBlock: {}, isTradeCollapsed: false, weeklyStats: {}, playerSeasonStats: {}, playerSeasonRanks: {}, playerWeeklyStats: {}, statsSheetsLoaded: false, seasonRankCache: null, isGameLogModalOpenFromComparison: false };
+        let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), tradeBlock: {}, isTradeCollapsed: false, weeklyStats: {}, playerSeasonStats: {}, playerSeasonRanks: {}, playerWeeklyStats: {}, statsSheetsLoaded: false, seasonRankCache: null, isGameLogModalOpenFromComparison: false, searchTerm: '' };
         const assignedLeagueColors = new Map();
         let nextColorIndex = 0;
         const assignedRyColors = new Map();
@@ -213,6 +135,241 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             "dynasty footballers": "DFB", "la leaguaaa dynasty est2024": "LLGA",
             "la leaugaaa dynasty est2024": "LLGA"
         };
+
+        const appendQueryParam = (url, key, value) => {
+            if (!value) return url;
+            const separator = url.includes('?') ? '&' : '?';
+            return `${url}${separator}${key}=${encodeURIComponent(value)}`;
+        };
+
+        const getActiveLeagueId = () => {
+            const selected = leagueSelect?.value;
+            if (selected && selected !== 'Select a league...') {
+                return selected;
+            }
+            return state.currentLeagueId || null;
+        };
+
+        const getCurrentNavTarget = () => {
+            switch (pageType) {
+                case 'rosters':
+                    return 'rosters';
+                case 'ownership':
+                    return 'ownership';
+                case 'research':
+                    return 'research';
+                case 'analyzer':
+                    return 'analyzer';
+                default:
+                    return 'home';
+            }
+        };
+
+        const setActiveNav = (target) => {
+            navItems.forEach(btn => {
+                const isActive = btn.dataset.navTarget === target;
+                btn.classList.toggle('active', isActive);
+            });
+        };
+
+        setActiveNav(getCurrentNavTarget());
+
+        const navigateToTarget = (target) => {
+            const username = usernameInput.value.trim();
+            const leagueId = getActiveLeagueId();
+            const ensureUsername = () => username && username.length > 0;
+
+            const withUsername = (baseUrl) => {
+                if (!ensureUsername()) return baseUrl;
+                return appendQueryParam(baseUrl, 'username', username);
+            };
+
+            const withLeague = (baseUrl) => {
+                if (!leagueId) return baseUrl;
+                return appendQueryParam(baseUrl, 'leagueId', leagueId);
+            };
+
+            switch (target) {
+                case 'home': {
+                    let url = pageType === 'welcome' ? './index.html' : '../index.html';
+                    url = withUsername(url);
+                    window.location.href = url;
+                    break;
+                }
+                case 'rosters': {
+                    if (!ensureUsername()) {
+                        usernameInput?.focus();
+                        return;
+                    }
+                    if (pageType === 'rosters') {
+                        setActiveNav('rosters');
+                        handleFetchRosters();
+                        return;
+                    }
+                    let url = pageType === 'welcome'
+                        ? 'rosters/rosters.html'
+                        : '../rosters/rosters.html';
+                    url = withLeague(withUsername(url));
+                    window.location.href = url;
+                    break;
+                }
+                case 'ownership': {
+                    if (!ensureUsername()) {
+                        usernameInput?.focus();
+                        return;
+                    }
+                    if (pageType === 'ownership') {
+                        setActiveNav('ownership');
+                        handleFetchOwnership();
+                        return;
+                    }
+                    let url = pageType === 'welcome'
+                        ? 'ownership/ownership.html'
+                        : '../ownership/ownership.html';
+                    url = withLeague(withUsername(url));
+                    window.location.href = url;
+                    break;
+                }
+                case 'research': {
+                    const url = resolveResearchUrl();
+                    if (pageType === 'research') {
+                        setActiveNav('research');
+                        return;
+                    }
+                    window.location.href = url;
+                    break;
+                }
+                case 'analyzer': {
+                    if (!ensureUsername()) {
+                        usernameInput?.focus();
+                        return;
+                    }
+                    if (!state.currentLeagueId && !leagueId) {
+                        setActiveNav(getCurrentNavTarget());
+                        return;
+                    }
+                    let url = pageType === 'welcome'
+                        ? 'analyzer/analyzer.html'
+                        : '../analyzer/analyzer.html';
+                    url = withLeague(withUsername(url));
+                    window.location.href = url;
+                    break;
+                }
+                default:
+                    break;
+            }
+        };
+
+        const openSearchChip = () => {
+            if (!searchChip) return;
+            if (!searchChip.classList.contains('is-open')) {
+                searchChip.classList.add('is-open');
+                searchToggle?.setAttribute('aria-expanded', 'true');
+            }
+            if (searchInput && document.activeElement !== searchInput) {
+                window.requestAnimationFrame(() => searchInput.focus());
+            }
+        };
+
+        const closeSearchChip = (force = false) => {
+            if (!searchChip) return;
+            if (!force && searchInput && searchInput.value.trim().length > 0) {
+                return;
+            }
+            searchChip.classList.remove('is-open');
+            searchToggle?.setAttribute('aria-expanded', 'false');
+            if (force) {
+                searchInput?.blur();
+            }
+        };
+
+        const updateSearchTerm = (term, { immediate = false } = {}) => {
+            if (pageType !== 'rosters') return;
+            const normalized = term.trim().toLowerCase();
+            if (immediate) {
+                state.searchTerm = normalized;
+                if (state.currentTeams) {
+                    renderAllTeamData(state.currentTeams);
+                }
+                return;
+            }
+            clearTimeout(searchDebounceTimer);
+            searchDebounceTimer = window.setTimeout(() => {
+                state.searchTerm = normalized;
+                if (state.currentTeams) {
+                    renderAllTeamData(state.currentTeams);
+                }
+            }, 250);
+        };
+
+        menuButton?.addEventListener('click', () => navigateToTarget('home'));
+
+        navItems.forEach(btn => {
+            btn.addEventListener('click', () => {
+                const target = btn.dataset.navTarget;
+                if (!target) return;
+                navigateToTarget(target);
+            });
+        });
+
+        analyzeLeagueButton?.addEventListener('click', () => {
+            const username = usernameInput.value.trim();
+            const leagueId = getActiveLeagueId();
+            if (!username || !leagueId) return;
+            let url = pageType === 'welcome'
+                ? 'analyzer/analyzer.html'
+                : '../analyzer/analyzer.html';
+            url = appendQueryParam(url, 'username', username);
+            url = appendQueryParam(url, 'leagueId', leagueId);
+            window.location.href = url;
+        });
+
+        searchToggle?.addEventListener('click', () => {
+            if (!searchChip) return;
+            if (searchChip.classList.contains('is-open')) {
+                closeSearchChip(true);
+            } else {
+                openSearchChip();
+            }
+        });
+
+        searchInput?.addEventListener('focus', () => {
+            if (searchCloseTimer) window.clearTimeout(searchCloseTimer);
+            openSearchChip();
+        });
+
+        searchInput?.addEventListener('blur', () => {
+            if (searchCloseTimer) window.clearTimeout(searchCloseTimer);
+            searchCloseTimer = window.setTimeout(() => closeSearchChip(false), 140);
+        });
+
+        searchInput?.addEventListener('input', (event) => {
+            updateSearchTerm(event.target.value || '');
+        });
+
+        searchInput?.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') {
+                searchInput.value = '';
+                updateSearchTerm('', { immediate: true });
+                closeSearchChip(true);
+            }
+        });
+
+        searchClearButton?.addEventListener('click', () => {
+            if (!searchInput) return;
+            searchInput.value = '';
+            updateSearchTerm('', { immediate: true });
+            closeSearchChip(true);
+        });
+
+        document.addEventListener('click', (event) => {
+            if (!searchChip) return;
+            if (searchChip.contains(event.target)) {
+                if (searchCloseTimer) window.clearTimeout(searchCloseTimer);
+                return;
+            }
+            closeSearchChip(false);
+        });
 
         // --- Event Listeners ---
         if (pageType === 'welcome') {
@@ -282,7 +439,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             compareButton?.addEventListener('click', handleCompareClick);
             clearCompareButton?.addEventListener('click', () => handleClearCompare(true));
             positionalViewBtn?.addEventListener('click', () => setRosterView('positional'));
-            depthChartViewBtn?.addEventListener('click', () => setRosterView('depth'));
+            depthChartViewBtn?.addEventListener('click', () => setRosterView('depthChart'));
             positionalFiltersContainer?.addEventListener('click', handlePositionFilter);
             clearFiltersButton?.addEventListener('click', handleClearFilters);
 
@@ -2618,17 +2775,27 @@ const SEASON_META_HEADERS = {
             const card = document.createElement('div');
             card.className = 'team-card';
             card.innerHTML = `<div class="roster-section starters-section"><h3>Starters</h3></div><div class="roster-section bench-section"><h3>Bench</h3></div><div class="roster-section taxi-section"><h3>Taxi</h3></div><div class="roster-section picks-section"><h3>Draft Picks</h3></div>`;
-            
+
             const filterActive = state.activePositions.size > 0;
             const filterFunc = player => !filterActive || state.activePositions.has(player.pos) || (state.activePositions.has('FLX') && ['RB', 'WR', 'TE'].includes(player.pos));
+            const searchActive = Boolean(state.searchTerm && state.searchTerm.length > 0);
+            const matchesSearch = (player) => !searchActive || (player?.name || '').toLowerCase().includes(state.searchTerm);
 
             const populate = (sel, data, creator) => {
                 const el = card.querySelector(sel);
-                const filteredData = data.filter(item => item.isPlaceholder || filterFunc(item));
-                
                 const h3 = el.querySelector('h3');
                 el.innerHTML = '';
                 el.appendChild(h3);
+
+                const filteredData = data.filter(item => {
+                    if (item.isPlaceholder) {
+                        return !searchActive && filterFunc(item);
+                    }
+                    if (!filterFunc(item)) {
+                        return false;
+                    }
+                    return matchesSearch(item);
+                });
 
                 if (filteredData.length > 0) {
                     filteredData.forEach(item => el.appendChild(creator(item, team.teamName)));
@@ -2666,6 +2833,8 @@ const SEASON_META_HEADERS = {
 
             const filterActive = state.activePositions.size > 0;
             const isFlexActive = state.activePositions.has('FLX');
+            const searchActive = Boolean(state.searchTerm && state.searchTerm.length > 0);
+            const matchesSearch = (player) => !searchActive || (player?.name || '').toLowerCase().includes(state.searchTerm);
 
             const positions = {
                 QB: team.allPlayers.filter(p => p.pos === 'QB').sort((a, b) => (b.ktc || 0) - (a.ktc || 0)),
@@ -2684,8 +2853,9 @@ const SEASON_META_HEADERS = {
                     const h3 = el.querySelector('h3');
                     el.innerHTML = '';
                     el.appendChild(h3);
-                    if (data && data.length > 0) {
-                        data.forEach(item => el.appendChild(creator(item, team.teamName)));
+                    const filteredPlayers = (data || []).filter(player => matchesSearch(player));
+                    if (filteredPlayers.length > 0) {
+                        filteredPlayers.forEach(item => el.appendChild(creator(item, team.teamName)));
                     } else {
                         el.innerHTML += `<div class="text-xs text-slate-500 p-1 italic">None</div>`;
                     }
@@ -2727,7 +2897,7 @@ const SEASON_META_HEADERS = {
             const row = document.createElement('div');
             row.className = 'player-row';
             const slotAbbr = { 'SUPER_FLEX': 'SFLX', 'FLEX': 'FLX' };
-            const displaySlot = state.currentRosterView === 'depth' ? (slotAbbr[player.slot] || player.slot) : player.pos;
+            const displaySlot = state.currentRosterView === 'depthChart' ? (slotAbbr[player.slot] || player.slot) : player.pos;
             row.dataset.assetId = player.id;
             row.dataset.assetLabel = player.name;
             row.dataset.assetKtc = player.ktc || 0;

--- a/DH_P3-5.3/styles/styles.css
+++ b/DH_P3-5.3/styles/styles.css
@@ -5602,3 +5602,448 @@ body[data-page="research"] .app-header {
   }
 }
 
+/* Rosters mobile liquid header variant A */
+body[data-page="rosters"] .liquid-header-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.75rem;
+  border-radius: 1.25rem;
+  background: var(--color-panel-bg);
+  border: 1px solid var(--color-panel-border);
+}
+
+body[data-page="rosters"] .liquid-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+body[data-page="rosters"] .liquid-nav-row {
+  justify-content: space-between;
+}
+
+body[data-page="rosters"] .dh-home-button {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-panel-border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--color-text-primary);
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  letter-spacing: 0.06em;
+}
+
+body[data-page="rosters"] .liquid-nav-menu {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+body[data-page="rosters"] .liquid-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  background: transparent;
+  color: var(--color-text-secondary);
+  border: 1px solid transparent;
+  font-size: 0.8rem;
+  transition: color 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+body[data-page="rosters"] .liquid-nav-item i {
+  font-size: 0.9rem;
+}
+
+body[data-page="rosters"] .liquid-nav-item.active {
+  background: rgba(118, 109, 255, 0.18);
+  border-color: rgba(118, 109, 255, 0.35);
+  color: var(--color-text-primary);
+}
+
+body[data-page="rosters"] .liquid-context {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+body[data-page="rosters"] .liquid-controls-row,
+body[data-page="rosters"] .liquid-filters-row {
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+body[data-page="rosters"] .liquid-filters-row .filters-container {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+body[data-page="rosters"] #positional-filters {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+body[data-page="rosters"] #roster-search-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  padding: 0.3rem 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+body[data-page="rosters"] #roster-search-chip .search-chip-field {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+body[data-page="rosters"] #roster-search-chip input {
+  background: transparent;
+  border: none;
+  color: var(--color-text-primary);
+  min-width: 8rem;
+}
+
+body[data-page="rosters"] .search-chip-toggle,
+body[data-page="rosters"] .search-chip-clear {
+  border: none;
+  background: transparent;
+  color: var(--color-text-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (max-width: 768px) {
+  body[data-page="rosters"] .app-header {
+    padding: 0;
+    background: transparent;
+    gap: 0.75rem;
+  }
+
+  body[data-page="rosters"] .liquid-header-shell {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    width: 100%;
+    background: linear-gradient(135deg, rgba(15, 20, 40, 0.72), rgba(20, 30, 55, 0.58));
+    border-radius: 1.75rem;
+    padding: 0.75rem 0.65rem;
+    position: relative;
+    overflow: hidden;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18), 0 12px 30px rgba(8, 10, 25, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(18px);
+  }
+
+  body[data-page="rosters"] .liquid-header-shell::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(120% 120% at 15% 15%, rgba(255, 255, 255, 0.18), transparent 60%);
+    pointer-events: none;
+  }
+
+  body[data-page="rosters"] .liquid-row {
+    display: grid;
+    width: 100%;
+    align-items: center;
+    position: relative;
+  }
+
+  body[data-page="rosters"] .liquid-row + .liquid-row::before {
+    content: "";
+    position: absolute;
+    top: -0.45rem;
+    left: 1.25rem;
+    right: 1.25rem;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.22), transparent);
+  }
+
+  body[data-page="rosters"] .liquid-nav-row {
+    grid-template-columns: 3rem 1fr;
+    column-gap: 0.75rem;
+  }
+
+  body[data-page="rosters"] .dh-home-button {
+    width: 3rem;
+    height: 3rem;
+    border-radius: 1.5rem;
+    border: none;
+    background: linear-gradient(145deg, rgba(255, 255, 255, 0.28), rgba(255, 255, 255, 0.08));
+    color: var(--color-text-primary);
+    font-weight: 700;
+    font-size: 1.1rem;
+    letter-spacing: 0.08em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  }
+
+  body[data-page="rosters"] .dh-home-button:active {
+    transform: scale(0.96);
+  }
+
+  body[data-page="rosters"] .liquid-nav-menu {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 0.4rem;
+  }
+
+  body[data-page="rosters"] .liquid-nav-item {
+    border: none;
+    border-radius: 999px;
+    padding: 0.4rem 0.35rem;
+    background: rgba(255, 255, 255, 0.07);
+    color: rgba(255, 255, 255, 0.72);
+    font-size: 0.68rem;
+    letter-spacing: 0.02em;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+    min-height: 3rem;
+    transition: background 180ms ease, color 180ms ease, transform 180ms ease;
+  }
+
+  body[data-page="rosters"] .liquid-nav-item i {
+    font-size: 1.05rem;
+  }
+
+  body[data-page="rosters"] .liquid-nav-item.active,
+  body[data-page="rosters"] .liquid-nav-item:focus-visible {
+    outline: none;
+    background: linear-gradient(135deg, rgba(55, 120, 255, 0.65), rgba(120, 160, 255, 0.8));
+    color: var(--color-panel-bg);
+    box-shadow: 0 6px 12px rgba(30, 60, 120, 0.35);
+    transform: translateY(-1px);
+  }
+
+  body[data-page="rosters"] .liquid-nav-item.active i {
+    color: var(--color-panel-bg);
+  }
+
+  body[data-page="rosters"] .liquid-context {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+  }
+
+  body[data-page="rosters"] .liquid-controls-row {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    column-gap: 0.65rem;
+  }
+
+  body[data-page="rosters"] .league-chip {
+    display: flex;
+    align-items: center;
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 999px;
+    padding: 0.25rem 0.5rem;
+    min-height: 2.6rem;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+  }
+
+  body[data-page="rosters"] .league-chip .custom-select-wrapper {
+    width: 100%;
+  }
+
+  body[data-page="rosters"] #leagueSelect {
+    width: 100%;
+    background: transparent;
+    color: var(--color-text-primary);
+    font-weight: 500;
+  }
+
+  body[data-page="rosters"] .view-switcher.secondary-switcher {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    background: rgba(255, 255, 255, 0.07);
+    border-radius: 999px;
+    padding: 0.25rem;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+    gap: 0.25rem;
+  }
+
+  body[data-page="rosters"] .view-switcher.secondary-switcher button {
+    border-radius: 999px;
+    border: none;
+    background: transparent;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.2rem;
+    color: rgba(255, 255, 255, 0.72);
+    font-size: 0.7rem;
+    padding: 0.35rem 0.25rem;
+    transition: background 160ms ease, color 160ms ease;
+  }
+
+  body[data-page="rosters"] .view-switcher.secondary-switcher button i {
+    font-size: 0.95rem;
+  }
+
+  body[data-page="rosters"] .view-switcher.secondary-switcher button.active {
+    background: linear-gradient(135deg, rgba(120, 160, 255, 0.9), rgba(70, 110, 220, 0.85));
+    color: var(--color-panel-bg);
+    box-shadow: 0 8px 16px rgba(30, 60, 120, 0.35);
+  }
+
+  body[data-page="rosters"] .liquid-filters-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+    column-gap: 0.5rem;
+  }
+
+  body[data-page="rosters"] .liquid-filters-row .filters-container {
+    display: grid;
+    grid-template-columns: repeat(6, auto);
+    align-items: center;
+    gap: 0.35rem;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  body[data-page="rosters"] .liquid-filters-row .filters-container::-webkit-scrollbar {
+    display: none;
+  }
+
+  body[data-page="rosters"] #positional-filters {
+    display: grid;
+    grid-auto-flow: column;
+    gap: 0.35rem;
+  }
+
+  body[data-page="rosters"] #positional-filters .filter-btn {
+    min-width: 2.5rem;
+    border-radius: 999px;
+    padding: 0.35rem 0.5rem;
+    background: rgba(255, 255, 255, 0.07);
+    color: rgba(255, 255, 255, 0.72);
+    border: 1px solid transparent;
+    transition: background 160ms ease, color 160ms ease, border 160ms ease;
+  }
+
+  body[data-page="rosters"] #positional-filters .filter-btn.active {
+    background: linear-gradient(135deg, rgba(90, 210, 255, 0.9), rgba(80, 150, 255, 0.9));
+    color: var(--color-panel-bg);
+    border-color: rgba(255, 255, 255, 0.35);
+    box-shadow: 0 6px 12px rgba(40, 80, 160, 0.35);
+  }
+
+  body[data-page="rosters"] #clearFiltersButton,
+  body[data-page="rosters"] #clearCompareButton {
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 999px;
+    min-width: 2.4rem;
+    min-height: 2.4rem;
+  }
+
+  body[data-page="rosters"] .compare-controls {
+    display: flex;
+    gap: 0.3rem;
+    align-items: center;
+  }
+
+  body[data-page="rosters"] #roster-search-chip {
+    justify-self: end;
+    display: grid;
+    grid-template-columns: auto;
+    align-items: center;
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 999px;
+    padding: 0.3rem;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+    position: relative;
+    transition: grid-template-columns 220ms ease, width 220ms ease;
+    width: 2.75rem;
+  }
+
+  body[data-page="rosters"] #roster-search-chip .search-chip-field {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 180ms ease;
+    width: 0;
+  }
+
+  body[data-page="rosters"] #roster-search-chip.is-open {
+    grid-template-columns: auto 1fr;
+    width: min(100%, 13rem);
+    background: linear-gradient(135deg, rgba(120, 160, 255, 0.16), rgba(80, 120, 220, 0.18));
+    box-shadow: 0 10px 18px rgba(30, 60, 120, 0.3);
+  }
+
+  body[data-page="rosters"] #roster-search-chip.is-open .search-chip-field {
+    opacity: 1;
+    pointer-events: auto;
+    width: 100%;
+  }
+
+  body[data-page="rosters"] #roster-search-chip input {
+    background: transparent;
+    border: none;
+    color: var(--color-text-primary);
+    width: 100%;
+    font-size: 0.85rem;
+  }
+
+  body[data-page="rosters"] #roster-search-chip input::placeholder {
+    color: rgba(255, 255, 255, 0.55);
+  }
+
+  body[data-page="rosters"] .search-chip-toggle,
+  body[data-page="rosters"] .search-chip-clear {
+    border: none;
+    background: transparent;
+    color: rgba(255, 255, 255, 0.9);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.1rem;
+    height: 2.1rem;
+    border-radius: 999px;
+    transition: background 160ms ease, transform 160ms ease, opacity 160ms ease;
+  }
+
+  body[data-page="rosters"] .search-chip-toggle:active,
+  body[data-page="rosters"] .search-chip-clear:active {
+    transform: scale(0.95);
+  }
+
+  body[data-page="rosters"] #roster-search-chip:not(.is-open) .search-chip-clear {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  body[data-page="rosters"] .header-quick-links,
+  body[data-page="rosters"] .username-area,
+  body[data-page="rosters"] .app-view-switcher,
+  body[data-page="rosters"] .legacy-action-slots {
+    display: none;
+  }
+}
+
+body[data-page="rosters"] #usernameInput {
+  display: none;
+}
+


### PR DESCRIPTION
## Summary
- replace the Rosters mobile header with a three-row liquid-glass capsule featuring DH home logo, inline nav, controls, and filters
- add a player search chip with animated expansion that debounces queries and filters in concert with position chips
- update navigation logic to preserve username/league context, adjust depth chart handling, and style the new mobile layout while hiding the username input on Rosters

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d1897c2424832e956ac5f455838215