### PR TITLE
Implement mobile liquid header variant A for rosters

### DIFF
--- a/DH_P3-5.3/rosters/rosters.html
+++ b/DH_P3-5.3/rosters/rosters.html
@@ -27,37 +27,36 @@
 <!-- EDITED: Added a class for layout control -->
 <div class="relative z-10 content-wrapper">
 <div id="header-container">
-<header class="app-header glass-panel">
-<div class="header-row" id="primary-header-row">
-<div class="menu-container">
-    <button id="menu-button" class="menu-button">
-        <svg viewBox="0 0 100 80" width="20" height="20">
-            <rect width="100" height="15"></rect>
-            <rect y="30" width="100" height="15"></rect>
-            <rect y="60" width="100" height="15"></rect>
-        </svg>
-    </button>
-    <div id="dropdown-menu" class="dropdown-menu hidden">
-        <a href="../">
+<header class="app-header glass-panel liquid-rosters-header">
+<div class="liquid-glass-shell" id="rostersLiquidShell">
+<div class="header-row liquid-row" id="primary-header-row">
+<div class="liquid-nav-grid" id="mobileLiquidNav" role="navigation" aria-label="Primary">
+    <div class="menu-container">
+        <button id="menu-button" class="dh-logo-button" data-nav-role="home" aria-label="Dynasty Hub Home">
+            <span class="dh-logo-monogram" aria-hidden="true">DH</span>
+        </button>
+    </div>
+    <div class="liquid-nav-items">
+        <button class="liquid-nav-item" type="button" data-nav="home">
             <i class="fa-solid fa-house-user" aria-hidden="true"></i>
             <span>Home</span>
-        </a>
-        <a href="#" id="menu-rosters">
+        </button>
+        <button class="liquid-nav-item active" type="button" data-nav="rosters" aria-current="page">
             <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
             <span>Rosters</span>
-        </a>
-        <a href="#" id="menu-ownership">
+        </button>
+        <button class="liquid-nav-item" type="button" data-nav="ownership">
             <i class="fa-solid fa-percent" aria-hidden="true"></i>
             <span>Ownership</span>
-        </a>
-        <a href="#" id="menu-research">
+        </button>
+        <button class="liquid-nav-item" type="button" data-nav="research">
             <i class="fa-solid fa-flask" aria-hidden="true"></i>
             <span>Research</span>
-        </a>
-        <a href="#" id="menu-analyzer">
+        </button>
+        <button class="liquid-nav-item" type="button" data-nav="analyzer">
             <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-            <span>League Analyzer</span>
-        </a>
+            <span>Lg.Analyze</span>
+        </button>
     </div>
 </div>
 <div class="header-quick-links" id="header-quick-links" aria-label="Research shortcuts"></div>
@@ -68,9 +67,31 @@
 <button id="fetchRostersButton">Rosters</button>
 <button id="fetchOwnershipButton">Ownership%</button>
 </div>
+<div id="dropdown-menu" class="dropdown-menu hidden">
+    <a href="../">
+        <i class="fa-solid fa-house-user" aria-hidden="true"></i>
+        <span>Home</span>
+    </a>
+    <a href="#" id="menu-rosters">
+        <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
+        <span>Rosters</span>
+    </a>
+    <a href="#" id="menu-ownership">
+        <i class="fa-solid fa-percent" aria-hidden="true"></i>
+        <span>Ownership</span>
+    </a>
+    <a href="#" id="menu-research">
+        <i class="fa-solid fa-flask" aria-hidden="true"></i>
+        <span>Research</span>
+    </a>
+    <a href="#" id="menu-analyzer">
+        <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+        <span>League Analyzer</span>
+    </a>
+</div>
 </div>
 <div class="hidden" id="contextual-controls">
-<div class="header-row" id="secondary-header-row">
+<div class="header-row liquid-row" id="secondary-header-row">
 <div class="analyzer-button-slot" id="analyzer-button-slot">
 <div class="analyzer-button-container">
     <button aria-label="Open League Analyzer" class="menu-button analyzer-button" id="analyzeLeagueButton" type="button">
@@ -79,17 +100,23 @@
     </button>
 </div>
 </div>
-<div class="custom-select-wrapper">
+<div class="custom-select-wrapper league-chip-wrap">
 <select disabled="" id="leagueSelect">
 <option>Select a league...</option>
 </select>
 </div>
-<div class="view-switcher secondary-switcher">
-<button id="positionalViewBtn">Positional </button>
-<button id="depthChartViewBtn">Lineup</button>
+<div class="view-switcher secondary-switcher liquid-view-toggle" role="tablist" aria-label="Roster view">
+<button id="positionalViewBtn" type="button" data-view="positional">
+    <i class="fa-solid fa-id-card" aria-hidden="true"></i>
+    <span>Positional</span>
+</button>
+<button id="depthChartViewBtn" type="button" data-view="depthChart">
+    <i class="fa-solid fa-elevator" aria-hidden="true"></i>
+    <span>Lineup</span>
+</button>
 </div>
 </div>
-<div class="header-row" id="filters-row">
+<div class="header-row liquid-row" id="filters-row">
     <div class="research-button-slot" id="research-button-slot">
     <div class="research-button-container">
         <button class="menu-button analyzer-button research-button" id="researchButton" type="button" aria-label="Open Research insights">
@@ -125,7 +152,18 @@
             </button>
         </div>
 
+        <div class="liquid-search-chip" id="rosterSearchContainer">
+            <button class="search-trigger" type="button" id="rosterSearchTrigger" aria-expanded="false" aria-controls="rosterSearchInput">
+                <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+                <span class="sr-only">Search players</span>
+            </button>
+            <div class="search-field">
+                <input type="search" id="rosterSearchInput" name="rosterSearchInput" placeholder="Search players" autocomplete="off" spellcheck="false" inputmode="search"/>
+            </div>
+        </div>
+
     </div>
+</div>
 </div>
 </div>
 </header>

--- a/DH_P3-5.3/scripts/app.js
+++ b/DH_P3-5.3/scripts/app.js
@@ -32,6 +32,11 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const researchButtonSlot = document.getElementById('research-button-slot');
         const analyzerButtonContainer = analyzerButtonSlot?.querySelector('.analyzer-button-container') || null;
         const researchButtonContainer = researchButtonSlot?.querySelector('.research-button-container') || null;
+        const mobileNav = document.getElementById('mobileLiquidNav');
+        const mobileNavButtons = mobileNav ? mobileNav.querySelectorAll('.liquid-nav-item') : [];
+        const rosterSearchContainer = document.getElementById('rosterSearchContainer');
+        const rosterSearchTrigger = document.getElementById('rosterSearchTrigger');
+        const rosterSearchInput = document.getElementById('rosterSearchInput');
 
         const gameLogsModal = document.getElementById('game-logs-modal');
         const modalCloseBtn = document.querySelector('.modal-close-btn');
@@ -69,14 +74,97 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             }
             return `../research/research.html${suffix}`;
         };
+        const getActiveUsername = () => {
+            const direct = usernameInput?.value?.trim();
+            if (direct) return direct;
+            const params = new URLSearchParams(window.location.search);
+            return params.get('username') || '';
+        };
+        const getRelevantLeagueId = () => {
+            const selectValue = leagueSelect?.value;
+            if (selectValue && selectValue !== 'Select a league...') {
+                return selectValue;
+            }
+            if (state.currentLeagueId) return state.currentLeagueId;
+            const params = new URLSearchParams(window.location.search);
+            return params.get('leagueId') || '';
+        };
+        const buildUsernameSuffix = (username) => (username ? `?username=${encodeURIComponent(username)}` : '');
+
+        function handlePrimaryNavSelection(target) {
+            const username = getActiveUsername();
+            const leagueId = getRelevantLeagueId();
+            const suffix = buildUsernameSuffix(username);
+            switch (target) {
+                case 'home': {
+                    const homePath = pageType === 'welcome' ? `index.html${suffix}` : `../index.html${suffix}`;
+                    window.location.href = homePath;
+                    break;
+                }
+                case 'rosters': {
+                    if (!username) return;
+                    if (pageType === 'rosters') {
+                        handleFetchRosters();
+                        return;
+                    }
+                    let rostersUrl = pageType === 'welcome'
+                        ? `rosters/rosters.html${suffix}`
+                        : `../rosters/rosters.html${suffix}`;
+                    if (leagueId) {
+                        rostersUrl += `${suffix ? '&' : '?'}leagueId=${leagueId}`;
+                    }
+                    window.location.href = rostersUrl;
+                    break;
+                }
+                case 'ownership': {
+                    if (!username) return;
+                    let ownershipUrl = pageType === 'welcome'
+                        ? `ownership/ownership.html${suffix}`
+                        : `../ownership/ownership.html${suffix}`;
+                    if (leagueId) {
+                        ownershipUrl += `${suffix ? '&' : '?'}leagueId=${leagueId}`;
+                    }
+                    window.location.href = ownershipUrl;
+                    break;
+                }
+                case 'research': {
+                    if (pageType === 'research') return;
+                    const researchUrl = resolveResearchUrl();
+                    window.location.href = researchUrl;
+                    break;
+                }
+                case 'analyzer': {
+                    if (!username) return;
+                    let analyzerUrl = pageType === 'welcome'
+                        ? `analyzer/analyzer.html${suffix}`
+                        : `../analyzer/analyzer.html${suffix}`;
+                    if (leagueId) {
+                        analyzerUrl += `${suffix ? '&' : '?'}leagueId=${leagueId}`;
+                    }
+                    window.location.href = analyzerUrl;
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
 
         menuButton?.addEventListener('click', (e) => {
+            const isHomeButton = menuButton.dataset.navRole === 'home';
+            if (isHomeButton) {
+                e.preventDefault();
+                const username = getActiveUsername();
+                const suffix = buildUsernameSuffix(username);
+                const homePath = pageType === 'welcome' ? `index.html${suffix}` : `../index.html${suffix}`;
+                window.location.href = homePath;
+                return;
+            }
             e.stopPropagation();
-            dropdownMenu.classList.toggle('hidden');
+            dropdownMenu?.classList.toggle('hidden');
         });
 
         document.addEventListener('click', (e) => {
-            if (dropdownMenu && !dropdownMenu.classList.contains('hidden') && !menuButton.contains(e.target)) {
+            if (dropdownMenu && !dropdownMenu.classList.contains('hidden') && !menuButton?.contains(e.target)) {
                 dropdownMenu.classList.add('hidden');
             }
         });
@@ -159,6 +247,97 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             window.location.href = url;
         });
 
+        if (mobileNavButtons.length > 0) {
+            mobileNavButtons.forEach((btn) => {
+                btn.addEventListener('click', () => {
+                    const target = btn.dataset.nav;
+                    if (!target) return;
+                    handlePrimaryNavSelection(target);
+                });
+            });
+        }
+
+        const updateRosterSearch = (value) => {
+            const normalized = (value || '').trim().toLowerCase();
+            if (state.searchTerm === normalized) return;
+            state.searchTerm = normalized;
+            if (clearFiltersButton) {
+                clearFiltersButton.classList.toggle('active', state.activePositions.size > 0 || normalized.length > 0);
+            }
+            if (state.currentTeams) {
+                renderAllTeamData(state.currentTeams);
+            }
+        };
+
+        const closeRosterSearch = (shouldClear = false) => {
+            if (!rosterSearchContainer) return;
+            rosterSearchContainer.classList.remove('is-active');
+            rosterSearchTrigger?.setAttribute('aria-expanded', 'false');
+            if (shouldClear && rosterSearchInput) {
+                rosterSearchInput.value = '';
+                updateRosterSearch('');
+            }
+        };
+
+        const openRosterSearch = () => {
+            if (!rosterSearchContainer) return;
+            rosterSearchContainer.classList.add('is-active');
+            rosterSearchTrigger?.setAttribute('aria-expanded', 'true');
+            if (rosterSearchInput) {
+                requestAnimationFrame(() => rosterSearchInput.focus());
+            }
+        };
+
+        if (rosterSearchTrigger && rosterSearchContainer && rosterSearchInput) {
+            rosterSearchTrigger.setAttribute('aria-expanded', 'false');
+            rosterSearchTrigger.addEventListener('click', (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                const isActive = rosterSearchContainer.classList.contains('is-active');
+                if (!isActive) {
+                    openRosterSearch();
+                } else if (rosterSearchInput.value.trim()) {
+                    rosterSearchInput.value = '';
+                    updateRosterSearch('');
+                    rosterSearchInput.focus();
+                } else {
+                    closeRosterSearch(true);
+                }
+            });
+
+            rosterSearchInput.addEventListener('input', (e) => {
+                const { value } = e.target;
+                if (rosterSearchDebounceId) {
+                    clearTimeout(rosterSearchDebounceId);
+                }
+                rosterSearchDebounceId = setTimeout(() => {
+                    updateRosterSearch(value);
+                }, 250);
+            });
+
+            rosterSearchInput.addEventListener('keydown', (e) => {
+                if (e.key === 'Escape') {
+                    rosterSearchInput.value = '';
+                    updateRosterSearch('');
+                    closeRosterSearch(true);
+                }
+            });
+
+            rosterSearchInput.addEventListener('blur', () => {
+                if (!rosterSearchInput.value.trim()) {
+                    closeRosterSearch(false);
+                }
+            });
+
+            document.addEventListener('click', (e) => {
+                if (!rosterSearchContainer.classList.contains('is-active')) return;
+                if (rosterSearchContainer.contains(e.target)) return;
+                if (!rosterSearchInput.value.trim()) {
+                    closeRosterSearch(false);
+                }
+            });
+        }
+
         if (headerQuickLinks && analyzerButtonSlot && researchButtonSlot && analyzerButtonContainer && researchButtonContainer) {
             const quickLinksQuery = window.matchMedia('(min-width: 1024px)');
             const placeQuickLinks = (isDesktop) => {
@@ -189,7 +368,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         }
 
         // --- State ---
-        let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), tradeBlock: {}, isTradeCollapsed: false, weeklyStats: {}, playerSeasonStats: {}, playerSeasonRanks: {}, playerWeeklyStats: {}, statsSheetsLoaded: false, seasonRankCache: null, isGameLogModalOpenFromComparison: false };
+        let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), tradeBlock: {}, isTradeCollapsed: false, weeklyStats: {}, playerSeasonStats: {}, playerSeasonRanks: {}, playerWeeklyStats: {}, statsSheetsLoaded: false, seasonRankCache: null, isGameLogModalOpenFromComparison: false, searchTerm: '' };
+        let rosterSearchDebounceId = null;
         const assignedLeagueColors = new Map();
         let nextColorIndex = 0;
         const assignedRyColors = new Map();
@@ -282,7 +462,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             compareButton?.addEventListener('click', handleCompareClick);
             clearCompareButton?.addEventListener('click', () => handleClearCompare(true));
             positionalViewBtn?.addEventListener('click', () => setRosterView('positional'));
-            depthChartViewBtn?.addEventListener('click', () => setRosterView('depth'));
+            depthChartViewBtn?.addEventListener('click', () => setRosterView(depthChartViewBtn.dataset.view || 'depthChart'));
             positionalFiltersContainer?.addEventListener('click', handlePositionFilter);
             clearFiltersButton?.addEventListener('click', handleClearFilters);
 
@@ -342,15 +522,20 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
         // --- View Toggling and Main Handlers ---
         function setRosterView(view) {
-    closeComparisonModal();
-    hideLegend();
-            state.currentRosterView = view;
-            const isPositional = view === 'positional';
-            positionalViewBtn.classList.toggle('active', isPositional);
-            depthChartViewBtn.classList.toggle('active', !isPositional);
-
-            positionalViewBtn.classList.toggle('counterpart-active', !isPositional);
-            depthChartViewBtn.classList.toggle('counterpart-active', isPositional);
+            closeComparisonModal();
+            hideLegend();
+            const normalizedView = view === 'depth' ? 'depthChart' : view;
+            state.currentRosterView = normalizedView;
+            const isPositional = normalizedView === 'positional';
+            if (positionalViewBtn) {
+                positionalViewBtn.classList.toggle('active', isPositional);
+                positionalViewBtn.classList.toggle('counterpart-active', !isPositional);
+            }
+            if (depthChartViewBtn) {
+                const isDepthActive = !isPositional;
+                depthChartViewBtn.classList.toggle('active', isDepthActive);
+                depthChartViewBtn.classList.toggle('counterpart-active', isPositional);
+            }
 
             if (state.currentTeams) {
                 renderAllTeamData(state.currentTeams);
@@ -663,6 +848,20 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         function handleClearFilters() {
             closeComparisonModal();
             state.activePositions.clear();
+            if (state.searchTerm) {
+                state.searchTerm = '';
+                if (rosterSearchInput) {
+                    rosterSearchInput.value = '';
+                }
+                if (rosterSearchContainer) {
+                    rosterSearchContainer.classList.remove('is-active');
+                    rosterSearchTrigger?.setAttribute('aria-expanded', 'false');
+                }
+                if (rosterSearchDebounceId) {
+                    clearTimeout(rosterSearchDebounceId);
+                    rosterSearchDebounceId = null;
+                }
+            }
             updatePositionFilterButtons();
             renderAllTeamData(state.currentTeams);
             clearFiltersButton.classList.remove('active');
@@ -693,7 +892,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             
             updatePositionFilterButtons();
             renderAllTeamData(state.currentTeams);
-            clearFiltersButton.classList.toggle('active', state.activePositions.size > 0);
+            clearFiltersButton.classList.toggle('active', state.activePositions.size > 0 || !!state.searchTerm);
         }
         
         function updatePositionFilterButtons() {
@@ -702,6 +901,26 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 const pos = btn.dataset.position;
                 btn.classList.toggle('active', state.activePositions.has(pos));
             });
+        }
+
+        function doesPlayerMatchSearch(player) {
+            const term = state.searchTerm;
+            if (!term) return true;
+            if (!player) return false;
+            const fields = [
+                player.name,
+                player.full_name,
+                player.fullName,
+                player.display_name,
+                player.displayName,
+                player.first_name,
+                player.last_name,
+                player.firstName,
+                player.lastName,
+                player.nickname
+            ];
+            const haystack = fields.filter(Boolean).join(' ').toLowerCase();
+            return haystack.includes(term);
         }
 
 
@@ -2576,6 +2795,7 @@ const SEASON_META_HEADERS = {
             rosterGrid.innerHTML = '';
             rosterGrid.style.justifyContent = ''; // Reset style
 
+            const searchActive = Boolean(state.searchTerm);
             let teamsToRender = teams;
             if (state.isCompareMode) {
                 teamsToRender = teams.filter(team => state.teamsToCompare.has(team.teamName));
@@ -2606,41 +2826,74 @@ const SEASON_META_HEADERS = {
                 header.appendChild(checkbox);
                 header.appendChild(teamNameSpan);
                 
-                const card = state.currentRosterView === 'positional' ? createPositionalTeamCard(team) : createDepthChartTeamCard(team);
-                
+                const card = state.currentRosterView === 'positional'
+                    ? createPositionalTeamCard(team)
+                    : createDepthChartTeamCard(team);
+
+                const hasVisiblePlayers = card?.dataset?.hasVisiblePlayers !== 'false';
+                if (searchActive && !hasVisiblePlayers) {
+                    return;
+                }
+
                 columnWrapper.appendChild(header);
                 columnWrapper.appendChild(card);
                 rosterGrid.appendChild(columnWrapper);
             });
+
+            if (searchActive && rosterGrid.children.length === 0) {
+                const emptyState = document.createElement('div');
+                emptyState.className = 'roster-search-empty';
+                emptyState.textContent = 'No players match your search.';
+                rosterGrid.appendChild(emptyState);
+            }
         }
 
         function createDepthChartTeamCard(team) {
             const card = document.createElement('div');
             card.className = 'team-card';
             card.innerHTML = `<div class="roster-section starters-section"><h3>Starters</h3></div><div class="roster-section bench-section"><h3>Bench</h3></div><div class="roster-section taxi-section"><h3>Taxi</h3></div><div class="roster-section picks-section"><h3>Draft Picks</h3></div>`;
-            
+
             const filterActive = state.activePositions.size > 0;
+            const searchActive = Boolean(state.searchTerm);
+            let visiblePlayerCount = 0;
             const filterFunc = player => !filterActive || state.activePositions.has(player.pos) || (state.activePositions.has('FLX') && ['RB', 'WR', 'TE'].includes(player.pos));
+
+            const shouldInclude = (item) => {
+                if (item.isPlaceholder) {
+                    return !filterActive && !searchActive;
+                }
+                const matchesFilter = !filterActive || filterFunc(item);
+                const matchesSearch = doesPlayerMatchSearch(item);
+                return matchesFilter && matchesSearch;
+            };
 
             const populate = (sel, data, creator) => {
                 const el = card.querySelector(sel);
-                const filteredData = data.filter(item => item.isPlaceholder || filterFunc(item));
-                
+                const filteredData = data.filter(shouldInclude);
+
                 const h3 = el.querySelector('h3');
                 el.innerHTML = '';
                 el.appendChild(h3);
 
                 if (filteredData.length > 0) {
-                    filteredData.forEach(item => el.appendChild(creator(item, team.teamName)));
-                } else {
+                    filteredData.forEach(item => {
+                        const node = creator(item, team.teamName);
+                        el.appendChild(node);
+                        if (!item.isPlaceholder) {
+                            visiblePlayerCount += 1;
+                        }
+                    });
+                } else if (!searchActive) {
                     el.innerHTML += `<div class="text-xs text-slate-500 p-1 italic">None</div>`;
+                } else {
+                    el.style.display = 'none';
                 }
             };
 
             populate('.starters-section', team.starters, createPlayerRow);
             populate('.bench-section', team.bench, createPlayerRow);
             populate('.taxi-section', team.taxi, createTaxiRow);
-            
+
             const picksEl = card.querySelector('.picks-section');
             const picksH3 = picksEl.querySelector('h3');
             picksEl.innerHTML = '';
@@ -2650,6 +2903,7 @@ const SEASON_META_HEADERS = {
             } else {
                 picksEl.innerHTML += `<div class="text-xs text-slate-500 p-1 italic">None</div>`;
             }
+            card.dataset.hasVisiblePlayers = visiblePlayerCount > 0 ? 'true' : 'false';
             return card;
         }
 
@@ -2666,6 +2920,8 @@ const SEASON_META_HEADERS = {
 
             const filterActive = state.activePositions.size > 0;
             const isFlexActive = state.activePositions.has('FLX');
+            const searchActive = Boolean(state.searchTerm);
+            let visiblePlayerCount = 0;
 
             const positions = {
                 QB: team.allPlayers.filter(p => p.pos === 'QB').sort((a, b) => (b.ktc || 0) - (a.ktc || 0)),
@@ -2677,18 +2933,29 @@ const SEASON_META_HEADERS = {
             const populate = (sel, data, creator) => {
                 const el = card.querySelector(sel);
                 const pos = sel.split('-')[0].toUpperCase().replace('.', '');
-                
+
                 el.style.display = 'none';
-                if (!filterActive || state.activePositions.has(pos) || (isFlexActive && ['RB', 'WR', 'TE'].includes(pos))) {
-                    el.style.display = 'block';
-                    const h3 = el.querySelector('h3');
-                    el.innerHTML = '';
-                    el.appendChild(h3);
-                    if (data && data.length > 0) {
-                        data.forEach(item => el.appendChild(creator(item, team.teamName)));
-                    } else {
-                        el.innerHTML += `<div class="text-xs text-slate-500 p-1 italic">None</div>`;
-                    }
+                const withinFilter = !filterActive || state.activePositions.has(pos) || (isFlexActive && ['RB', 'WR', 'TE'].includes(pos));
+                if (!withinFilter) {
+                    return;
+                }
+
+                const filteredData = (data || []).filter(player => doesPlayerMatchSearch(player));
+                if (filteredData.length === 0 && searchActive) {
+                    return;
+                }
+
+                el.style.display = 'block';
+                const h3 = el.querySelector('h3');
+                el.innerHTML = '';
+                el.appendChild(h3);
+                if (filteredData.length > 0) {
+                    filteredData.forEach(item => {
+                        el.appendChild(creator(item, team.teamName));
+                        visiblePlayerCount += 1;
+                    });
+                } else {
+                    el.innerHTML += `<div class="text-xs text-slate-500 p-1 italic">None</div>`;
                 }
             };
 
@@ -2708,6 +2975,7 @@ const SEASON_META_HEADERS = {
                     picksEl.innerHTML += `<div class="text-xs text-slate-500 p-1 italic">None</div>`;
                 }
             }
+            card.dataset.hasVisiblePlayers = visiblePlayerCount > 0 ? 'true' : 'false';
             return card;
         }
 
@@ -2727,7 +2995,7 @@ const SEASON_META_HEADERS = {
             const row = document.createElement('div');
             row.className = 'player-row';
             const slotAbbr = { 'SUPER_FLEX': 'SFLX', 'FLEX': 'FLX' };
-            const displaySlot = state.currentRosterView === 'depth' ? (slotAbbr[player.slot] || player.slot) : player.pos;
+            const displaySlot = state.currentRosterView === 'depthChart' ? (slotAbbr[player.slot] || player.slot) : player.pos;
             row.dataset.assetId = player.id;
             row.dataset.assetLabel = player.name;
             row.dataset.assetKtc = player.ktc || 0;

--- a/DH_P3-5.3/styles/styles.css
+++ b/DH_P3-5.3/styles/styles.css
@@ -2578,6 +2578,335 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
     color: var(--color-text-primary);
 }
 
+body[data-page="rosters"] .username-area {
+    display: none !important;
+}
+
+body[data-page="rosters"] .roster-search-empty {
+    width: 100%;
+    text-align: center;
+    padding: 1.5rem 0.75rem;
+    color: var(--color-text-secondary);
+    font-style: italic;
+    font-size: 0.85rem;
+}
+
+@media (max-width: 768px) {
+    body[data-page="rosters"] .app-header.liquid-rosters-header {
+        background: transparent;
+        box-shadow: none;
+        padding: 0;
+    }
+
+    body[data-page="rosters"] #rostersLiquidShell {
+        display: grid;
+        gap: 0;
+        border-radius: 24px;
+        background: linear-gradient(145deg, rgba(21,24,41,0.82), rgba(10,12,26,0.76));
+        border: 1px solid rgba(255,255,255,0.1);
+        box-shadow: inset 0 1px 0 rgba(255,255,255,0.18);
+        backdrop-filter: blur(18px);
+        position: relative;
+        overflow: hidden;
+    }
+
+    body[data-page="rosters"] #rostersLiquidShell::after {
+        content: '';
+        position: absolute;
+        inset: 1px;
+        border-radius: 22px;
+        pointer-events: none;
+        box-shadow: inset 0 0 25px rgba(118,109,255,0.08);
+    }
+
+    body[data-page="rosters"] #rostersLiquidShell > .liquid-row {
+        padding: 0.85rem 1rem;
+        display: grid;
+        gap: 0.75rem;
+    }
+
+    body[data-page="rosters"] #rostersLiquidShell > .liquid-row + .liquid-row {
+        border-top: 1px solid rgba(255,255,255,0.08);
+        box-shadow: inset 0 1px 0 rgba(255,255,255,0.05);
+    }
+
+    body[data-page="rosters"] #primary-header-row {
+        grid-template-columns: 1fr;
+    }
+
+    body[data-page="rosters"] .liquid-nav-grid {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        align-items: center;
+        gap: 0.85rem;
+    }
+
+    body[data-page="rosters"] .liquid-nav-items {
+        display: grid;
+        grid-template-columns: repeat(5, minmax(0, 1fr));
+        gap: 0.35rem;
+    }
+
+    body[data-page="rosters"] .dh-logo-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 2.4rem;
+        height: 2.4rem;
+        border-radius: 999px;
+        border: 1px solid rgba(255,255,255,0.16);
+        background: radial-gradient(circle at 25% 25%, rgba(118,109,255,0.6), rgba(10,12,28,0.7));
+        color: var(--color-text-primary);
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+    }
+
+    body[data-page="rosters"] .dh-logo-button:hover,
+    body[data-page="rosters"] .dh-logo-button:focus-visible {
+        transform: translateY(-1px) scale(1.03);
+        border-color: rgba(118,109,255,0.55);
+        box-shadow: 0 8px 18px rgba(118,109,255,0.3);
+    }
+
+    body[data-page="rosters"] .dh-logo-monogram {
+        font-size: 1.05rem;
+    }
+
+    body[data-page="rosters"] .liquid-nav-item {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.35rem;
+        font-weight: 600;
+        border-radius: 999px;
+        border: 1px solid transparent;
+        background: transparent;
+        color: var(--color-text-secondary);
+        padding: 0.35rem 0.65rem;
+        font-size: 0.68rem;
+        transition: color 0.18s ease, background 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+    }
+
+    body[data-page="rosters"] .liquid-nav-item i {
+        font-size: 0.95rem;
+        color: inherit;
+    }
+
+    body[data-page="rosters"] .liquid-nav-item.active {
+        background: linear-gradient(135deg, rgba(118,109,255,0.25), rgba(66,194,255,0.25));
+        border-color: rgba(118,109,255,0.55);
+        color: var(--color-accent-primary);
+        box-shadow: 0 4px 12px rgba(118,109,255,0.25);
+    }
+
+    body[data-page="rosters"] .liquid-nav-item:not(.active):hover,
+    body[data-page="rosters"] .liquid-nav-item:not(.active):focus-visible {
+        color: var(--color-text-primary);
+        border-color: rgba(255,255,255,0.18);
+    }
+
+    body[data-page="rosters"] #primary-header-row .primary-switcher,
+    body[data-page="rosters"] #primary-header-row .header-quick-links,
+    body[data-page="rosters"] #dropdown-menu {
+        display: none !important;
+    }
+
+    body[data-page="rosters"] #contextual-controls {
+        display: grid;
+        gap: 0;
+    }
+
+    body[data-page="rosters"] #secondary-header-row {
+        grid-template-columns: auto 1fr;
+        align-items: center;
+        gap: 0.75rem;
+    }
+
+    body[data-page="rosters"] .league-chip-wrap {
+        border-radius: 999px;
+        background: rgba(18,21,35,0.7);
+        border: 1px solid rgba(255,255,255,0.1);
+        padding: 0.15rem 0.45rem;
+        display: flex;
+        align-items: center;
+        min-height: 2.6rem;
+    }
+
+    body[data-page="rosters"] .league-chip-wrap select {
+        width: 100%;
+        background: transparent;
+        border: none;
+        color: var(--color-text-primary);
+        font-weight: 600;
+        font-size: 0.85rem;
+        padding: 0;
+        appearance: none;
+    }
+
+    body[data-page="rosters"] .liquid-view-toggle {
+        background: rgba(18,21,35,0.65);
+        border-radius: 999px;
+        border: 1px solid rgba(255,255,255,0.12);
+        padding: 0.2rem;
+        gap: 0.3rem;
+    }
+
+    body[data-page="rosters"] .liquid-view-toggle button {
+        display: grid;
+        grid-auto-flow: column;
+        align-items: center;
+        justify-content: center;
+        gap: 0.35rem;
+        border-radius: 999px;
+        border: none;
+        padding: 0.35rem 0.75rem;
+        background: transparent;
+        color: var(--color-text-secondary);
+        font-weight: 600;
+        transition: background 0.18s ease, color 0.18s ease, box-shadow 0.18s ease;
+    }
+
+    body[data-page="rosters"] .liquid-view-toggle button.active,
+    body[data-page="rosters"] .liquid-view-toggle button.counterpart-active {
+        background: linear-gradient(135deg, rgba(118,109,255,0.38), rgba(66,194,255,0.32));
+        color: var(--color-text-primary);
+        box-shadow: 0 8px 14px rgba(118,109,255,0.22);
+    }
+
+    body[data-page="rosters"] #filters-row {
+        grid-template-columns: auto;
+    }
+
+    body[data-page="rosters"] #filters-row .filters-container {
+        display: grid;
+        grid-template-columns: 1fr auto auto;
+        align-items: center;
+        gap: 0.55rem;
+    }
+
+    body[data-page="rosters"] #positional-filters {
+        display: grid;
+        grid-template-columns: repeat(5, minmax(0, 1fr));
+        gap: 0.35rem;
+    }
+
+    body[data-page="rosters"] .liquid-search-chip {
+        display: inline-grid;
+        grid-auto-flow: column;
+        align-items: center;
+        gap: 0.4rem;
+        border-radius: 999px;
+        border: 1px solid rgba(255,255,255,0.1);
+        background: rgba(18,21,35,0.65);
+        padding: 0.25rem;
+        position: relative;
+        overflow: hidden;
+        transition: border-color 0.18s ease;
+    }
+
+    body[data-page="rosters"] .liquid-search-chip:hover,
+    body[data-page="rosters"] .liquid-search-chip:focus-within {
+        border-color: rgba(118,109,255,0.45);
+    }
+
+    body[data-page="rosters"] .liquid-search-chip .search-trigger {
+        width: 2.25rem;
+        height: 2.25rem;
+        border-radius: 999px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: none;
+        background: linear-gradient(135deg, rgba(118,109,255,0.3), rgba(66,194,255,0.3));
+        color: var(--color-text-primary);
+        transition: transform 0.18s ease, box-shadow 0.18s ease;
+    }
+
+    body[data-page="rosters"] .liquid-search-chip .search-trigger:hover,
+    body[data-page="rosters"] .liquid-search-chip .search-trigger:focus-visible {
+        transform: scale(1.05);
+        box-shadow: 0 6px 14px rgba(118,109,255,0.25);
+    }
+
+    body[data-page="rosters"] .liquid-search-chip .search-field {
+        width: 0;
+        opacity: 0;
+        transform: scaleX(0.8);
+        transform-origin: left center;
+        transition: transform 0.2s ease-out, opacity 0.2s ease-out, width 0.2s ease-out;
+    }
+
+    body[data-page="rosters"] .liquid-search-chip .search-field input {
+        width: 100%;
+        border: none;
+        background: transparent;
+        color: var(--color-text-primary);
+        font-size: 0.78rem;
+        padding: 0.25rem 0.35rem 0.25rem 0.1rem;
+        outline: none;
+    }
+
+    body[data-page="rosters"] .liquid-search-chip.is-active .search-field {
+        width: min(200px, 55vw);
+        opacity: 1;
+        transform: scaleX(1);
+    }
+
+    body[data-page="rosters"] .liquid-search-chip.is-active {
+        border-color: rgba(118,109,255,0.55);
+        box-shadow: inset 0 0 0 1px rgba(118,109,255,0.15);
+    }
+
+    body[data-page="rosters"] #positional-filters .filter-btn {
+        border-radius: 999px;
+        border: 1px solid rgba(255,255,255,0.12);
+        background: rgba(18,21,35,0.7);
+        padding: 0.45rem 0.3rem;
+        font-size: 0.78rem;
+        font-weight: 600;
+        transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+    }
+
+    body[data-page="rosters"] #positional-filters .filter-btn.active {
+        background: linear-gradient(135deg, rgba(118,109,255,0.32), rgba(66,194,255,0.28));
+        border-color: rgba(118,109,255,0.45);
+        color: var(--color-text-primary);
+        box-shadow: 0 6px 12px rgba(118,109,255,0.18);
+    }
+
+    body[data-page="rosters"] #clearFiltersButton,
+    body[data-page="rosters"] #clearCompareButton {
+        width: 2.6rem;
+        height: 2.6rem;
+        border-radius: 999px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: 1px solid rgba(255,255,255,0.12);
+        background: rgba(18,21,35,0.65);
+        transition: border-color 0.18s ease, transform 0.18s ease;
+    }
+
+    body[data-page="rosters"] #clearFiltersButton:hover,
+    body[data-page="rosters"] #clearFiltersButton:focus-visible,
+    body[data-page="rosters"] #clearCompareButton:hover,
+    body[data-page="rosters"] #clearCompareButton:focus-visible {
+        border-color: rgba(118,109,255,0.45);
+        transform: translateY(-1px);
+    }
+
+    body[data-page="rosters"] .compare-controls {
+        display: none;
+    }
+}
+
+@media (min-width: 769px) {
+    body[data-page="rosters"] .liquid-search-chip {
+        display: none;
+    }
+}
+
 #analyzeLeagueButton.glow-on-select {
     box-shadow: 0 0 8px #7300ff;
     color: #eeeeee;


### PR DESCRIPTION
## Summary
- redesign the rosters header for mobile with a unified liquid-glass navigation capsule, icon buttons, and inline search
- apply mobile-specific styling for the three-row capsule, glass chip league selector, segmented view toggle, and expanding search affordance
- wire new navigation routing, debounce search filtering, and depth view handling so rosters rendering respects positional filters and player name queries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1897c2424832e956ac5f455838215