### PR TITLE
Tighten mobile rosters header layout and search

### DIFF
--- a/DH_P3-5.3/rosters/rosters.html
+++ b/DH_P3-5.3/rosters/rosters.html
@@ -28,106 +28,112 @@
 <div class="relative z-10 content-wrapper">
 <div id="header-container">
 <header class="app-header glass-panel">
-<div class="header-row" id="primary-header-row">
-<div class="menu-container">
-    <button id="menu-button" class="menu-button">
-        <svg viewBox="0 0 100 80" width="20" height="20">
-            <rect width="100" height="15"></rect>
-            <rect y="30" width="100" height="15"></rect>
-            <rect y="60" width="100" height="15"></rect>
-        </svg>
-    </button>
-    <div id="dropdown-menu" class="dropdown-menu hidden">
-        <a href="../">
-            <i class="fa-solid fa-house-user" aria-hidden="true"></i>
-            <span>Home</span>
-        </a>
-        <a href="#" id="menu-rosters">
-            <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
-            <span>Rosters</span>
-        </a>
-        <a href="#" id="menu-ownership">
-            <i class="fa-solid fa-percent" aria-hidden="true"></i>
-            <span>Ownership</span>
-        </a>
-        <a href="#" id="menu-research">
-            <i class="fa-solid fa-flask" aria-hidden="true"></i>
-            <span>Research</span>
-        </a>
-        <a href="#" id="menu-analyzer">
-            <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-            <span>League Analyzer</span>
-        </a>
-    </div>
-</div>
-<div class="header-quick-links" id="header-quick-links" aria-label="Research shortcuts"></div>
-<div class="username-area">
-<input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
-</div>
-<div class="app-view-switcher primary-switcher">
-<button id="fetchRostersButton">Rosters</button>
-<button id="fetchOwnershipButton">Ownership%</button>
-</div>
-</div>
-<div class="hidden" id="contextual-controls">
-<div class="header-row" id="secondary-header-row">
-<div class="analyzer-button-slot" id="analyzer-button-slot">
-<div class="analyzer-button-container">
-    <button aria-label="Open League Analyzer" class="menu-button analyzer-button" id="analyzeLeagueButton" type="button">
-        <i class="fa-solid fa-square-poll-vertical analyzer-icon" aria-hidden="true"></i>
-        <span class="analyzer-label">Analyzer</span>
-    </button>
-</div>
-</div>
-<div class="custom-select-wrapper">
-<select disabled="" id="leagueSelect">
-<option>Select a league...</option>
-</select>
-</div>
-<div class="view-switcher secondary-switcher">
-<button id="positionalViewBtn">Positional </button>
-<button id="depthChartViewBtn">Lineup</button>
-</div>
-</div>
-<div class="header-row" id="filters-row">
-    <div class="research-button-slot" id="research-button-slot">
-    <div class="research-button-container">
-        <button class="menu-button analyzer-button research-button" id="researchButton" type="button" aria-label="Open Research insights">
-            <i class="fa-solid fa-flask-vial analyzer-icon" aria-hidden="true"></i>
-            <span class="analyzer-label">Research</span>
-        </button>
-    </div>
-    </div>
-    <div class="filters-container">
-        <div id="positional-filters">
-            <button class="filter-btn" data-position="QB">QB</button>
-            <button class="filter-btn" data-position="RB">RB</button>
-            <button class="filter-btn" data-position="WR">WR</button>
-            <button class="filter-btn" data-position="TE">TE</button>
-            <button class="filter-btn" data-position="FLX">FLX</button>
+        <div class="mhA-shell" id="mobileRosterShell">
+            <div class="mhA-row mhA-row-nav" id="primary-header-row">
+                <button id="menu-button" class="mhA-logo" type="button" aria-label="Go to Home">
+                    <span class="sr-only">Dynasty Hero Home</span>
+                    <img src="../assets/welcome/welcome-logo-256.png" alt="Dynasty Hero" loading="lazy"/>
+                </button>
+                <nav class="mhA-nav" aria-label="Primary navigation">
+                    <button class="mhA-nav-item" data-nav="home" type="button">
+                        <i class="fa-solid fa-house-user" aria-hidden="true"></i>
+                        <span>Home</span>
+                    </button>
+                    <button class="mhA-nav-item is-active" data-nav="rosters" type="button" aria-current="page">
+                        <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
+                        <span>Rosters</span>
+                    </button>
+                    <button class="mhA-nav-item" data-nav="ownership" type="button">
+                        <i class="fa-solid fa-percent" aria-hidden="true"></i>
+                        <span>Ownership</span>
+                    </button>
+                    <button class="mhA-nav-item" data-nav="research" type="button">
+                        <i class="fa-solid fa-flask" aria-hidden="true"></i>
+                        <span>Research</span>
+                    </button>
+                    <button class="mhA-nav-item" data-nav="analyzer" type="button">
+                        <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+                        <span>Lg.Analyze</span>
+                    </button>
+                </nav>
+            </div>
+            <div class="mhA-row mhA-row-controls" id="secondary-header-row">
+                <div class="mhA-league" id="leagueChipWrapper">
+                    <select disabled id="leagueSelect">
+                        <option>Select a league...</option>
+                    </select>
+                </div>
+                <div class="mhA-view" id="view-controls" role="group" aria-label="Roster view">
+                    <button class="mhA-view-btn is-active active" id="positionalViewBtn" type="button" data-view="positional">
+                        <i class="fa-solid fa-id-card" aria-hidden="true"></i>
+                        <span>Positional</span>
+                    </button>
+                    <button class="mhA-view-btn" id="depthChartViewBtn" type="button" data-view="depthChart">
+                        <i class="fa-solid fa-elevator" aria-hidden="true"></i>
+                        <span>Lineup</span>
+                    </button>
+                </div>
+            </div>
+            <div class="mhA-row mhA-row-filters" id="filters-row">
+                <div class="mhA-filters">
+                    <div id="positional-filters" class="mhA-position-chips">
+                        <button class="filter-btn" data-position="QB">QB</button>
+                        <button class="filter-btn" data-position="RB">RB</button>
+                        <button class="filter-btn" data-position="WR">WR</button>
+                        <button class="filter-btn" data-position="TE">TE</button>
+                        <button class="filter-btn" data-position="FLX">FLX</button>
+                    </div>
+                    <button class="mhA-clear control-button-subtle" id="clearFiltersButton">
+                        <span class="clear-filters-stack">
+                            <i class="fa-solid fa-filter-circle-xmark" aria-hidden="true"></i>
+                            <span class="sr-only">Clear filters</span>
+                        </span>
+                    </button>
+                    <div class="compare-controls">
+                        <button class="control-button hidden" id="compareButton" aria-hidden="true" tabindex="-1" style="display:none;"></button>
+                        <button class="control-button-subtle hidden" id="clearCompareButton" aria-label="Clear selections">
+                            <span class="clear-filters-stack">
+                                <i class="fa-regular fa-rectangle-xmark" aria-hidden="true"></i>
+                                <span class="sr-only">Clear compare selections</span>
+                            </span>
+                        </button>
+                    </div>
+                </div>
+                <div class="mhA-search" id="rosterSearch">
+                    <button class="mhA-search-trigger" type="button" aria-expanded="false" aria-controls="rosterSearchPopover">
+                        <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+                        <span class="sr-only">Search players</span>
+                    </button>
+                    <div class="mhA-search-popover" id="rosterSearchPopover" role="dialog" aria-modal="false" aria-hidden="true">
+                        <div class="mhA-search-popover-inner">
+                            <div class="mhA-search-field">
+                                <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+                                <input type="search" id="rosterSearchInput" name="rosterSearchInput" placeholder="Search players" autocomplete="off" spellcheck="false"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
-        <button class="control-button-subtle" id="clearFiltersButton">
-            <span class="clear-filters-stack">
-                <i class="fa-solid fa-filter-circle-xmark" aria-hidden="true"></i>
-                <span class="sr-only">Clear filters</span>
-            </span>
-        </button>
-
-        <div class="compare-controls">
-            <!-- Hidden compare button kept only to satisfy JS state machine (do not show) -->
-            <button class="control-button hidden" id="compareButton" aria-hidden="true" tabindex="-1" style="display:none;"></button>
-            <!-- Clear selections button -->
-            <button class="control-button-subtle hidden" id="clearCompareButton" aria-label="Clear selections">
-                <span class="clear-filters-stack">
-                    <i class="fa-regular fa-rectangle-xmark" aria-hidden="true"></i>
-                    <span class="sr-only">Clear compare selections</span>
-                </span>
+<div class="legacy-header-support">
+    <div class="analyzer-button-slot" id="analyzer-button-slot">
+        <div class="analyzer-button-container">
+            <button aria-label="Open League Analyzer" class="menu-button analyzer-button" id="analyzeLeagueButton" type="button">
+                <i class="fa-solid fa-square-poll-vertical analyzer-icon" aria-hidden="true"></i>
+                <span class="analyzer-label">Analyzer</span>
             </button>
         </div>
-
+    </div>
+    <div class="header-quick-links" id="header-quick-links" aria-label="Research shortcuts"></div>
+    <div class="username-area">
+        <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
+    </div>
+    <div class="app-view-switcher primary-switcher">
+        <button id="fetchRostersButton">Rosters</button>
+        <button id="fetchOwnershipButton">Ownership%</button>
     </div>
 </div>
-</div>
+<div class="hidden" id="contextual-controls"></div>
 </header>
 </div>
 <main class="container mx-auto" id="content">

--- a/DH_P3-5.3/scripts/app.js
+++ b/DH_P3-5.3/scripts/app.js
@@ -18,6 +18,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const rosterGrid = document.getElementById('rosterGrid');
         const compareButton = document.getElementById('compareButton');
         const clearCompareButton = document.getElementById('clearCompareButton');
+        const compareControls = document.querySelector('.mhA-filters .compare-controls');
         const positionalViewBtn = document.getElementById('positionalViewBtn');
         const depthChartViewBtn = document.getElementById('depthChartViewBtn');
         const viewControls = document.getElementById('view-controls');
@@ -50,17 +51,25 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             compareButton.innerHTML = COMPARE_BUTTON_PREVIEW_HTML;
         }
 
-        // --- Menu Button ---
+        // --- Navigation & Search Controls ---
         const menuButton = document.getElementById('menu-button');
-        const dropdownMenu = document.getElementById('dropdown-menu');
-        const menuRosters = document.getElementById('menu-rosters');
-        const menuOwnership = document.getElementById('menu-ownership');
-        const menuAnalyzer = document.getElementById('menu-analyzer');
-        const menuResearch = document.getElementById('menu-research');
+        const navButtons = document.querySelectorAll('.mhA-nav-item');
         const analyzeLeagueButton = document.getElementById('analyzeLeagueButton');
+        const searchChip = document.getElementById('rosterSearch');
+        const searchTrigger = searchChip?.querySelector('.mhA-search-trigger');
+        const searchPopover = searchChip?.querySelector('.mhA-search-popover');
+        const rosterSearchInput = document.getElementById('rosterSearchInput');
+        let searchDebounceId = null;
+        let removeOutsideSearchHandler = null;
+        let removeEscapeSearchHandler = null;
+
         const resolveResearchUrl = () => {
+            const params = new URLSearchParams();
             const username = usernameInput.value.trim();
-            const suffix = username ? `?username=${encodeURIComponent(username)}` : '';
+            if (username) {
+                params.set('username', username);
+            }
+            const suffix = params.toString() ? `?${params.toString()}` : '';
             if (pageType === 'welcome') {
                 return `research/research.html${suffix}`;
             }
@@ -70,85 +79,121 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             return `../research/research.html${suffix}`;
         };
 
-        menuButton?.addEventListener('click', (e) => {
-            e.stopPropagation();
-            dropdownMenu.classList.toggle('hidden');
-        });
-
-        document.addEventListener('click', (e) => {
-            if (dropdownMenu && !dropdownMenu.classList.contains('hidden') && !menuButton.contains(e.target)) {
-                dropdownMenu.classList.add('hidden');
-            }
-        });
-
-        menuRosters?.addEventListener('click', () => {
-            const username = usernameInput.value.trim();
-            if (!username) return;
-            if (pageType === 'rosters') {
-                handleFetchRosters();
-            } else {
-                let url = pageType === 'welcome'
-                    ? `rosters/rosters.html?username=${encodeURIComponent(username)}`
-                    : `../rosters/rosters.html?username=${encodeURIComponent(username)}`;
-                const selected = leagueSelect?.value;
-                if (selected && selected !== 'Select a league...') {
-                    url += `&leagueId=${selected}`;
-                } else if (state.currentLeagueId) {
-                    url += `&leagueId=${state.currentLeagueId}`;
-                }
-                window.location.href = url;
-            }
-            dropdownMenu.classList.add('hidden');
-        });
-
-        menuAnalyzer?.addEventListener('click', () => {
-            const username = usernameInput.value.trim();
-            if (!username) return;
-            let url = pageType === 'welcome'
-                ? `analyzer/analyzer.html?username=${encodeURIComponent(username)}`
-                : `../analyzer/analyzer.html?username=${encodeURIComponent(username)}`;
-            const selected = leagueSelect?.value || state.currentLeagueId;
+        const getActiveLeagueId = () => {
+            const selected = leagueSelect?.value;
             if (selected && selected !== 'Select a league...') {
-                url += `&leagueId=${selected}`;
+                return selected;
             }
-            window.location.href = url;
-            dropdownMenu.classList.add('hidden');
+            if (state.currentLeagueId) {
+                return state.currentLeagueId;
+            }
+            return null;
+        };
+
+        const buildNavUrl = (target) => {
+            if (target === 'research') {
+                return resolveResearchUrl();
+            }
+
+            const params = new URLSearchParams();
+            const username = usernameInput.value.trim();
+            if (username) {
+                params.set('username', username);
+            }
+            if (['rosters', 'ownership', 'analyzer'].includes(target)) {
+                const activeLeague = getActiveLeagueId();
+                if (activeLeague) {
+                    params.set('leagueId', activeLeague);
+                }
+            }
+
+            const query = params.toString();
+            const appendQuery = (base) => (query ? `${base}?${query}` : base);
+
+            switch (target) {
+                case 'home':
+                    return appendQuery(pageType === 'welcome' ? 'index.html' : '../index.html');
+                case 'rosters':
+                    return appendQuery(pageType === 'welcome' ? 'rosters/rosters.html' : '../rosters/rosters.html');
+                case 'ownership':
+                    return appendQuery(pageType === 'welcome' ? 'ownership/ownership.html' : '../ownership/ownership.html');
+                case 'analyzer':
+                    return appendQuery(pageType === 'welcome' ? 'analyzer/analyzer.html' : '../analyzer/analyzer.html');
+                default:
+                    return null;
+            }
+        };
+
+        const handleNavSelection = (target) => {
+            if (!target) return;
+
+            if (target === 'home') {
+                const url = buildNavUrl('home');
+                if (url) {
+                    window.location.href = url;
+                }
+                return;
+            }
+
+            const username = usernameInput.value.trim();
+            if (!username) {
+                return;
+            }
+
+            if (target === 'rosters') {
+                if (pageType === 'rosters') {
+                    handleFetchRosters();
+                } else {
+                    const url = buildNavUrl('rosters');
+                    if (url) {
+                        window.location.href = url;
+                    }
+                }
+                return;
+            }
+
+            if (target === 'ownership') {
+                if (pageType === 'ownership') {
+                    handleFetchOwnership();
+                } else {
+                    const url = buildNavUrl('ownership');
+                    if (url) {
+                        window.location.href = url;
+                    }
+                }
+                return;
+            }
+
+            if (target === 'analyzer') {
+                const url = buildNavUrl('analyzer');
+                if (url) {
+                    window.location.href = url;
+                }
+                return;
+            }
+
+            if (target === 'research') {
+                if (pageType === 'research') {
+                    return;
+                }
+                const url = buildNavUrl('research');
+                if (url) {
+                    window.location.href = url;
+                }
+            }
+        };
+
+        menuButton?.addEventListener('click', () => handleNavSelection('home'));
+
+        navButtons.forEach((btn) => {
+            btn.addEventListener('click', () => handleNavSelection(btn.dataset.nav));
         });
 
         analyzeLeagueButton?.addEventListener('click', () => {
             const username = usernameInput.value.trim();
             if (!username || !state.currentLeagueId) return;
-            window.location.href = `../analyzer/analyzer.html?username=${encodeURIComponent(username)}&leagueId=${state.currentLeagueId}`;
-        });
-
-        menuOwnership?.addEventListener('click', () => {
-            const username = usernameInput.value.trim();
-            if (!username) return;
-            if (pageType === 'ownership') {
-                handleFetchOwnership();
-            } else {
-                let url = pageType === 'welcome'
-                    ? `ownership/ownership.html?username=${encodeURIComponent(username)}`
-                    : `../ownership/ownership.html?username=${encodeURIComponent(username)}`;
-                const selected = leagueSelect?.value;
-                if (selected && selected !== 'Select a league...') {
-                    url += `&leagueId=${selected}`;
-                } else if (state.currentLeagueId) {
-                    url += `&leagueId=${state.currentLeagueId}`;
-                }
-                window.location.href = url;
-            }
-            dropdownMenu.classList.add('hidden');
-        });
-
-        menuResearch?.addEventListener('click', () => {
-            if (pageType === 'research') {
-                dropdownMenu.classList.add('hidden');
-                return;
-            }
-            const url = resolveResearchUrl();
-            window.location.href = url;
-            dropdownMenu.classList.add('hidden');
+            const params = new URLSearchParams({ username, leagueId: state.currentLeagueId });
+            window.location.href = `../analyzer/analyzer.html?${params.toString()}`;
         });
 
         researchButton?.addEventListener('click', () => {
@@ -156,8 +201,110 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 return;
             }
             const url = resolveResearchUrl();
-            window.location.href = url;
+            if (url) {
+                window.location.href = url;
+            }
         });
+
+        if (searchTrigger && rosterSearchInput && searchChip) {
+            const openSearch = () => {
+                if (searchChip.classList.contains('is-open')) return;
+                searchChip.classList.add('is-open');
+                searchTrigger.setAttribute('aria-expanded', 'true');
+                searchPopover?.setAttribute('aria-hidden', 'false');
+                requestAnimationFrame(() => rosterSearchInput.focus({ preventScroll: true }));
+
+                const handlePointerDown = (event) => {
+                    if (!searchChip.contains(event.target)) {
+                        closeSearch();
+                    }
+                };
+
+                const handleEscape = (event) => {
+                    if (event.key === 'Escape') {
+                        event.preventDefault();
+                        rosterSearchInput.value = '';
+                        state.playerSearchTerm = '';
+                        if (state.currentTeams) {
+                            renderAllTeamData(state.currentTeams);
+                        }
+                        closeSearch();
+                    }
+                };
+
+                document.addEventListener('pointerdown', handlePointerDown);
+                document.addEventListener('keydown', handleEscape);
+                removeOutsideSearchHandler = () => {
+                    document.removeEventListener('pointerdown', handlePointerDown);
+                    removeOutsideSearchHandler = null;
+                };
+                removeEscapeSearchHandler = () => {
+                    document.removeEventListener('keydown', handleEscape);
+                    removeEscapeSearchHandler = null;
+                };
+            };
+
+            const closeSearch = () => {
+                if (!searchChip.classList.contains('is-open')) return;
+                searchChip.classList.remove('is-open');
+                searchTrigger.setAttribute('aria-expanded', 'false');
+                searchPopover?.setAttribute('aria-hidden', 'true');
+                if (removeOutsideSearchHandler) {
+                    removeOutsideSearchHandler();
+                }
+                if (removeEscapeSearchHandler) {
+                    removeEscapeSearchHandler();
+                }
+            };
+
+            searchTrigger.addEventListener('click', () => {
+                if (searchChip.classList.contains('is-open')) {
+                    closeSearch();
+                } else {
+                    openSearch();
+                }
+            });
+
+            rosterSearchInput.addEventListener('input', (event) => {
+                const value = event.target.value.trim().toLowerCase();
+                if (searchDebounceId) {
+                    clearTimeout(searchDebounceId);
+                }
+                searchDebounceId = setTimeout(() => {
+                    state.playerSearchTerm = value;
+                    if (value) {
+                        openSearch();
+                    }
+                    if (state.currentTeams) {
+                        renderAllTeamData(state.currentTeams);
+                    }
+                }, 250);
+            });
+
+            rosterSearchInput.addEventListener('blur', () => {
+                setTimeout(() => {
+                    if (!searchChip.contains(document.activeElement) && !rosterSearchInput.value.trim()) {
+                        closeSearch();
+                    }
+                }, 120);
+            });
+        
+            searchChip.addEventListener('transitionend', () => {
+                if (!searchChip.classList.contains('is-open')) {
+                    searchTrigger.blur();
+                }
+            });
+        }
+
+        if (!searchTrigger && rosterSearchInput) {
+            rosterSearchInput.addEventListener('input', (event) => {
+                const value = event.target.value.trim().toLowerCase();
+                state.playerSearchTerm = value;
+                if (state.currentTeams) {
+                    renderAllTeamData(state.currentTeams);
+                }
+            });
+        }
 
         if (headerQuickLinks && analyzerButtonSlot && researchButtonSlot && analyzerButtonContainer && researchButtonContainer) {
             const quickLinksQuery = window.matchMedia('(min-width: 1024px)');
@@ -189,7 +336,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         }
 
         // --- State ---
-        let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), tradeBlock: {}, isTradeCollapsed: false, weeklyStats: {}, playerSeasonStats: {}, playerSeasonRanks: {}, playerWeeklyStats: {}, statsSheetsLoaded: false, seasonRankCache: null, isGameLogModalOpenFromComparison: false };
+        let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), playerSearchTerm: '', tradeBlock: {}, isTradeCollapsed: false, weeklyStats: {}, playerSeasonStats: {}, playerSeasonRanks: {}, playerWeeklyStats: {}, statsSheetsLoaded: false, seasonRankCache: null, isGameLogModalOpenFromComparison: false };
         const assignedLeagueColors = new Map();
         let nextColorIndex = 0;
         const assignedRyColors = new Map();
@@ -282,7 +429,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             compareButton?.addEventListener('click', handleCompareClick);
             clearCompareButton?.addEventListener('click', () => handleClearCompare(true));
             positionalViewBtn?.addEventListener('click', () => setRosterView('positional'));
-            depthChartViewBtn?.addEventListener('click', () => setRosterView('depth'));
+            depthChartViewBtn?.addEventListener('click', () => setRosterView('depthChart'));
             positionalFiltersContainer?.addEventListener('click', handlePositionFilter);
             clearFiltersButton?.addEventListener('click', handleClearFilters);
 
@@ -342,8 +489,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
         // --- View Toggling and Main Handlers ---
         function setRosterView(view) {
-    closeComparisonModal();
-    hideLegend();
+            closeComparisonModal();
+            hideLegend();
             state.currentRosterView = view;
             const isPositional = view === 'positional';
             positionalViewBtn.classList.toggle('active', isPositional);
@@ -351,6 +498,9 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
             positionalViewBtn.classList.toggle('counterpart-active', !isPositional);
             depthChartViewBtn.classList.toggle('counterpart-active', isPositional);
+
+            positionalViewBtn.classList.toggle('is-active', isPositional);
+            depthChartViewBtn.classList.toggle('is-active', !isPositional);
 
             if (state.currentTeams) {
                 renderAllTeamData(state.currentTeams);
@@ -591,6 +741,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             compareButton.disabled = count < 2;
             clearCompareButton.classList.toggle('hidden', count === 0);
             clearCompareButton.classList.toggle('active', count >= 2);
+            compareControls?.classList.toggle('is-visible', count > 0 || state.isCompareMode);
 
             if (count > 1) {
                 compareButton.classList.add('glow-on-select');
@@ -702,6 +853,64 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 const pos = btn.dataset.position;
                 btn.classList.toggle('active', state.activePositions.has(pos));
             });
+        }
+
+
+        function matchesPositionFilters(player) {
+            if (!player || player.isPlaceholder) {
+                return true;
+            }
+            if (state.activePositions.size === 0) {
+                return true;
+            }
+            const basePos = (player.pos || player.position || player.basePosition || '').toUpperCase();
+            if (!basePos) {
+                return true;
+            }
+            if (state.activePositions.has(basePos)) {
+                return true;
+            }
+            if (state.activePositions.has('FLX') && ['RB', 'WR', 'TE'].includes(basePos)) {
+                return true;
+            }
+            return false;
+        }
+
+        function computePlayerSearchKey(player) {
+            if (!player) return '';
+            if (player._searchCache) return player._searchCache;
+            const fields = [
+                player.name,
+                player.full_name,
+                player.fullName,
+                player.display_name,
+                player.playerName,
+                player.first_name,
+                player.last_name,
+                player.nickname,
+                player.searchName,
+                player.search,
+                player.player?.full_name,
+                player.player?.display_name,
+            ];
+            const key = fields
+                .filter(Boolean)
+                .map(value => String(value).toLowerCase())
+                .join(' ');
+            player._searchCache = key;
+            return key;
+        }
+
+        function playerMatchesSearch(player) {
+            const term = state.playerSearchTerm;
+            if (!term) {
+                return true;
+            }
+            if (!player || player.isPlaceholder) {
+                return false;
+            }
+            const cacheKey = player._searchCache || computePlayerSearchKey(player);
+            return cacheKey.includes(term);
         }
 
 
@@ -2618,14 +2827,19 @@ const SEASON_META_HEADERS = {
             const card = document.createElement('div');
             card.className = 'team-card';
             card.innerHTML = `<div class="roster-section starters-section"><h3>Starters</h3></div><div class="roster-section bench-section"><h3>Bench</h3></div><div class="roster-section taxi-section"><h3>Taxi</h3></div><div class="roster-section picks-section"><h3>Draft Picks</h3></div>`;
-            
-            const filterActive = state.activePositions.size > 0;
-            const filterFunc = player => !filterActive || state.activePositions.has(player.pos) || (state.activePositions.has('FLX') && ['RB', 'WR', 'TE'].includes(player.pos));
 
             const populate = (sel, data, creator) => {
                 const el = card.querySelector(sel);
-                const filteredData = data.filter(item => item.isPlaceholder || filterFunc(item));
-                
+                const filteredData = data.filter(item => {
+                    if (!matchesPositionFilters(item)) {
+                        return false;
+                    }
+                    if (item.isPlaceholder) {
+                        return state.playerSearchTerm === '';
+                    }
+                    return playerMatchesSearch(item);
+                });
+
                 const h3 = el.querySelector('h3');
                 el.innerHTML = '';
                 el.appendChild(h3);
@@ -2664,9 +2878,6 @@ const SEASON_META_HEADERS = {
                 <div class="roster-section picks-section"><h3>Draft Picks</h3></div>
             `;
 
-            const filterActive = state.activePositions.size > 0;
-            const isFlexActive = state.activePositions.has('FLX');
-
             const positions = {
                 QB: team.allPlayers.filter(p => p.pos === 'QB').sort((a, b) => (b.ktc || 0) - (a.ktc || 0)),
                 RB: team.allPlayers.filter(p => p.pos === 'RB').sort((a, b) => (b.ktc || 0) - (a.ktc || 0)),
@@ -2677,18 +2888,24 @@ const SEASON_META_HEADERS = {
             const populate = (sel, data, creator) => {
                 const el = card.querySelector(sel);
                 const pos = sel.split('-')[0].toUpperCase().replace('.', '');
-                
-                el.style.display = 'none';
-                if (!filterActive || state.activePositions.has(pos) || (isFlexActive && ['RB', 'WR', 'TE'].includes(pos))) {
-                    el.style.display = 'block';
-                    const h3 = el.querySelector('h3');
-                    el.innerHTML = '';
-                    el.appendChild(h3);
-                    if (data && data.length > 0) {
-                        data.forEach(item => el.appendChild(creator(item, team.teamName)));
-                    } else {
-                        el.innerHTML += `<div class="text-xs text-slate-500 p-1 italic">None</div>`;
-                    }
+                const sectionAllowed = matchesPositionFilters({ pos });
+
+                if (!sectionAllowed) {
+                    el.style.display = 'none';
+                    return;
+                }
+
+                el.style.display = 'block';
+                const h3 = el.querySelector('h3');
+                el.innerHTML = '';
+                el.appendChild(h3);
+
+                const filteredPlayers = (data || []).filter(player => matchesPositionFilters(player) && playerMatchesSearch(player));
+
+                if (filteredPlayers.length > 0) {
+                    filteredPlayers.forEach(item => el.appendChild(creator(item, team.teamName)));
+                } else {
+                    el.innerHTML += `<div class="text-xs text-slate-500 p-1 italic">None</div>`;
                 }
             };
 
@@ -2727,7 +2944,7 @@ const SEASON_META_HEADERS = {
             const row = document.createElement('div');
             row.className = 'player-row';
             const slotAbbr = { 'SUPER_FLEX': 'SFLX', 'FLEX': 'FLX' };
-            const displaySlot = state.currentRosterView === 'depth' ? (slotAbbr[player.slot] || player.slot) : player.pos;
+            const displaySlot = state.currentRosterView === 'depthChart' ? (slotAbbr[player.slot] || player.slot) : player.pos;
             row.dataset.assetId = player.id;
             row.dataset.assetLabel = player.name;
             row.dataset.assetKtc = player.ktc || 0;

--- a/DH_P3-5.3/styles/styles.css
+++ b/DH_P3-5.3/styles/styles.css
@@ -5602,3 +5602,366 @@ body[data-page="research"] .app-header {
   }
 }
 
+/* --- Mobile Rosters Liquid Header (Variant A rebuild) --- */
+body[data-page="rosters"] #mobileRosterShell {
+  display: none;
+}
+
+body[data-page="rosters"] #usernameInput {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  body[data-page="rosters"] .app-header {
+    padding: 0.55rem 0.4rem 0.5rem;
+  }
+
+  body[data-page="rosters"] .legacy-header-support {
+    display: none;
+  }
+
+  body[data-page="rosters"] #mobileRosterShell {
+    position: relative;
+    display: grid;
+    gap: 0.55rem;
+    padding: 0.5rem 0.6rem;
+    border-radius: 28px;
+    background: linear-gradient(145deg, rgba(18, 21, 39, 0.72), rgba(18, 22, 44, 0.45));
+    border: 1px solid rgba(120, 134, 200, 0.32);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12), 0 14px 28px rgba(8, 11, 26, 0.45);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
+    overflow: hidden;
+  }
+
+  body[data-page="rosters"] #mobileRosterShell::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    background: radial-gradient(circle at 18% 12%, rgba(255, 255, 255, 0.14), transparent 55%);
+    mix-blend-mode: screen;
+  }
+
+  body[data-page="rosters"] .mhA-row {
+    position: relative;
+    display: grid;
+    align-items: center;
+    width: 100%;
+  }
+
+  body[data-page="rosters"] .mhA-row:not(:last-child)::after {
+    content: "";
+    position: absolute;
+    left: 0.35rem;
+    right: 0.35rem;
+    bottom: -0.28rem;
+    height: 1px;
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0));
+    opacity: 0.5;
+  }
+
+  body[data-page="rosters"] .mhA-row-nav {
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    gap: 0.4rem;
+    padding-bottom: 0.2rem;
+  }
+
+  body[data-page="rosters"] .mhA-logo {
+    display: grid;
+    place-items: center;
+    width: 40px;
+    height: 40px;
+    align-self: center;
+    border-radius: 50%;
+    background: linear-gradient(145deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0.02));
+    border: 1px solid rgba(168, 182, 255, 0.32);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35), 0 10px 18px rgba(8, 11, 26, 0.35);
+    padding: 0.2rem;
+    cursor: pointer;
+    transition: transform 160ms ease-out;
+  }
+
+  body[data-page="rosters"] .mhA-logo img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    display: block;
+  }
+
+  body[data-page="rosters"] .mhA-logo:active {
+    transform: scale(0.95);
+  }
+
+  body[data-page="rosters"] .mhA-nav {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 0.35rem;
+    align-items: stretch;
+  }
+
+  body[data-page="rosters"] .mhA-nav-item {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 0.16rem;
+    padding: 0.3rem 0.22rem;
+    border-radius: 16px;
+    border: 1px solid rgba(112, 128, 188, 0.32);
+    background: linear-gradient(155deg, rgba(18, 22, 44, 0.65), rgba(18, 20, 40, 0.45));
+    color: rgba(212, 220, 255, 0.88);
+    font-size: 0.62rem;
+    font-weight: 600;
+    line-height: 1.05;
+    text-align: center;
+    white-space: nowrap;
+    min-height: 46px;
+    height: 100%;
+    cursor: pointer;
+    transition: background 180ms ease-out, color 180ms ease-out, transform 180ms ease-out, border-color 180ms ease-out;
+  }
+
+  body[data-page="rosters"] .mhA-nav-item i {
+    font-size: 0.95rem;
+    opacity: 0.72;
+  }
+
+  body[data-page="rosters"] .mhA-nav-item.is-active {
+    background: linear-gradient(135deg, rgba(118, 109, 255, 0.9), rgba(66, 194, 255, 0.78));
+    border-color: rgba(118, 109, 255, 0.9);
+    color: #0f1325;
+    box-shadow: 0 8px 18px rgba(11, 15, 32, 0.35);
+    transform: translateY(-1px);
+  }
+
+  body[data-page="rosters"] .mhA-nav-item.is-active i {
+    opacity: 1;
+    color: #0f1325;
+  }
+
+  body[data-page="rosters"] .mhA-row-controls {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.5rem;
+    padding: 0.05rem 0;
+  }
+
+  body[data-page="rosters"] .mhA-league {
+    display: grid;
+    align-items: center;
+    justify-content: start;
+  }
+
+  body[data-page="rosters"] .mhA-league select {
+    appearance: none;
+    width: 100%;
+    height: 44px;
+    border-radius: 999px;
+    border: 1px solid rgba(120, 134, 200, 0.32);
+    background: linear-gradient(160deg, rgba(18, 22, 44, 0.72), rgba(18, 20, 40, 0.42));
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    color: var(--color-text-primary);
+    font-size: 0.78rem;
+    font-weight: 600;
+    padding: 0 2.25rem 0 0.9rem;
+    transition: border-color 180ms ease-out, box-shadow 180ms ease-out;
+  }
+
+  body[data-page="rosters"] .mhA-league select:disabled {
+    opacity: 0.72;
+  }
+
+  body[data-page="rosters"] .mhA-view {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.35rem;
+    align-items: center;
+    background: linear-gradient(160deg, rgba(18, 22, 44, 0.75), rgba(18, 20, 40, 0.45));
+    border-radius: 999px;
+    border: 1px solid rgba(120, 134, 200, 0.32);
+    padding: 0.2rem;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  }
+
+  body[data-page="rosters"] .mhA-view-btn {
+    display: grid;
+    grid-template-rows: auto auto;
+    place-items: center;
+    gap: 0.15rem;
+    min-height: 44px;
+    border: none;
+    border-radius: 999px;
+    background: transparent;
+    color: rgba(212, 220, 255, 0.85);
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-align: center;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: background 180ms ease-out, color 180ms ease-out, transform 180ms ease-out;
+  }
+
+  body[data-page="rosters"] .mhA-view-btn i {
+    font-size: 0.95rem;
+    opacity: 0.78;
+  }
+
+  body[data-page="rosters"] .mhA-view-btn.is-active {
+    background: linear-gradient(135deg, rgba(118, 109, 255, 0.88), rgba(66, 194, 255, 0.78));
+    color: #0f1325;
+    box-shadow: 0 6px 12px rgba(11, 15, 32, 0.35);
+    transform: translateY(-1px);
+  }
+
+  body[data-page="rosters"] .mhA-view-btn.is-active i {
+    opacity: 1;
+    color: #0f1325;
+  }
+
+  body[data-page="rosters"] .mhA-row-filters {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.5rem;
+    align-items: center;
+    padding-top: 0.1rem;
+  }
+
+  body[data-page="rosters"] .mhA-filters {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    gap: 0.3rem;
+    align-items: center;
+  }
+
+  body[data-page="rosters"] .mhA-filters .compare-controls {
+    display: none;
+    justify-content: flex-end;
+    gap: 0.3rem;
+  }
+
+  body[data-page="rosters"] .mhA-filters .compare-controls.is-visible {
+    display: flex;
+  }
+
+  body[data-page="rosters"] .mhA-position-chips {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 0.25rem;
+  }
+
+  body[data-page="rosters"] .mhA-position-chips .filter-btn {
+    border-radius: 16px;
+    padding: 0.28rem 0;
+    font-size: 0.7rem;
+  }
+
+  body[data-page="rosters"] .mhA-clear {
+    display: grid;
+    place-items: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    border: 1px solid rgba(120, 134, 200, 0.32);
+    background: linear-gradient(155deg, rgba(18, 22, 44, 0.7), rgba(18, 20, 40, 0.45));
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    color: rgba(212, 220, 255, 0.85);
+  }
+
+  body[data-page="rosters"] .mhA-search {
+    position: relative;
+    display: grid;
+    place-items: center;
+  }
+
+  body[data-page="rosters"] .mhA-search-trigger {
+    width: 42px;
+    height: 42px;
+    display: grid;
+    place-items: center;
+    border-radius: 50%;
+    border: 1px solid rgba(120, 134, 200, 0.32);
+    background: linear-gradient(135deg, rgba(118, 109, 255, 0.92), rgba(66, 194, 255, 0.82));
+    color: #0f1325;
+    box-shadow: 0 10px 18px rgba(11, 15, 32, 0.35);
+    transition: transform 160ms ease-out;
+  }
+
+  body[data-page="rosters"] .mhA-search-trigger:active {
+    transform: scale(0.94);
+  }
+
+  body[data-page="rosters"] .mhA-search-popover {
+    position: absolute;
+    right: 0;
+    bottom: calc(100% + 0.4rem);
+    width: min(240px, 90vw);
+    border-radius: 18px;
+    border: 1px solid rgba(120, 134, 200, 0.35);
+    background: linear-gradient(160deg, rgba(18, 22, 44, 0.82), rgba(18, 20, 40, 0.6));
+    box-shadow: 0 12px 24px rgba(10, 12, 26, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    padding: 0.55rem;
+    opacity: 0;
+    transform: scale(0.92);
+    transform-origin: bottom right;
+    pointer-events: none;
+    overflow: visible;
+    transition: opacity 180ms ease-out, transform 180ms ease-out;
+  }
+
+  body[data-page="rosters"] .mhA-search-popover::before {
+    content: "";
+    position: absolute;
+    right: 0.85rem;
+    bottom: -0.5rem;
+    width: 0.9rem;
+    height: 0.9rem;
+    background: inherit;
+    transform: rotate(45deg);
+    border-right: 1px solid rgba(120, 134, 200, 0.35);
+    border-bottom: 1px solid rgba(120, 134, 200, 0.35);
+    filter: drop-shadow(0 6px 12px rgba(9, 11, 26, 0.4));
+    z-index: -1;
+  }
+
+  body[data-page="rosters"] .mhA-search-popover-inner {
+    position: relative;
+    z-index: 1;
+  }
+
+  body[data-page="rosters"] .mhA-search-field {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    gap: 0.5rem;
+    border-radius: 14px;
+    border: 1px solid rgba(120, 134, 200, 0.32);
+    background: linear-gradient(155deg, rgba(18, 22, 44, 0.7), rgba(18, 20, 40, 0.45));
+    padding: 0.35rem 0.5rem;
+  }
+
+  body[data-page="rosters"] .mhA-search-field i {
+    font-size: 0.85rem;
+    color: rgba(212, 220, 255, 0.85);
+  }
+
+  body[data-page="rosters"] .mhA-search-field input {
+    width: 100%;
+    background: transparent;
+    border: none;
+    color: var(--color-text-primary);
+    font-size: 0.78rem;
+  }
+
+  body[data-page="rosters"] .mhA-search.is-open .mhA-search-popover {
+    opacity: 1;
+    transform: scale(1);
+    pointer-events: auto;
+  }
+}
+
+@media (min-width: 768px) {
+  body[data-page="rosters"] #mobileRosterShell {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- shrink the DH logo badge, tighten nav spacing, and resize labels so the mobile header row renders with uniform glass chips
- restyle the search affordance into a compact circular trigger with a floating popover field and adjusted filters spacing
- update mobile scripts to manage the new search popover lifecycle while keeping compare controls hidden until needed

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1897c2424832e956ac5f455838215