### PR TITLE
Replace compare clear button with search popover

### DIFF
--- a/DH_P3-5.3/ownership/ownership.html
+++ b/DH_P3-5.3/ownership/ownership.html
@@ -91,7 +91,37 @@
 </div>
 <div class="compare-controls">
 <button class="control-button" disabled="" id="compareButton">Preview</button>
-<button class="control-button-subtle hidden" id="clearCompareButton">Clear</button>
+<button
+    class="control-button-subtle compare-search-toggle"
+    id="compareSearchToggle"
+    type="button"
+    aria-haspopup="true"
+    aria-expanded="false"
+    aria-controls="compareSearchPopover"
+    aria-label="Toggle team search"
+>
+    <span class="sr-only">Toggle team search</span>
+    <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+</button>
+<div
+    class="compare-search-popover"
+    id="compareSearchPopover"
+    role="dialog"
+    aria-modal="false"
+    aria-label="Team search"
+    aria-hidden="true"
+    tabindex="-1"
+>
+    <label class="sr-only" for="compareSearchInput">Search teams</label>
+    <input
+        id="compareSearchInput"
+        type="search"
+        inputmode="search"
+        autocomplete="off"
+        spellcheck="false"
+        placeholder="Search teams..."
+    />
+</div>
 </div>
 </div>
 </div>

--- a/DH_P3-5.3/rosters/rosters.html
+++ b/DH_P3-5.3/rosters/rosters.html
@@ -116,13 +116,38 @@
         <div class="compare-controls">
             <!-- Hidden compare button kept only to satisfy JS state machine (do not show) -->
             <button class="control-button hidden" id="compareButton" aria-hidden="true" tabindex="-1" style="display:none;"></button>
-            <!-- Clear selections button -->
-            <button class="control-button-subtle hidden" id="clearCompareButton" aria-label="Clear selections">
-                <span class="clear-filters-stack">
-                    <i class="fa-regular fa-rectangle-xmark" aria-hidden="true"></i>
-                    <span class="sr-only">Clear compare selections</span>
-                </span>
+            <!-- Compare search toggle -->
+            <button
+                class="control-button-subtle compare-search-toggle"
+                id="compareSearchToggle"
+                type="button"
+                aria-haspopup="true"
+                aria-expanded="false"
+                aria-controls="compareSearchPopover"
+                aria-label="Toggle team search"
+            >
+                <span class="sr-only">Toggle team search</span>
+                <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
             </button>
+            <div
+                class="compare-search-popover"
+                id="compareSearchPopover"
+                role="dialog"
+                aria-modal="false"
+                aria-label="Team search"
+                aria-hidden="true"
+                tabindex="-1"
+            >
+                <label class="sr-only" for="compareSearchInput">Search teams</label>
+                <input
+                    id="compareSearchInput"
+                    type="search"
+                    inputmode="search"
+                    autocomplete="off"
+                    spellcheck="false"
+                    placeholder="Search teams..."
+                />
+            </div>
         </div>
 
     </div>

--- a/DH_P3-5.3/scripts/app.js
+++ b/DH_P3-5.3/scripts/app.js
@@ -17,7 +17,9 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const rosterContainer = document.getElementById('rosterContainer');
         const rosterGrid = document.getElementById('rosterGrid');
         const compareButton = document.getElementById('compareButton');
-        const clearCompareButton = document.getElementById('clearCompareButton');
+        const compareSearchToggle = document.getElementById('compareSearchToggle');
+        const compareSearchPopover = document.getElementById('compareSearchPopover');
+        const compareSearchInput = document.getElementById('compareSearchInput');
         const positionalViewBtn = document.getElementById('positionalViewBtn');
         const depthChartViewBtn = document.getElementById('depthChartViewBtn');
         const viewControls = document.getElementById('view-controls');
@@ -190,6 +192,9 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
         // --- State ---
         let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), tradeBlock: {}, isTradeCollapsed: false, weeklyStats: {}, playerSeasonStats: {}, playerSeasonRanks: {}, playerWeeklyStats: {}, statsSheetsLoaded: false, seasonRankCache: null, isGameLogModalOpenFromComparison: false };
+        let compareSearchTerm = '';
+        let compareSearchDebounceHandle = null;
+        let isCompareSearchOpen = false;
         const assignedLeagueColors = new Map();
         let nextColorIndex = 0;
         const assignedRyColors = new Map();
@@ -280,7 +285,6 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             });
 
             compareButton?.addEventListener('click', handleCompareClick);
-            clearCompareButton?.addEventListener('click', () => handleClearCompare(true));
             positionalViewBtn?.addEventListener('click', () => setRosterView('positional'));
             depthChartViewBtn?.addEventListener('click', () => setRosterView('depth'));
             positionalFiltersContainer?.addEventListener('click', handlePositionFilter);
@@ -311,7 +315,23 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 });
             }
         }
-        
+
+        if (compareSearchToggle && compareSearchPopover && compareSearchInput) {
+            compareSearchToggle.addEventListener('click', (event) => {
+                event.preventDefault();
+                if (isCompareSearchOpen) {
+                    closeCompareSearchPopover();
+                } else {
+                    openCompareSearchPopover();
+                }
+            });
+
+            compareSearchInput.addEventListener('input', handleCompareSearchInput);
+            compareSearchInput.addEventListener('search', handleCompareSearchInput);
+            applyCompareSearchFilter();
+            syncCompareSearchToggleState();
+        }
+
         // --- Initialization ---
         document.addEventListener('DOMContentLoaded', async () => {
             if (pageType === 'analyzer') return;
@@ -532,6 +552,89 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             }
         }
 
+        function syncCompareSearchToggleState() {
+            if (!compareSearchToggle) return;
+            const hasQuery = compareSearchTerm.trim().length > 0;
+            compareSearchToggle.classList.toggle('active', isCompareSearchOpen || hasQuery);
+            compareSearchToggle.setAttribute('aria-expanded', String(isCompareSearchOpen));
+        }
+
+        function applyCompareSearchFilter() {
+            const columns = document.querySelectorAll('.roster-column[data-team-name]');
+            if (!columns.length) {
+                return;
+            }
+            const term = compareSearchTerm.trim().toLowerCase();
+            columns.forEach(column => {
+                const name = (column.dataset.teamName || '').toLowerCase();
+                const matches = !term || name.includes(term);
+                column.classList.toggle('compare-search-hidden', !matches);
+            });
+        }
+
+        function openCompareSearchPopover() {
+            if (!compareSearchPopover || !compareSearchToggle) return;
+            if (isCompareSearchOpen) return;
+            isCompareSearchOpen = true;
+            compareSearchPopover.classList.add('is-open');
+            compareSearchPopover.setAttribute('aria-hidden', 'false');
+            syncCompareSearchToggleState();
+            if (compareSearchInput) {
+                compareSearchInput.value = compareSearchTerm;
+                window.requestAnimationFrame(() => {
+                    compareSearchInput.focus({ preventScroll: false });
+                    compareSearchInput.select();
+                });
+            }
+            document.addEventListener('pointerdown', handleCompareSearchOutside, true);
+            document.addEventListener('keydown', handleCompareSearchKeydown, true);
+        }
+
+        function closeCompareSearchPopover(focusToggle = true) {
+            if (!compareSearchPopover || !compareSearchToggle) return;
+            if (!isCompareSearchOpen) {
+                syncCompareSearchToggleState();
+                return;
+            }
+            isCompareSearchOpen = false;
+            compareSearchPopover.classList.remove('is-open');
+            compareSearchPopover.setAttribute('aria-hidden', 'true');
+            syncCompareSearchToggleState();
+            document.removeEventListener('pointerdown', handleCompareSearchOutside, true);
+            document.removeEventListener('keydown', handleCompareSearchKeydown, true);
+            if (focusToggle) {
+                compareSearchToggle.focus({ preventScroll: false });
+            }
+        }
+
+        function handleCompareSearchOutside(event) {
+            if (!isCompareSearchOpen) return;
+            if (compareSearchPopover?.contains(event.target) || compareSearchToggle?.contains(event.target)) {
+                return;
+            }
+            closeCompareSearchPopover(false);
+        }
+
+        function handleCompareSearchKeydown(event) {
+            if (event.key === 'Escape' && isCompareSearchOpen) {
+                event.preventDefault();
+                event.stopPropagation();
+                closeCompareSearchPopover();
+            }
+        }
+
+        function handleCompareSearchInput(event) {
+            const value = event?.target?.value ?? '';
+            compareSearchTerm = value;
+            if (compareSearchDebounceHandle) {
+                clearTimeout(compareSearchDebounceHandle);
+            }
+            compareSearchDebounceHandle = setTimeout(() => {
+                applyCompareSearchFilter();
+                syncCompareSearchToggleState();
+            }, 140);
+        }
+
         function handleCompareClick() {
             state.isCompareMode = !state.isCompareMode;
             rosterView.classList.toggle('is-trade-mode', state.isCompareMode);
@@ -584,13 +687,11 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         }
 
         function updateCompareButtonState() {
-            if (!compareButton || !clearCompareButton) {
+            if (!compareButton) {
                 return;
             }
             const count = state.teamsToCompare.size;
             compareButton.disabled = count < 2;
-            clearCompareButton.classList.toggle('hidden', count === 0);
-            clearCompareButton.classList.toggle('active', count >= 2);
 
             if (count > 1) {
                 compareButton.classList.add('glow-on-select');
@@ -2612,6 +2713,8 @@ const SEASON_META_HEADERS = {
                 columnWrapper.appendChild(card);
                 rosterGrid.appendChild(columnWrapper);
             });
+
+            applyCompareSearchFilter();
         }
 
         function createDepthChartTeamCard(team) {

--- a/DH_P3-5.3/styles/styles.css
+++ b/DH_P3-5.3/styles/styles.css
@@ -806,23 +806,104 @@
             line-height: 1;
         }
 
-    #clearCompareButton {
-        font-size: 1.2rem !important;
-        margin-top: 2px !important;
+    .compare-controls {
+        position: relative;
+        display: flex;
+        align-items: center;
+        gap: 0.35rem;
     }
 
+    .compare-search-toggle {
+        text-decoration: none;
+        padding: 0.5rem;
+        min-width: 44px;
+        min-height: 44px;
+        border-radius: 10px;
+        color: var(--color-text-tertiary);
+        background: linear-gradient(145deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02));
+        border: 1px solid transparent;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1rem;
+        line-height: 0;
+        transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    }
 
-#clearCompareButton .clear-filters-stack i {
-    color: #5F679588;
-    margin-top: 5px;
-    margin-left: 5px;
-    font-size: 1.5rem !important;
+    .compare-search-toggle i {
+        font-size: 1.05rem;
+    }
 
-}
+    .compare-search-toggle:hover,
+    .compare-search-toggle:focus-visible,
+    .compare-search-toggle.active {
+        color: var(--color-text-secondary);
+        background: linear-gradient(145deg, rgba(255,255,255,0.08), rgba(255,255,255,0.04));
+        border-color: var(--color-panel-border);
+        box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255,255,255,0.05);
+        outline: none;
+    }
 
-#clearCompareButton.active .clear-filters-stack i {
-    color: var(--color-text-secondary);
-}
+    .compare-search-toggle:focus-visible {
+        outline: 2px solid rgba(115, 16, 255, 0.4);
+        outline-offset: 2px;
+    }
+
+    .compare-search-popover {
+        position: absolute;
+        top: calc(100% + 0.5rem);
+        right: 0;
+        width: min(92vw, 320px);
+        max-height: 60vh;
+        padding: 0.75rem;
+        border-radius: 14px;
+        border: 1px solid var(--color-panel-border);
+        background: var(--color-panel-bg);
+        background: color-mix(in srgb, var(--color-panel-bg) 92%, rgba(10, 12, 25, 0.85));
+        box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45);
+        backdrop-filter: blur(12px);
+        -webkit-backdrop-filter: blur(12px);
+        color: var(--color-text-secondary);
+        overflow: auto;
+        -webkit-overflow-scrolling: touch;
+        opacity: 0;
+        transform: translateY(-4px) scale(0.98);
+        pointer-events: none;
+        transition: opacity 0.18s ease, transform 0.18s ease;
+        z-index: 60;
+    }
+
+    .compare-search-popover.is-open {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+        pointer-events: auto;
+    }
+
+    #compareSearchInput {
+        width: 100%;
+        border-radius: 10px;
+        border: 1px solid var(--color-panel-border);
+        background: rgba(255,255,255,0.05);
+        padding: 0.65rem 0.75rem;
+        font-size: 0.95rem;
+        color: var(--color-text-secondary);
+        box-shadow: inset 0 1px 2px rgba(0,0,0,0.35);
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    #compareSearchInput:focus {
+        outline: none;
+        border-color: var(--color-text-secondary);
+        box-shadow: 0 0 0 2px rgba(115, 16, 255, 0.25);
+    }
+
+    #compareSearchInput::placeholder {
+        color: var(--color-text-tertiary);
+    }
+
+    .compare-search-hidden {
+        display: none !important;
+    }
 
 
 @media (max-width: 819px) {


### PR DESCRIPTION
## Summary
- replace the compare clear button on roster and ownership views with a compact search toggle and popover
- add styling for the compare search toggle and popover to match the existing glass aesthetic and mobile requirements
- implement debounced team name filtering, popover focus management, and accessibility wiring in the shared app script

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1f65fc05c832eae0ef8943c686c1b