### PR TITLE
Replace compare clear with search popover

### DIFF
--- a/DH_P3-5.3/ownership/ownership.html
+++ b/DH_P3-5.3/ownership/ownership.html
@@ -91,7 +91,14 @@
 </div>
 <div class="compare-controls">
 <button class="control-button" disabled="" id="compareButton">Preview</button>
-<button class="control-button-subtle hidden" id="clearCompareButton">Clear</button>
+<button class="control-button-subtle compare-search-toggle" id="compareSearchToggle" type="button" aria-label="Search teams" aria-haspopup="true" aria-expanded="false">
+    <span class="sr-only">Open compare search</span>
+    <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+</button>
+<div class="compare-search-popover hidden" id="compareSearchPopover" role="dialog" aria-label="Search teams">
+    <label class="sr-only" for="compareSearchInput">Search teams</label>
+    <input class="compare-search-input" id="compareSearchInput" type="search" inputmode="search" autocomplete="off" placeholder="Filter teams..." />
+</div>
 </div>
 </div>
 </div>

--- a/DH_P3-5.3/rosters/rosters.html
+++ b/DH_P3-5.3/rosters/rosters.html
@@ -116,13 +116,14 @@
         <div class="compare-controls">
             <!-- Hidden compare button kept only to satisfy JS state machine (do not show) -->
             <button class="control-button hidden" id="compareButton" aria-hidden="true" tabindex="-1" style="display:none;"></button>
-            <!-- Clear selections button -->
-            <button class="control-button-subtle hidden" id="clearCompareButton" aria-label="Clear selections">
-                <span class="clear-filters-stack">
-                    <i class="fa-regular fa-rectangle-xmark" aria-hidden="true"></i>
-                    <span class="sr-only">Clear compare selections</span>
-                </span>
+            <button class="control-button-subtle compare-search-toggle" id="compareSearchToggle" type="button" aria-label="Search teams" aria-haspopup="true" aria-expanded="false">
+                <span class="sr-only">Open compare search</span>
+                <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
             </button>
+            <div class="compare-search-popover hidden" id="compareSearchPopover" role="dialog" aria-label="Search teams">
+                <label class="sr-only" for="compareSearchInput">Search teams</label>
+                <input class="compare-search-input" id="compareSearchInput" type="search" inputmode="search" autocomplete="off" placeholder="Filter teams..." />
+            </div>
         </div>
 
     </div>

--- a/DH_P3-5.3/scripts/app.js
+++ b/DH_P3-5.3/scripts/app.js
@@ -17,7 +17,9 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const rosterContainer = document.getElementById('rosterContainer');
         const rosterGrid = document.getElementById('rosterGrid');
         const compareButton = document.getElementById('compareButton');
-        const clearCompareButton = document.getElementById('clearCompareButton');
+        const compareSearchToggle = document.getElementById('compareSearchToggle');
+        const compareSearchPopover = document.getElementById('compareSearchPopover');
+        const compareSearchInput = document.getElementById('compareSearchInput');
         const positionalViewBtn = document.getElementById('positionalViewBtn');
         const depthChartViewBtn = document.getElementById('depthChartViewBtn');
         const viewControls = document.getElementById('view-controls');
@@ -189,11 +191,12 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         }
 
         // --- State ---
-        let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), tradeBlock: {}, isTradeCollapsed: false, weeklyStats: {}, playerSeasonStats: {}, playerSeasonRanks: {}, playerWeeklyStats: {}, statsSheetsLoaded: false, seasonRankCache: null, isGameLogModalOpenFromComparison: false };
+        let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), tradeBlock: {}, isTradeCollapsed: false, weeklyStats: {}, playerSeasonStats: {}, playerSeasonRanks: {}, playerWeeklyStats: {}, statsSheetsLoaded: false, seasonRankCache: null, isGameLogModalOpenFromComparison: false, compareSearchQuery: '' };
         const assignedLeagueColors = new Map();
         let nextColorIndex = 0;
         const assignedRyColors = new Map();
         let nextRyColorIndex = 0;
+        let compareSearchDebounceHandle = null;
 
         // --- Constants ---
         const API_BASE = 'https://api.sleeper.app/v1';
@@ -253,6 +256,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             });
         }
 
+        setupCompareSearchControls();
+
         if (pageType === 'rosters') {
             leagueSelect?.addEventListener('change', (e) => {
                 handleLeagueSelect(e);
@@ -280,7 +285,6 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             });
 
             compareButton?.addEventListener('click', handleCompareClick);
-            clearCompareButton?.addEventListener('click', () => handleClearCompare(true));
             positionalViewBtn?.addEventListener('click', () => setRosterView('positional'));
             depthChartViewBtn?.addEventListener('click', () => setRosterView('depth'));
             positionalFiltersContainer?.addEventListener('click', handlePositionFilter);
@@ -532,6 +536,153 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             }
         }
 
+        function isCompareSearchOpen() {
+            return !!compareSearchPopover && !compareSearchPopover.classList.contains('hidden');
+        }
+
+        function openCompareSearchPopover() {
+            if (!compareSearchPopover) return;
+
+            compareSearchPopover.classList.remove('hidden');
+            compareSearchPopover.setAttribute('aria-hidden', 'false');
+            requestAnimationFrame(() => {
+                compareSearchPopover.classList.add('is-visible');
+            });
+            compareSearchToggle?.setAttribute('aria-expanded', 'true');
+
+            if (compareSearchInput) {
+                compareSearchInput.value = state.compareSearchQuery || '';
+                setTimeout(() => {
+                    try {
+                        compareSearchInput.focus({ preventScroll: true });
+                    } catch (error) {
+                        compareSearchInput.focus();
+                    }
+                    compareSearchInput.select();
+                }, 20);
+            }
+        }
+
+        function closeCompareSearchPopover(focusToggle = true) {
+            if (!compareSearchPopover || compareSearchPopover.classList.contains('hidden')) {
+                return;
+            }
+
+            compareSearchPopover.classList.remove('is-visible');
+            compareSearchPopover.setAttribute('aria-hidden', 'true');
+            compareSearchToggle?.setAttribute('aria-expanded', 'false');
+
+            let hideHandled = false;
+            const finalizeHide = () => {
+                if (hideHandled) return;
+                hideHandled = true;
+                compareSearchPopover.classList.add('hidden');
+                compareSearchPopover.removeEventListener('transitionend', finalizeHide);
+            };
+
+            compareSearchPopover.addEventListener('transitionend', finalizeHide);
+            setTimeout(finalizeHide, 180);
+
+            if (focusToggle && compareSearchToggle) {
+                try {
+                    compareSearchToggle.focus({ preventScroll: true });
+                } catch (error) {
+                    compareSearchToggle.focus();
+                }
+            }
+        }
+
+        function setupCompareSearchControls() {
+            if (!compareSearchToggle || !compareSearchPopover) {
+                if (compareSearchInput) {
+                    compareSearchInput.addEventListener('input', scheduleCompareSearchUpdate);
+                    compareSearchInput.addEventListener('search', () => {
+                        state.compareSearchQuery = compareSearchInput.value || '';
+                        if (compareSearchDebounceHandle) {
+                            clearTimeout(compareSearchDebounceHandle);
+                            compareSearchDebounceHandle = null;
+                        }
+                        applyCompareSearchFilter();
+                    });
+                }
+                applyCompareSearchFilter();
+                return;
+            }
+
+            compareSearchPopover.setAttribute('aria-hidden', 'true');
+
+            compareSearchToggle.addEventListener('click', (event) => {
+                event.preventDefault();
+                if (isCompareSearchOpen()) {
+                    closeCompareSearchPopover();
+                } else {
+                    openCompareSearchPopover();
+                }
+            });
+
+            const outsideEvent = window.PointerEvent ? 'pointerdown' : 'mousedown';
+            document.addEventListener(outsideEvent, (event) => {
+                if (!isCompareSearchOpen()) return;
+                const target = event.target;
+                if (compareSearchPopover.contains(target) || compareSearchToggle.contains(target)) {
+                    return;
+                }
+                closeCompareSearchPopover();
+            });
+
+            document.addEventListener('keydown', (event) => {
+                if (event.key === 'Escape' && isCompareSearchOpen()) {
+                    event.preventDefault();
+                    closeCompareSearchPopover();
+                }
+            });
+
+            if (compareSearchInput) {
+                compareSearchInput.addEventListener('input', scheduleCompareSearchUpdate);
+                compareSearchInput.addEventListener('search', () => {
+                    state.compareSearchQuery = compareSearchInput.value || '';
+                    if (compareSearchDebounceHandle) {
+                        clearTimeout(compareSearchDebounceHandle);
+                        compareSearchDebounceHandle = null;
+                    }
+                    applyCompareSearchFilter();
+                });
+            }
+
+            applyCompareSearchFilter();
+        }
+
+        function scheduleCompareSearchUpdate() {
+            if (!compareSearchInput) return;
+
+            state.compareSearchQuery = compareSearchInput.value || '';
+            if (compareSearchDebounceHandle) {
+                clearTimeout(compareSearchDebounceHandle);
+            }
+
+            compareSearchDebounceHandle = setTimeout(() => {
+                compareSearchDebounceHandle = null;
+                applyCompareSearchFilter();
+            }, 140);
+        }
+
+        function applyCompareSearchFilter() {
+            const rawQuery = (compareSearchInput?.value ?? state.compareSearchQuery ?? '').toString();
+            state.compareSearchQuery = rawQuery;
+            const query = rawQuery.trim().toLowerCase();
+
+            const teamNodes = document.querySelectorAll('[data-team-name]');
+            teamNodes.forEach(node => {
+                const name = (node.dataset.teamName || '').toLowerCase();
+                const isMatch = !query || name.includes(query);
+                node.classList.toggle('compare-search-hidden', !isMatch);
+            });
+
+            if (compareSearchToggle) {
+                compareSearchToggle.classList.toggle('active', query.length > 0);
+            }
+        }
+
         function handleCompareClick() {
             state.isCompareMode = !state.isCompareMode;
             rosterView.classList.toggle('is-trade-mode', state.isCompareMode);
@@ -584,13 +735,11 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         }
 
         function updateCompareButtonState() {
-            if (!compareButton || !clearCompareButton) {
+            if (!compareButton) {
                 return;
             }
             const count = state.teamsToCompare.size;
             compareButton.disabled = count < 2;
-            clearCompareButton.classList.toggle('hidden', count === 0);
-            clearCompareButton.classList.toggle('active', count >= 2);
 
             if (count > 1) {
                 compareButton.classList.add('glow-on-select');
@@ -2586,7 +2735,7 @@ const SEASON_META_HEADERS = {
                 const columnWrapper = document.createElement('div');
                 columnWrapper.className = 'roster-column';
                 columnWrapper.dataset.teamName = team.teamName;
-                
+
                 const header = document.createElement('div');
                 header.className = 'team-header-item';
                 
@@ -2612,6 +2761,8 @@ const SEASON_META_HEADERS = {
                 columnWrapper.appendChild(card);
                 rosterGrid.appendChild(columnWrapper);
             });
+
+            applyCompareSearchFilter();
         }
 
         function createDepthChartTeamCard(team) {

--- a/DH_P3-5.3/styles/styles.css
+++ b/DH_P3-5.3/styles/styles.css
@@ -806,23 +806,108 @@
             line-height: 1;
         }
 
-    #clearCompareButton {
-        font-size: 1.2rem !important;
-        margin-top: 2px !important;
-    }
+        .compare-controls {
+            position: relative;
+            display: flex;
+            align-items: center;
+            gap: 0.4rem;
+            padding-right: clamp(0.5rem, 2vw, 0.75rem);
+        }
 
+        .compare-search-toggle {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0.55rem;
+            min-width: 44px;
+            min-height: 44px;
+            border-radius: 999px;
+            background: transparent;
+            border: 1px solid transparent;
+            color: var(--color-text-tertiary);
+            text-decoration: none;
+            line-height: 1;
+            transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
+        }
 
-#clearCompareButton .clear-filters-stack i {
-    color: #5F679588;
-    margin-top: 5px;
-    margin-left: 5px;
-    font-size: 1.5rem !important;
+        .compare-search-toggle .fa-magnifying-glass {
+            font-size: 1.1rem;
+        }
 
-}
+        .compare-search-toggle:hover,
+        .compare-search-toggle:focus-visible,
+        .compare-search-toggle[aria-expanded="true"],
+        .compare-search-toggle.active {
+            color: var(--color-text-secondary);
+            border-color: rgba(142, 154, 255, 0.38);
+            background: linear-gradient(180deg, rgba(255,255,255,0.08), rgba(9,12,32,0.45));
+            box-shadow: 0 4px 18px rgba(9, 12, 32, 0.35);
+        }
 
-#clearCompareButton.active .clear-filters-stack i {
-    color: var(--color-text-secondary);
-}
+        .compare-search-toggle:focus-visible {
+            outline: 2px solid rgba(143, 155, 255, 0.7);
+            outline-offset: 2px;
+        }
+
+        .compare-search-popover {
+            position: absolute;
+            top: calc(100% + 0.5rem);
+            right: clamp(0.5rem, 2vw, 0.75rem);
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+            width: min(92vw, 320px);
+            max-height: 60vh;
+            padding: 0.9rem;
+            background: var(--color-panel-bg);
+            border: 1px solid var(--color-panel-border);
+            border-radius: 0.9rem;
+            box-shadow: 0 12px 28px rgba(6, 8, 22, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.04);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+            color: var(--color-text-secondary);
+            overflow: auto;
+            -webkit-overflow-scrolling: touch;
+            z-index: 60;
+            opacity: 0;
+            transform: translateY(-6px);
+            pointer-events: none;
+            transition: opacity 140ms ease, transform 140ms ease;
+        }
+
+        .compare-search-popover.is-visible {
+            opacity: 1;
+            transform: translateY(0);
+            pointer-events: auto;
+        }
+
+        .compare-search-input {
+            width: 100%;
+            padding: 0.7rem 0.85rem;
+            border-radius: 0.75rem;
+            border: 1px solid rgba(142, 154, 255, 0.28);
+            background: linear-gradient(180deg, rgba(15, 18, 34, 0.92), rgba(10, 12, 24, 0.92));
+            color: var(--color-text-secondary);
+            font-size: 0.95rem;
+            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 0 0 1px rgba(110, 120, 198, 0.08);
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .compare-search-input::placeholder {
+            color: var(--color-text-tertiary);
+        }
+
+        .compare-search-input:focus {
+            border-color: rgba(160, 172, 255, 0.6);
+            box-shadow: 0 0 0 2px rgba(98, 110, 255, 0.25);
+            outline: none;
+        }
+
+        .compare-search-hidden {
+            display: none !important;
+        }
 
 
 @media (max-width: 819px) {
@@ -2530,10 +2615,6 @@ font-weight: 500 !important;
     margin-top: 4px;
     font-size: 1.35rem;
     line-height: 1;
-}
-
-.compare-controls .clear-filters-stack i {
-    font-size: 1.35rem;
 }
 
 #clearFiltersButton .clear-filters-label {


### PR DESCRIPTION
## Summary
- replace the compare clear button on roster and ownership views with a compact compare search toggle and popover
- add JavaScript state, event handling, and filtering logic to drive the compare search overlay without affecting compare selections
- style the new search control and popover to match the existing glass aesthetic while meeting mobile sizing requirements

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1f65fc05c832eae0ef8943c686c1b