### PR TITLE
Improve compare search popover and filtering

### DIFF
--- a/DH_P3-5.3/ownership/ownership.html
+++ b/DH_P3-5.3/ownership/ownership.html
@@ -91,7 +91,26 @@
 </div>
 <div class="compare-controls">
 <button class="control-button" disabled="" id="compareButton">Preview</button>
-<button class="control-button-subtle hidden" id="clearCompareButton">Clear</button>
+<button id="compareSearchToggle"
+        class="control-button-subtle compare-search-toggle"
+        aria-haspopup="true"
+        aria-expanded="false"
+        aria-controls="compareSearchPopover">
+    <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+    <span class="sr-only">Search teams</span>
+</button>
+
+<div id="compareSearchPopover"
+     class="compare-search-popover hidden"
+     role="dialog"
+     aria-modal="false">
+    <label for="compareSearchInput" class="sr-only">Search teams</label>
+    <input id="compareSearchInput"
+           type="search"
+           placeholder="Search teams…"
+           autocomplete="off"
+           inputmode="search" />
+</div>
 </div>
 </div>
 </div>

--- a/DH_P3-5.3/rosters/rosters.html
+++ b/DH_P3-5.3/rosters/rosters.html
@@ -116,13 +116,26 @@
         <div class="compare-controls">
             <!-- Hidden compare button kept only to satisfy JS state machine (do not show) -->
             <button class="control-button hidden" id="compareButton" aria-hidden="true" tabindex="-1" style="display:none;"></button>
-            <!-- Clear selections button -->
-            <button class="control-button-subtle hidden" id="clearCompareButton" aria-label="Clear selections">
-                <span class="clear-filters-stack">
-                    <i class="fa-regular fa-rectangle-xmark" aria-hidden="true"></i>
-                    <span class="sr-only">Clear compare selections</span>
-                </span>
+            <button id="compareSearchToggle"
+                    class="control-button-subtle compare-search-toggle"
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                    aria-controls="compareSearchPopover">
+                <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+                <span class="sr-only">Search teams</span>
             </button>
+
+            <div id="compareSearchPopover"
+                 class="compare-search-popover hidden"
+                 role="dialog"
+                 aria-modal="false">
+                <label for="compareSearchInput" class="sr-only">Search teams</label>
+                <input id="compareSearchInput"
+                       type="search"
+                       placeholder="Search teams…"
+                       autocomplete="off"
+                       inputmode="search" />
+            </div>
         </div>
 
     </div>

--- a/DH_P3-5.3/scripts/app.js
+++ b/DH_P3-5.3/scripts/app.js
@@ -17,7 +17,9 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const rosterContainer = document.getElementById('rosterContainer');
         const rosterGrid = document.getElementById('rosterGrid');
         const compareButton = document.getElementById('compareButton');
-        const clearCompareButton = document.getElementById('clearCompareButton');
+        const compareSearchToggle  = document.getElementById('compareSearchToggle');
+        const compareSearchPopover = document.getElementById('compareSearchPopover');
+        const compareSearchInput   = document.getElementById('compareSearchInput');
         const positionalViewBtn = document.getElementById('positionalViewBtn');
         const depthChartViewBtn = document.getElementById('depthChartViewBtn');
         const viewControls = document.getElementById('view-controls');
@@ -280,7 +282,6 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             });
 
             compareButton?.addEventListener('click', handleCompareClick);
-            clearCompareButton?.addEventListener('click', () => handleClearCompare(true));
             positionalViewBtn?.addEventListener('click', () => setRosterView('positional'));
             depthChartViewBtn?.addEventListener('click', () => setRosterView('depth'));
             positionalFiltersContainer?.addEventListener('click', handlePositionFilter);
@@ -584,13 +585,11 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         }
 
         function updateCompareButtonState() {
-            if (!compareButton || !clearCompareButton) {
+            if (!compareButton) {
                 return;
             }
             const count = state.teamsToCompare.size;
             compareButton.disabled = count < 2;
-            clearCompareButton.classList.toggle('hidden', count === 0);
-            clearCompareButton.classList.toggle('active', count >= 2);
 
             if (count > 1) {
                 compareButton.classList.add('glow-on-select');
@@ -609,11 +608,95 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 compareButton.classList.remove('compare-show-all');
                 unlockCompareButtonSize();
             }
-            
+
             if (count < 2 && state.isCompareMode) {
                 handleCompareClick(); // Automatically exit compare mode
             }
         }
+
+        function openCompareSearch() {
+            if (!compareSearchPopover || !compareSearchToggle || !compareSearchInput) {
+                return;
+            }
+            compareSearchPopover.classList.remove('hidden');
+            compareSearchToggle.setAttribute('aria-expanded', 'true');
+            compareSearchInput.focus();
+        }
+
+        function closeCompareSearch() {
+            if (!compareSearchPopover || !compareSearchToggle || !compareSearchInput) {
+                return;
+            }
+            compareSearchPopover.classList.add('hidden');
+            compareSearchToggle.setAttribute('aria-expanded', 'false');
+            compareSearchInput.value = '';
+            filterTeamsByQuery('');
+        }
+
+        function filterTeamsByQuery(q) {
+            const query = (q || '').trim().toLowerCase();
+            const hasQuery = query.length > 0;
+            const columns = rosterGrid?.querySelectorAll('.roster-column') || [];
+
+            columns.forEach(column => {
+                const playerRows = column.querySelectorAll('.player-row');
+                let columnHasMatch = !hasQuery;
+
+                playerRows.forEach(row => {
+                    const name = (row.dataset.playerName || '').toLowerCase();
+                    const matches = !hasQuery || name.includes(query);
+                    row.classList.toggle('hidden', hasQuery && !matches);
+                    if (matches) {
+                        columnHasMatch = true;
+                    }
+                });
+
+                const rosterSections = column.querySelectorAll('.roster-section');
+                rosterSections.forEach(section => {
+                    const sectionRows = section.querySelectorAll('.player-row');
+                    const sectionHasMatch = !hasQuery || Array.from(sectionRows).some(row => !row.classList.contains('hidden'));
+                    section.classList.toggle('hidden', hasQuery && !sectionHasMatch);
+                });
+
+                column.classList.toggle('hidden', hasQuery && !columnHasMatch);
+            });
+        }
+
+        let searchDebounce;
+
+        compareSearchToggle?.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const isOpen = compareSearchToggle.getAttribute('aria-expanded') === 'true';
+            if (isOpen) {
+                closeCompareSearch();
+            } else {
+                openCompareSearch();
+            }
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!compareSearchPopover || !compareSearchToggle) {
+                return;
+            }
+            if (compareSearchPopover.classList.contains('hidden')) {
+                return;
+            }
+            if (!compareSearchPopover.contains(e.target) && !compareSearchToggle.contains(e.target)) {
+                closeCompareSearch();
+            }
+        });
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') {
+                closeCompareSearch();
+            }
+        });
+
+        compareSearchInput?.addEventListener('input', (e) => {
+            const val = e.target.value;
+            clearTimeout(searchDebounce);
+            searchDebounce = setTimeout(() => filterTeamsByQuery(val), 120);
+        });
 
         function handleAssetClickForTrade(e) {
             if (!state.isCompareMode) return;
@@ -2586,32 +2669,36 @@ const SEASON_META_HEADERS = {
                 const columnWrapper = document.createElement('div');
                 columnWrapper.className = 'roster-column';
                 columnWrapper.dataset.teamName = team.teamName;
-                
+
                 const header = document.createElement('div');
                 header.className = 'team-header-item';
-                
+
                 const checkbox = document.createElement('div');
                 checkbox.className = 'team-compare-checkbox';
                 if (state.teamsToCompare.has(team.teamName)) {
                     checkbox.classList.add('selected');
                 }
                 checkbox.dataset.teamName = team.teamName;
-                
+
                 const teamNameSpan = document.createElement('span');
                 teamNameSpan.className = 'team-name';
                 teamNameSpan.textContent = team.teamName;
                 header.title = team.teamName;
-                
-                
+
+
                 header.appendChild(checkbox);
                 header.appendChild(teamNameSpan);
-                
+
                 const card = state.currentRosterView === 'positional' ? createPositionalTeamCard(team) : createDepthChartTeamCard(team);
-                
+
                 columnWrapper.appendChild(header);
                 columnWrapper.appendChild(card);
                 rosterGrid.appendChild(columnWrapper);
             });
+
+            if (compareSearchInput && compareSearchInput.value) {
+                filterTeamsByQuery(compareSearchInput.value);
+            }
         }
 
         function createDepthChartTeamCard(team) {
@@ -2734,6 +2821,8 @@ const SEASON_META_HEADERS = {
             row.dataset.assetPos = displaySlot;
             row.dataset.assetBasePos = (player.pos || displaySlot || '').toUpperCase();
             row.dataset.assetTeam = (player.team || 'FA').toUpperCase();
+            row.dataset.playerName = player.name || '';
+            row.dataset.teamName = teamName || '';
 
             if (state.tradeBlock[teamName]?.find(a => a.id === player.id)) {
                 row.classList.add('player-selected');

--- a/DH_P3-5.3/styles/styles.css
+++ b/DH_P3-5.3/styles/styles.css
@@ -806,25 +806,6 @@
             line-height: 1;
         }
 
-    #clearCompareButton {
-        font-size: 1.2rem !important;
-        margin-top: 2px !important;
-    }
-
-
-#clearCompareButton .clear-filters-stack i {
-    color: #5F679588;
-    margin-top: 5px;
-    margin-left: 5px;
-    font-size: 1.5rem !important;
-
-}
-
-#clearCompareButton.active .clear-filters-stack i {
-    color: var(--color-text-secondary);
-}
-
-
 @media (max-width: 819px) {
   .app-header.preview-active > .header-row:first-of-type {
     display: none;
@@ -2532,8 +2513,65 @@ font-weight: 500 !important;
     line-height: 1;
 }
 
-.compare-controls .clear-filters-stack i {
+.compare-controls .compare-search-toggle i {
     font-size: 1.35rem;
+}
+
+.compare-controls {
+    position: relative;
+}
+
+.compare-search-toggle {
+    line-height: 1;
+}
+
+.compare-search-popover {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 6px;
+    z-index: 50;
+    width: 220px;
+    padding: 8px;
+    border: 1px solid var(--color-panel-border);
+    background: rgba(22, 24, 43, 0.92);
+    background: color-mix(in srgb, var(--color-bg-light) 92%, rgba(22, 24, 43, 0.92));
+    border-radius: 8px;
+    box-shadow:
+        0 2px 8px rgba(0, 0, 0, 0.25),
+        inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    transition: opacity .15s ease, transform .15s ease;
+    opacity: 0;
+    transform: translateY(-4px);
+}
+
+.compare-search-popover:not(.hidden) {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+#compareSearchInput {
+    width: 100%;
+    padding: 8px 10px;
+    font-size: 0.85rem;
+    color: var(--color-text-secondary);
+    background: rgba(0, 0, 0, 0.15);
+    border: 1px solid var(--color-panel-border);
+    border-radius: 6px;
+    outline: none;
+}
+
+#compareSearchInput::placeholder {
+    color: var(--color-text-tertiary);
+}
+
+@media (max-width: 480px) {
+    .compare-search-popover {
+        width: min(92vw, 320px);
+        right: 8px;
+    }
 }
 
 #clearFiltersButton .clear-filters-label {


### PR DESCRIPTION
## Summary
- darken the compare search popover background for better legibility while retaining the glass treatment
- filter roster columns and player rows by player name so only matching players remain visible across teams
- tag rendered player rows with player and team metadata to support the new filtering logic

## Testing
- not run (project has no automated tests)

------
https://chatgpt.com/codex/tasks/task_e_68d1f3b60460832ea92533be4efd0f61