### PR TITLE
Improve compare search popover contrast and filter players

### DIFF
--- a/DH_P3-5.3/ownership/ownership.html
+++ b/DH_P3-5.3/ownership/ownership.html
@@ -91,7 +91,32 @@
 </div>
 <div class="compare-controls">
 <button class="control-button" disabled="" id="compareButton">Preview</button>
-<button class="control-button-subtle hidden" id="clearCompareButton">Clear</button>
+<button id="compareSearchToggle"
+        class="control-button-subtle compare-search-toggle"
+        aria-haspopup="true"
+        aria-expanded="false"
+        aria-controls="compareSearchPopover">
+    <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+    <span class="sr-only">Search teams</span>
+</button>
+
+    <div id="compareSearchPopover"
+         class="compare-search-popover hidden"
+         role="dialog"
+         aria-modal="false">
+        <button type="button"
+                id="compareSearchClose"
+                class="compare-search-close"
+                aria-label="Close search popover">
+            <i class="fa-solid fa-circle-xmark" aria-hidden="true"></i>
+        </button>
+        <label for="compareSearchInput" class="sr-only">Search teams</label>
+        <input id="compareSearchInput"
+               type="search"
+               placeholder="Search teams…"
+               autocomplete="off"
+               inputmode="search" />
+</div>
 </div>
 </div>
 </div>

--- a/DH_P3-5.3/rosters/rosters.html
+++ b/DH_P3-5.3/rosters/rosters.html
@@ -116,13 +116,32 @@
         <div class="compare-controls">
             <!-- Hidden compare button kept only to satisfy JS state machine (do not show) -->
             <button class="control-button hidden" id="compareButton" aria-hidden="true" tabindex="-1" style="display:none;"></button>
-            <!-- Clear selections button -->
-            <button class="control-button-subtle hidden" id="clearCompareButton" aria-label="Clear selections">
-                <span class="clear-filters-stack">
-                    <i class="fa-regular fa-rectangle-xmark" aria-hidden="true"></i>
-                    <span class="sr-only">Clear compare selections</span>
-                </span>
+            <button id="compareSearchToggle"
+                    class="control-button-subtle compare-search-toggle"
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                    aria-controls="compareSearchPopover">
+                <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+                <span class="sr-only">Search teams</span>
             </button>
+
+            <div id="compareSearchPopover"
+                 class="compare-search-popover hidden"
+                 role="dialog"
+                 aria-modal="false">
+                <button type="button"
+                        id="compareSearchClose"
+                        class="compare-search-close"
+                        aria-label="Close search popover">
+                    <i class="fa-solid fa-circle-xmark" aria-hidden="true"></i>
+                </button>
+                <label for="compareSearchInput" class="sr-only">Search teams</label>
+                <input id="compareSearchInput"
+                       type="search"
+                       placeholder="Search teams…"
+                       autocomplete="off"
+                       inputmode="search" />
+            </div>
         </div>
 
     </div>

--- a/DH_P3-5.3/scripts/app.js
+++ b/DH_P3-5.3/scripts/app.js
@@ -17,7 +17,10 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const rosterContainer = document.getElementById('rosterContainer');
         const rosterGrid = document.getElementById('rosterGrid');
         const compareButton = document.getElementById('compareButton');
-        const clearCompareButton = document.getElementById('clearCompareButton');
+        const compareSearchToggle  = document.getElementById('compareSearchToggle');
+        const compareSearchPopover = document.getElementById('compareSearchPopover');
+        const compareSearchInput   = document.getElementById('compareSearchInput');
+        const compareSearchClose   = document.getElementById('compareSearchClose');
         const positionalViewBtn = document.getElementById('positionalViewBtn');
         const depthChartViewBtn = document.getElementById('depthChartViewBtn');
         const viewControls = document.getElementById('view-controls');
@@ -280,7 +283,6 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             });
 
             compareButton?.addEventListener('click', handleCompareClick);
-            clearCompareButton?.addEventListener('click', () => handleClearCompare(true));
             positionalViewBtn?.addEventListener('click', () => setRosterView('positional'));
             depthChartViewBtn?.addEventListener('click', () => setRosterView('depth'));
             positionalFiltersContainer?.addEventListener('click', handlePositionFilter);
@@ -584,13 +586,11 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         }
 
         function updateCompareButtonState() {
-            if (!compareButton || !clearCompareButton) {
+            if (!compareButton) {
                 return;
             }
             const count = state.teamsToCompare.size;
             compareButton.disabled = count < 2;
-            clearCompareButton.classList.toggle('hidden', count === 0);
-            clearCompareButton.classList.toggle('active', count >= 2);
 
             if (count > 1) {
                 compareButton.classList.add('glow-on-select');
@@ -609,11 +609,111 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 compareButton.classList.remove('compare-show-all');
                 unlockCompareButtonSize();
             }
-            
+
             if (count < 2 && state.isCompareMode) {
                 handleCompareClick(); // Automatically exit compare mode
             }
         }
+
+        function openCompareSearch() {
+            if (!compareSearchPopover || !compareSearchToggle || !compareSearchInput) {
+                return;
+            }
+            compareSearchPopover.classList.remove('hidden');
+            compareSearchToggle.setAttribute('aria-expanded', 'true');
+            compareSearchInput.focus();
+        }
+
+        function closeCompareSearch() {
+            if (!compareSearchPopover || !compareSearchToggle || !compareSearchInput) {
+                return;
+            }
+            compareSearchPopover.classList.add('hidden');
+            compareSearchToggle.setAttribute('aria-expanded', 'false');
+            compareSearchInput.value = '';
+            filterTeamsByQuery('');
+            if (document.activeElement === compareSearchInput) {
+                compareSearchToggle.focus();
+            }
+        }
+
+        function filterTeamsByQuery(q) {
+            if (!rosterGrid) {
+                return;
+            }
+
+            const query = (q || '').trim().toLowerCase();
+            const rosterColumns = rosterGrid.querySelectorAll('.roster-column');
+
+            rosterColumns.forEach(column => {
+                const playerRows = column.querySelectorAll('.player-row');
+                let hasMatch = false;
+
+                playerRows.forEach(row => {
+                    const playerName = (row.dataset.playerName || row.dataset.assetLabel || '').toLowerCase();
+                    const matches = !query || playerName.includes(query);
+                    row.classList.toggle('compare-search-hidden', Boolean(query) && !matches);
+                    if (matches) {
+                        hasMatch = true;
+                    }
+                });
+
+                const sections = column.querySelectorAll('.roster-section');
+                sections.forEach(section => {
+                    const visiblePlayer = section.querySelector('.player-row:not(.compare-search-hidden)');
+                    section.classList.toggle('compare-search-hidden', Boolean(query) && !visiblePlayer);
+                });
+
+                const pickRows = column.querySelectorAll('.pick-row');
+                pickRows.forEach(row => {
+                    row.classList.toggle('compare-search-hidden', Boolean(query));
+                });
+
+                column.classList.toggle('compare-search-hidden', Boolean(query) && !hasMatch);
+            });
+        }
+
+        let searchDebounce;
+
+        compareSearchToggle?.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const isOpen = compareSearchToggle.getAttribute('aria-expanded') === 'true';
+            if (isOpen) {
+                closeCompareSearch();
+            } else {
+                openCompareSearch();
+            }
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!compareSearchPopover || !compareSearchToggle) {
+                return;
+            }
+            if (compareSearchPopover.classList.contains('hidden')) {
+                return;
+            }
+            if (!compareSearchPopover.contains(e.target) && !compareSearchToggle.contains(e.target)) {
+                closeCompareSearch();
+            }
+        });
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') {
+                closeCompareSearch();
+            }
+        });
+
+        compareSearchInput?.addEventListener('input', (e) => {
+            const val = e.target.value;
+            clearTimeout(searchDebounce);
+            searchDebounce = setTimeout(() => filterTeamsByQuery(val), 120);
+        });
+
+        compareSearchClose?.addEventListener('click', (e) => {
+            e.stopPropagation();
+            closeCompareSearch();
+            compareSearchToggle?.focus();
+        });
 
         function handleAssetClickForTrade(e) {
             if (!state.isCompareMode) return;
@@ -2586,32 +2686,36 @@ const SEASON_META_HEADERS = {
                 const columnWrapper = document.createElement('div');
                 columnWrapper.className = 'roster-column';
                 columnWrapper.dataset.teamName = team.teamName;
-                
+
                 const header = document.createElement('div');
                 header.className = 'team-header-item';
-                
+
                 const checkbox = document.createElement('div');
                 checkbox.className = 'team-compare-checkbox';
                 if (state.teamsToCompare.has(team.teamName)) {
                     checkbox.classList.add('selected');
                 }
                 checkbox.dataset.teamName = team.teamName;
-                
+
                 const teamNameSpan = document.createElement('span');
                 teamNameSpan.className = 'team-name';
                 teamNameSpan.textContent = team.teamName;
                 header.title = team.teamName;
-                
-                
+
+
                 header.appendChild(checkbox);
                 header.appendChild(teamNameSpan);
-                
+
                 const card = state.currentRosterView === 'positional' ? createPositionalTeamCard(team) : createDepthChartTeamCard(team);
-                
+
                 columnWrapper.appendChild(header);
                 columnWrapper.appendChild(card);
                 rosterGrid.appendChild(columnWrapper);
             });
+
+            if (compareSearchInput && compareSearchInput.value) {
+                filterTeamsByQuery(compareSearchInput.value);
+            }
         }
 
         function createDepthChartTeamCard(team) {
@@ -2728,8 +2832,29 @@ const SEASON_META_HEADERS = {
             row.className = 'player-row';
             const slotAbbr = { 'SUPER_FLEX': 'SFLX', 'FLEX': 'FLX' };
             const displaySlot = state.currentRosterView === 'depth' ? (slotAbbr[player.slot] || player.slot) : player.pos;
+            const fullPlayer = state.players?.[player.id];
+            const firstName = (player.first_name || fullPlayer?.first_name || '').trim();
+            const lastName = (player.last_name || fullPlayer?.last_name || '').trim();
+            const nameCandidates = [
+                player.name,
+                player.full_name,
+                player.display_name,
+                `${firstName} ${lastName}`.trim(),
+                fullPlayer?.full_name,
+                `${(fullPlayer?.first_name || '').trim()} ${(fullPlayer?.last_name || '').trim()}`.trim(),
+                firstName,
+                lastName,
+                fullPlayer?.first_name,
+                fullPlayer?.last_name
+            ];
+            const playerSearchKey = Array.from(new Set(
+                nameCandidates
+                    .map(name => (name || '').trim().toLowerCase())
+                    .filter(Boolean)
+            )).join(' ');
             row.dataset.assetId = player.id;
             row.dataset.assetLabel = player.name;
+            row.dataset.playerName = playerSearchKey || (player.name || '').toLowerCase();
             row.dataset.assetKtc = player.ktc || 0;
             row.dataset.assetPos = displaySlot;
             row.dataset.assetBasePos = (player.pos || displaySlot || '').toUpperCase();

--- a/DH_P3-5.3/styles/styles.css
+++ b/DH_P3-5.3/styles/styles.css
@@ -806,25 +806,6 @@
             line-height: 1;
         }
 
-    #clearCompareButton {
-        font-size: 1.2rem !important;
-        margin-top: 2px !important;
-    }
-
-
-#clearCompareButton .clear-filters-stack i {
-    color: #5F679588;
-    margin-top: 5px;
-    margin-left: 5px;
-    font-size: 1.5rem !important;
-
-}
-
-#clearCompareButton.active .clear-filters-stack i {
-    color: var(--color-text-secondary);
-}
-
-
 @media (max-width: 819px) {
   .app-header.preview-active > .header-row:first-of-type {
     display: none;
@@ -2532,8 +2513,117 @@ font-weight: 500 !important;
     line-height: 1;
 }
 
-.compare-controls .clear-filters-stack i {
+.compare-controls .compare-search-toggle i {
     font-size: 1.35rem;
+}
+
+.compare-controls {
+    position: relative;
+}
+
+.compare-search-toggle {
+    line-height: 1;
+}
+
+.compare-search-popover {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 6px;
+    z-index: 50;
+    width: 220px;
+    padding: 14px 14px 12px;
+    border: 1px solid var(--color-panel-border);
+    background: rgba(13, 15, 31, 0.92);
+    border-radius: 8px;
+    box-shadow:
+        0 8px 20px rgba(0, 0, 0, 0.35),
+        inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(6px);
+    transition: opacity .15s ease, transform .15s ease;
+    opacity: 0;
+    transform: translateY(-4px);
+}
+
+.compare-search-popover:not(.hidden) {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.compare-search-close {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: var(--color-text-tertiary);
+    cursor: pointer;
+    transition: color .15s ease, transform .15s ease;
+}
+
+.compare-search-close i {
+    font-size: 1.05rem;
+    pointer-events: none;
+}
+
+.compare-search-close:hover,
+.compare-search-close:focus-visible {
+    color: var(--color-text-primary);
+    transform: scale(1.05);
+}
+
+.compare-search-close:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.25);
+    outline-offset: 2px;
+}
+
+.compare-search-hidden {
+    display: none !important;
+}
+
+#compareSearchInput {
+    width: 100%;
+    margin-top: 12px;
+    padding: 10px 12px;
+    font-size: 1rem;
+    color: var(--color-text-primary);
+    background: rgba(18, 22, 40, 0.85);
+    border: 1px solid var(--color-panel-border);
+    border-radius: 6px;
+    outline: none;
+}
+
+#compareSearchInput::placeholder {
+    color: var(--color-text-tertiary);
+}
+
+@media (max-width: 640px) {
+    .filters-container {
+        position: relative;
+    }
+
+    .compare-controls {
+        position: static;
+    }
+
+    .compare-search-popover {
+        top: 50%;
+        left: 50%;
+        right: auto;
+        margin-top: 0;
+        width: min(92vw, 320px);
+        transform: translate(-50%, -56%);
+    }
+
+    .compare-search-popover:not(.hidden) {
+        transform: translate(-50%, -50%);
+    }
 }
 
 #clearFiltersButton .clear-filters-label {


### PR DESCRIPTION
## Summary
- darken the compare search popover and input styling so the overlay remains legible against the roster grid
- add player-name data attributes during roster rendering so the compare search can inspect individual players
- update the search filter logic to target player rows, hiding non-matching players, sections, and teams while the query is active
- extend the compare search to match first and last names, add an inline close control, reposition the popover on mobile, and raise the input sizing to avoid mobile zooming

## Testing
- not run (project has no automated tests)

------
https://chatgpt.com/codex/tasks/task_e_68d1f3b60460832ea92533be4efd0f61