### PR TITLE
Adjust desktop header layout for rosters controls

### DIFF
--- a/DH_P3-5.32/styles/styles.css
+++ b/DH_P3-5.32/styles/styles.css
@@ -401,11 +401,42 @@
 
             #primary-header-row {
                 grid-template-columns: var(--header-icon-size) max-content minmax(120px, var(--header-field-max-width)) minmax(var(--header-switcher-width), 1fr);
+                order: 1;
+                flex-basis: 100%;
+                margin-inline: auto;
             }
 
             .header-quick-links .analyzer-button,
             .header-quick-links .research-button {
                 gap: 0.2rem;
+            }
+
+            #secondary-header-row,
+            #filters-row {
+                display: contents;
+            }
+
+            #contextual-controls .analyzer-button-slot:empty,
+            #contextual-controls .research-button-slot:empty {
+                display: none;
+            }
+
+            #contextual-controls .analyzer-button-slot {
+                order: 2;
+            }
+
+            #contextual-controls .custom-select-wrapper {
+                order: 3;
+            }
+
+            #contextual-controls .secondary-switcher {
+                order: 4;
+            }
+
+            #contextual-controls .filters-container {
+                order: 5;
+                flex: 1 1 320px;
+                margin-left: auto;
             }
 
             #header-quick-links #analyzeLeagueButton,


### PR DESCRIPTION
## Summary
- center the primary roster header row on desktop while keeping existing grid layout
- flatten secondary and filters rows into the desktop flex flow so the league select and view switcher sit to the left of filters
- hide empty analyzer and research slots and grow the filters area to align controls without affecting mobile views

## Testing
- npm test *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d218b5558c832eb874ab04a3beba3b