### PR TITLE
Adjust desktop header layout for rosters controls

### DIFF
--- a/DH_P3-5.32/styles/styles.css
+++ b/DH_P3-5.32/styles/styles.css
@@ -400,12 +400,49 @@
             }
 
             #primary-header-row {
-                grid-template-columns: var(--header-icon-size) max-content minmax(120px, var(--header-field-max-width)) minmax(var(--header-switcher-width), 1fr);
+                grid-template-columns: var(--header-icon-size) max-content minmax(120px, var(--header-field-max-width)) max-content;
+                justify-items: center;
+                order: 1;
+                flex-basis: 100%;
+                margin-inline: auto;
+            }
+
+            #primary-header-row .username-area,
+            #primary-header-row .primary-switcher {
+                justify-self: center;
             }
 
             .header-quick-links .analyzer-button,
             .header-quick-links .research-button {
                 gap: 0.2rem;
+            }
+
+            #secondary-header-row,
+            #filters-row {
+                display: contents;
+            }
+
+            #contextual-controls .analyzer-button-slot:empty,
+            #contextual-controls .research-button-slot:empty {
+                display: none;
+            }
+
+            #contextual-controls .analyzer-button-slot {
+                order: 2;
+            }
+
+            #contextual-controls .custom-select-wrapper {
+                order: 3;
+            }
+
+            #contextual-controls .secondary-switcher {
+                order: 4;
+            }
+
+            #contextual-controls .filters-container {
+                order: 5;
+                flex: 1 1 320px;
+                margin-left: auto;
             }
 
             #header-quick-links #analyzeLeagueButton,


### PR DESCRIPTION
## Summary
- tighten the desktop primary header grid so the menu, quick links, username, and primary view switcher align together in the center
- center the username input and primary switcher within their grid cells to keep the rosters/ownership toggle grouped with the other controls

## Testing
- not run (not specified)


------
https://chatgpt.com/codex/tasks/task_e_68d218b5558c832eb874ab04a3beba3b