### PR TITLE
Center primary desktop header controls

### DIFF
--- a/DH_P3-5.32/styles/styles.css
+++ b/DH_P3-5.32/styles/styles.css
@@ -243,7 +243,15 @@
             padding-bottom: 2px; /* space for scrollbar */
         }
 
-        .app-header > .header-row:first-of-type,
+        .app-header > .header-row:first-of-type {
+            display: grid;
+            grid-template-columns: var(--header-icon-size) minmax(120px, var(--header-field-max-width)) minmax(var(--header-switcher-width), 1fr);
+            align-items: center;
+            gap: 0.5rem;
+            padding-left: 0.25rem;
+            padding-right: 0.25rem;
+        }
+
         #contextual-controls .header-row:first-child {
             display: grid;
             grid-template-columns: var(--header-icon-size) minmax(120px, var(--header-field-max-width)) minmax(var(--header-switcher-width), 1fr);
@@ -400,12 +408,48 @@
             }
 
             #primary-header-row {
-                grid-template-columns: var(--header-icon-size) max-content minmax(120px, var(--header-field-max-width)) minmax(var(--header-switcher-width), 1fr);
+                grid-template-columns: var(--header-icon-size) max-content minmax(120px, var(--header-field-max-width)) max-content;
+                justify-content: center;
+                order: 1;
+                flex-basis: 100%;
+                margin-inline: auto;
+            }
+
+            #primary-header-row .primary-switcher {
+                justify-self: center;
             }
 
             .header-quick-links .analyzer-button,
             .header-quick-links .research-button {
                 gap: 0.2rem;
+            }
+
+            #secondary-header-row,
+            #filters-row {
+                display: contents;
+            }
+
+            #contextual-controls .analyzer-button-slot:empty,
+            #contextual-controls .research-button-slot:empty {
+                display: none;
+            }
+
+            #contextual-controls .analyzer-button-slot {
+                order: 2;
+            }
+
+            #contextual-controls .custom-select-wrapper {
+                order: 3;
+            }
+
+            #contextual-controls .secondary-switcher {
+                order: 4;
+            }
+
+            #contextual-controls .filters-container {
+                order: 5;
+                flex: 1 1 320px;
+                margin-left: auto;
             }
 
             #header-quick-links #analyzeLeagueButton,


### PR DESCRIPTION
## Summary
- ensure the primary roster header row stays centered on desktop by tightening its grid columns and centering the switcher alongside quick links
- maintain the desktop-only relocation of the league select and view switcher so the filters remain aligned without affecting mobile

## Testing
- npm test *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d218b5558c832eb874ab04a3beba3b