### PR TITLE
Align desktop roster header controls

### DIFF
--- a/DH_P3-5.32/styles/styles.css
+++ b/DH_P3-5.32/styles/styles.css
@@ -400,7 +400,54 @@
             }
 
             #primary-header-row {
-                grid-template-columns: var(--header-icon-size) max-content minmax(120px, var(--header-field-max-width)) minmax(var(--header-switcher-width), 1fr);
+                display: contents;
+            }
+
+            #secondary-header-row,
+            #filters-row {
+                display: contents;
+            }
+
+            #primary-header-row .menu-container {
+                order: 1;
+            }
+
+            #primary-header-row .header-quick-links {
+                order: 2;
+            }
+
+            #primary-header-row .username-area {
+                order: 3;
+                width: min(var(--header-field-max-width), 100%);
+                flex: 0 1 var(--header-field-max-width);
+            }
+
+            #primary-header-row .primary-switcher {
+                order: 4;
+                flex: 0 0 auto;
+            }
+
+            #contextual-controls .analyzer-button-slot,
+            #contextual-controls .research-button-slot {
+                display: none;
+            }
+
+            #contextual-controls .custom-select-wrapper {
+                order: 5;
+            }
+
+            #contextual-controls .secondary-switcher {
+                order: 6;
+            }
+
+            #contextual-controls .filters-container {
+                order: 7;
+                flex: 1 1 360px;
+                margin-left: 0;
+            }
+
+            #contextual-controls .filters-container .compare-controls {
+                margin-left: auto;
             }
 
             .header-quick-links .analyzer-button,


### PR DESCRIPTION
## Summary
- flatten the desktop header rows so each control participates in one flex line
- order the hamburger, quick links, username, and roster/ownership toggle ahead of the league, positional, and filter controls
- hide the relocated analyzer/research slots and let the filters/search group expand at the end of the row

## Testing
- npm test *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d218b5558c832eb874ab04a3beba3b