### PR TITLE
Align desktop roster header control order

### DIFF
--- a/DH_P3-5.32/styles/styles.css
+++ b/DH_P3-5.32/styles/styles.css
@@ -400,12 +400,53 @@
             }
 
             #primary-header-row {
-                grid-template-columns: var(--header-icon-size) max-content minmax(120px, var(--header-field-max-width)) minmax(var(--header-switcher-width), 1fr);
+                grid-template-columns: var(--header-icon-size) max-content minmax(120px, var(--header-field-max-width)) max-content;
+                order: 1;
+                flex-basis: auto;
+                width: max-content;
+                justify-content: center;
+                margin-inline: auto;
             }
 
             .header-quick-links .analyzer-button,
             .header-quick-links .research-button {
                 gap: 0.2rem;
+            }
+
+            #secondary-header-row,
+            #filters-row {
+                display: contents;
+            }
+
+            #contextual-controls .analyzer-button-slot:empty,
+            #contextual-controls .research-button-slot:empty {
+                display: none;
+            }
+
+            #contextual-controls .analyzer-button-slot {
+                order: 2;
+            }
+
+            #contextual-controls .research-button-slot {
+                order: 3;
+            }
+
+            #contextual-controls .custom-select-wrapper {
+                order: 5;
+            }
+
+            #contextual-controls .secondary-switcher {
+                order: 6;
+            }
+
+            #contextual-controls .filters-container {
+                order: 7;
+                flex: 1 1 360px;
+                margin-left: 0.75rem;
+            }
+
+            #contextual-controls .filters-container .compare-controls {
+                margin-left: auto;
             }
 
             #header-quick-links #analyzeLeagueButton,


### PR DESCRIPTION
## Summary
- adjust the desktop primary header grid to use content-based widths so the menu, quick links, username, and primary switcher stay grouped and centered
- reorder the desktop contextual controls so the league select, positional/lineup switcher, filters, and search follow the requested sequence while allowing the filter stack to expand

## Testing
- npm test *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d218b5558c832eb874ab04a3beba3b