### PR TITLE
Adjust roster header desktop layout

### DIFF
--- a/DH_P3-5.32/styles/styles.css
+++ b/DH_P3-5.32/styles/styles.css
@@ -1626,13 +1626,19 @@
                 display: contents;
             }
 
+            #primary-header-row,
+            #secondary-header-row,
+            #filters-row {
+                display: contents;
+            }
+
             .header-row {
                 width: auto;
                 border-top: none !important;
                 padding-top: 0 !important;
                 padding-bottom: 0 !important;
             }
-            
+
             #contextual-controls .header-row:has(#positional-filters) {
                 flex-basis: 100%;
                 justify-content: center;
@@ -1652,6 +1658,71 @@
             .username-area, .custom-select-wrapper {
                 flex-grow: 0;
                 max-width: 220px;
+            }
+
+            .app-header > .menu-container,
+            .app-header > .header-quick-links,
+            .app-header > .analyzer-button-slot,
+            .app-header > .research-button-slot,
+            .app-header > .username-area,
+            .app-header > .app-view-switcher.primary-switcher,
+            .app-header > .custom-select-wrapper,
+            .app-header > .view-switcher.secondary-switcher,
+            .app-header > .filters-container {
+                margin-block: 0;
+            }
+
+            .app-header > .menu-container { order: 1; }
+
+            .app-header > .header-quick-links,
+            .app-header > .analyzer-button-slot { order: 2; }
+
+            .app-header > .username-area { order: 3; }
+
+            .app-header > .app-view-switcher.primary-switcher { order: 4; }
+
+            .app-header > .custom-select-wrapper { order: 5; }
+
+            .app-header > .view-switcher.secondary-switcher { order: 6; }
+
+            .app-header > .research-button-slot { order: 7; }
+
+            .app-header > .filters-container {
+                order: 8;
+                flex: 1 1 260px;
+                min-width: 260px;
+            }
+
+            .app-header > .custom-select-wrapper,
+            .app-header > .view-switcher.secondary-switcher {
+                flex: 0 0 auto;
+                align-self: stretch;
+            }
+
+            .app-header > .menu-container,
+            .app-header > .analyzer-button-slot,
+            .app-header > .research-button-slot,
+            .app-header > .username-area,
+            .app-header > .app-view-switcher.primary-switcher {
+                align-self: stretch;
+            }
+
+            .app-header > .menu-container,
+            .app-header > .analyzer-button-slot,
+            .app-header > .research-button-slot,
+            .app-header > .view-switcher.secondary-switcher,
+            .app-header > .filters-container,
+            .app-header > .app-view-switcher.primary-switcher,
+            .app-header > .username-area {
+                height: var(--header-control-height);
+            }
+
+            .app-header > .filters-container {
+                align-items: center;
+            }
+
+            .research-button {
+                margin-top: 0;
             }
         }
 


### PR DESCRIPTION
## Summary
- flatten the roster header rows inside the desktop breakpoint so individual controls can be reordered without disturbing mobile structure
- reorder and size the menu, username, view switchers, league selector, and filters so the dropdown and positional switcher sit just left of the filter strip on desktop
- align header controls vertically on desktop by sharing the common control height and removing residual row margins

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d21902d868832ebadf108ea60f6f32