### PR TITLE
Add player physical details to roster modals

### DIFF
--- a/DH_P3-5.32 official 3/rosters/rosters.html
+++ b/DH_P3-5.32 official 3/rosters/rosters.html
@@ -189,6 +189,7 @@
     <button class="modal-close-btn">&times;</button>
     <div id="modal-header">
       <h3 id="modal-player-name">Player Game Logs</h3>
+      <div id="modal-player-physicals" class="player-physicals modal-player-physicals"></div>
       <div id="modal-summary-row">
         <div id="modal-summary-chips">
           <!-- Summary chips will be rendered here -->

--- a/DH_P3-5.32 official 3/scripts/app.js
+++ b/DH_P3-5.32 official 3/scripts/app.js
@@ -1605,11 +1605,162 @@ const SEASON_META_HEADERS = {
         }
 
         // --- UI Rendering ---
+        function getPlayerPhysicalAttributes(playerId) {
+            const playerData = state.players?.[playerId];
+            const sanitizeNumber = (value) => {
+                if (typeof value === 'number' && Number.isFinite(value)) return value;
+                if (typeof value === 'string' && value.trim() !== '') {
+                    const parsed = Number.parseFloat(value.replace(/[^0-9.\-]/g, ''));
+                    return Number.isFinite(parsed) ? parsed : null;
+                }
+                return null;
+            };
+
+            const resolveAge = () => {
+                const directAge = sanitizeNumber(playerData?.age ?? playerData?.metadata?.age);
+                if (Number.isFinite(directAge)) {
+                    return Math.floor(directAge);
+                }
+
+                if (playerData?.birth_date) {
+                    const birth = new Date(playerData.birth_date);
+                    if (!Number.isNaN(birth.getTime())) {
+                        const today = new Date();
+                        let age = today.getFullYear() - birth.getFullYear();
+                        const hasHadBirthday =
+                            today.getMonth() > birth.getMonth() ||
+                            (today.getMonth() === birth.getMonth() && today.getDate() >= birth.getDate());
+                        if (!hasHadBirthday) age -= 1;
+                        return age;
+                    }
+                }
+                return null;
+            };
+
+            const parseHeightString = (value) => {
+                if (!value) return null;
+                const normalized = String(value).trim();
+                if (!normalized) return null;
+                const dashMatch = normalized.match(/^(\d{1,2})\s*-\s*(\d{1,2})$/);
+                if (dashMatch) {
+                    return { feet: Number.parseInt(dashMatch[1], 10), inches: Number.parseInt(dashMatch[2], 10) };
+                }
+                const quoteMatch = normalized.match(/^(\d{1,2})\s*'\s*(\d{1,2})?\s*"?$/);
+                if (quoteMatch) {
+                    return {
+                        feet: Number.parseInt(quoteMatch[1], 10),
+                        inches: quoteMatch[2] ? Number.parseInt(quoteMatch[2], 10) : 0
+                    };
+                }
+                return null;
+            };
+
+            const resolveHeight = () => {
+                if (!playerData) return null;
+                let result = parseHeightString(playerData.height);
+                if (!result) {
+                    const numericHeight = sanitizeNumber(playerData.height);
+                    if (Number.isFinite(numericHeight)) {
+                        const feet = Math.floor(numericHeight / 12);
+                        const inches = Math.round(numericHeight % 12);
+                        result = { feet, inches };
+                    }
+                }
+                if (!result && playerData?.metadata) {
+                    const metaHeight = parseHeightString(playerData.metadata.height);
+                    if (metaHeight) {
+                        result = metaHeight;
+                    } else {
+                        const metaNumeric = sanitizeNumber(playerData.metadata.height);
+                        if (Number.isFinite(metaNumeric)) {
+                            const feet = Math.floor(metaNumeric / 12);
+                            const inches = Math.round(metaNumeric % 12);
+                            result = { feet, inches };
+                        }
+                    }
+                    if (!result && playerData.metadata.height_inches) {
+                        const totalInches = sanitizeNumber(playerData.metadata.height_inches);
+                        if (Number.isFinite(totalInches)) {
+                            const feet = Math.floor(totalInches / 12);
+                            const inches = Math.round(totalInches % 12);
+                            result = { feet, inches };
+                        }
+                    }
+                }
+                if (!result && playerData.height_inches) {
+                    const totalInches = sanitizeNumber(playerData.height_inches);
+                    if (Number.isFinite(totalInches)) {
+                        const feet = Math.floor(totalInches / 12);
+                        const inches = Math.round(totalInches % 12);
+                        result = { feet, inches };
+                    }
+                }
+                if (!result && playerData.height_ft) {
+                    const feet = sanitizeNumber(playerData.height_ft);
+                    const inches = sanitizeNumber(playerData.height_in || playerData.height_inches);
+                    if (Number.isFinite(feet)) {
+                        result = { feet, inches: Number.isFinite(inches) ? inches : 0 };
+                    }
+                }
+                if (!result) return null;
+                const feet = Number.isFinite(result.feet) ? result.feet : null;
+                const inches = Number.isFinite(result.inches) ? result.inches : 0;
+                if (feet === null) return null;
+                const safeInches = Math.max(0, Math.round(inches));
+                return `${feet}'${safeInches}"`;
+            };
+
+            const resolveWeight = () => {
+                const rawWeight = sanitizeNumber(
+                    playerData?.weight ??
+                    playerData?.weight_lbs ??
+                    playerData?.metadata?.weight ??
+                    playerData?.metadata?.weight_lbs
+                );
+                if (Number.isFinite(rawWeight)) {
+                    return `${Math.round(rawWeight)} lbs`;
+                }
+                return null;
+            };
+
+            const age = resolveAge();
+            const height = resolveHeight();
+            const weight = resolveWeight();
+
+            return {
+                age: Number.isFinite(age) ? age : null,
+                height: height || null,
+                weight: weight || null
+            };
+        }
+
+        function buildPlayerPhysicalsMarkup(physicals) {
+            const items = [
+                { label: 'AGE', value: Number.isFinite(physicals.age) ? physicals.age : 'N/A' },
+                { label: 'HEIGHT', value: physicals.height || 'N/A' },
+                { label: 'WEIGHT', value: physicals.weight || 'N/A' }
+            ];
+            return items.map(item => (
+                `<div class="player-physical">` +
+                    `<span class="player-physical-label">${item.label}</span>` +
+                    `<span class="player-physical-value">${item.value}</span>` +
+                `</div>`
+            )).join('');
+        }
+
+        function renderModalPlayerPhysicals(playerId) {
+            const physicalsContainer = document.getElementById('modal-player-physicals');
+            if (!physicalsContainer) return;
+            const physicals = getPlayerPhysicalAttributes(playerId);
+            physicalsContainer.innerHTML = buildPlayerPhysicalsMarkup(physicals);
+        }
+
         async function handlePlayerNameClick(player) {
             const fullPlayer = state.players[player.id];
             const playerName = fullPlayer ? `${fullPlayer.first_name} ${fullPlayer.last_name}` : player.name;
 
             modalPlayerName.textContent = `${playerName}`;
+            renderModalPlayerPhysicals(player.id);
             document.getElementById('modal-summary-chips').innerHTML = ''; // Clear previous chips
             const existingHeaderContainer = document.querySelector('.modal-header-left-container');
             if(existingHeaderContainer) existingHeaderContainer.remove();
@@ -2160,6 +2311,12 @@ const SEASON_META_HEADERS = {
                 nameHeader.appendChild(nameButton);
                 nameHeader.appendChild(tagsRow);
                 headerContainer.appendChild(nameHeader);
+
+                const physicals = getPlayerPhysicalAttributes(player.id);
+                const physicalsRow = document.createElement('div');
+                physicalsRow.className = 'player-physicals player-physicals--compact';
+                physicalsRow.innerHTML = buildPlayerPhysicalsMarkup(physicals);
+                headerContainer.appendChild(physicalsRow);
 
                 playerNamesRow.appendChild(headerContainer);
             });

--- a/DH_P3-5.32 official 3/styles/styles.css
+++ b/DH_P3-5.32 official 3/styles/styles.css
@@ -3070,6 +3070,55 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
       text-align: center;
       margin-bottom: 1rem;
     }
+
+    .player-physicals {
+      display: flex;
+      justify-content: center;
+      align-items: flex-end;
+      gap: 1.25rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .modal-player-physicals {
+      margin-top: -0.25rem;
+    }
+
+    .player-physical {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.15rem;
+    }
+
+    .player-physical-label {
+      font-size: 0.55rem;
+      letter-spacing: 0.12rem;
+      color: rgba(255, 255, 255, 0.65);
+      text-transform: uppercase;
+    }
+
+    .player-physical-value {
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: #ffffff;
+      text-shadow: 0 0 6px rgba(0, 0, 0, 0.45);
+    }
+
+    .player-physicals--compact {
+      gap: 0.9rem;
+      margin-top: 0.35rem;
+      margin-bottom: 0.45rem;
+    }
+
+    .player-physicals--compact .player-physical-label {
+      font-size: 0.48rem;
+      letter-spacing: 0.1rem;
+      color: rgba(255, 255, 255, 0.55);
+    }
+
+    .player-physicals--compact .player-physical-value {
+      font-size: 0.78rem;
+    }
     
     #modal-summary-row {
       display: flex;


### PR DESCRIPTION
## Summary
- render Sleeper age, height, and weight data in the game log modal header for quick reference
- show the same physical measurements in the comparison modal using a compact presentation
- style the new physical detail rows so labels stay small and values remain readable in both contexts

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d29160a680832eaac9770b30d22068